### PR TITLE
🔖 chore: Bump version to 0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1670,7 +1670,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plm"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "assert_cmd",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plm"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 license = "MIT"
 


### PR DESCRIPTION
## 概要

バージョンを 0.3.1 にバンプ。v0.3.0 はタグのみ作成されリリースが生成されなかったため欠番とする。

## 変更内容

### 🎯 変更の種類

- [x] 🔧 設定変更 (Configuration)

### 📝 詳細な変更内容

- `Cargo.toml` の version を `0.3.0` → `0.3.1` に変更
- `Cargo.lock` を同期

## ⚠️ 注意

このPRは #82 (ワークフロー統合) のマージ後にマージしてください。マージにより新しい release ワークフローがトリガーされ、v0.3.1 のリリースが自動作成されます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)