### PR TITLE
refactor(import): Extract methods from run() to reduce complexity

### DIFF
--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -244,7 +244,9 @@ fn deploy_one(
         Ok(_result) => {
             println!(
                 "  + {} {}: {} -> {}",
-                target.name(), deployment.kind, deployment.name,
+                target.name(),
+                deployment.kind,
+                deployment.name,
                 deployment.path().display()
             );
 
@@ -273,7 +275,10 @@ fn deploy_one(
         Err(e) => {
             println!(
                 "  x {} {}: {} - {}",
-                target.name(), deployment.kind, deployment.name, e
+                target.name(),
+                deployment.kind,
+                deployment.name,
+                e
             );
             DeployOutcome::Failure
         }
@@ -299,7 +304,10 @@ fn place_components(
                 Err(e) => {
                     println!(
                         "  x {} {}: {} - {}",
-                        target.name(), component.kind, component.name, e
+                        target.name(),
+                        component.kind,
+                        component.name,
+                        e
                     );
                     total_failure += 1;
                     continue;
@@ -412,8 +420,12 @@ pub async fn run(args: Args) -> Result<(), String> {
     let mut import_registry = ImportRegistry::new().map_err(|e| e.to_string())?;
 
     println!("\nPlacement Results:");
-    let (total_success, total_failure) =
-        place_components(&target_names, &filtered_components, &ctx, &mut import_registry)?;
+    let (total_success, total_failure) = place_components(
+        &target_names,
+        &filtered_components,
+        &ctx,
+        &mut import_registry,
+    )?;
 
     // 10. Summary
     let summary = CommandSummary::format(total_success, total_failure);


### PR DESCRIPTION
## Summary

- Extract the ~100-line double for-loop (target × component) in `run()` into focused helper functions
- Introduce `ImportContext` struct to bundle import operation parameters instead of threading many locals
- Introduce `DeployOutcome` enum (`Success` / `Failure` / `Skipped`) for explicit deploy result handling
- Extract `build_deployment()`, `deploy_one()`, and `place_components()` functions

## Motivation

The `run()` function in `src/commands/import.rs` had a deeply nested double for-loop handling target iteration, support checks, placement context construction, deployment building, execution, and import record recording all in one block. This made the function hard to read and modify.

This refactoring breaks the loop body into single-responsibility functions while preserving the exact same external behavior.

## Changes

| File | Change |
|------|--------|
| `src/commands/import.rs` | Extract methods, introduce `ImportContext` and `DeployOutcome` (+152 / -108 lines) |

## Verification

- [x] `cargo check` passes
- [x] `cargo test` — 824 tests all pass
- [x] `cargo clippy` — no warnings
- [x] No external interface changes (pure refactoring)

🤖 Generated with [Claude Code](https://claude.com/claude-code)