### PR TITLE
🤖 ci: Auto-tag on Cargo.toml version change

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,0 +1,38 @@
+name: Auto Tag
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'Cargo.toml'
+
+jobs:
+  tag:
+    name: Create version tag
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get version from Cargo.toml
+        id: version
+        run: |
+          VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Check if tag exists
+        id: check
+        run: |
+          if git ls-remote --tags origin "refs/tags/${{ steps.version.outputs.tag }}" | grep -q .; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create and push tag
+        if: steps.check.outputs.exists == 'false'
+        run: |
+          git tag "${{ steps.version.outputs.tag }}"
+          git push origin "${{ steps.version.outputs.tag }}"


### PR DESCRIPTION
## Summary

- main ブランチへの push 時に `Cargo.toml` のバージョン変更を検知し、対応する `v*` タグを自動作成・プッシュするワークフローを追加
- 手動でのタグ作成・プッシュステップを不要にし、リリースフローを簡素化
- 既存の `release.yml`（`v*` タグトリガー）が連鎖的に実行されるため変更不要

## Test plan

- [ ] `Cargo.toml` の `version` を変更する PR を作成・マージし、「Auto Tag」ワークフローが実行されることを確認
- [ ] 対応する `v*` タグが自動作成されることを確認
- [ ] 「Release」ワークフローが連鎖的にトリガーされることを確認
- [ ] 既にタグが存在する場合はスキップされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)