### PR TITLE
Fix case-sensitive SKILL.md detection and refactor error handling

### DIFF
--- a/src/commands/disable.rs
+++ b/src/commands/disable.rs
@@ -7,7 +7,6 @@ use crate::application::{disable_plugin, OperationResult};
 use crate::plugin::{meta, PluginCache};
 use clap::{Parser, ValueEnum};
 use std::env;
-use std::process;
 
 #[derive(Debug, Clone, ValueEnum)]
 pub enum TargetKind {
@@ -44,12 +43,10 @@ pub async fn run(args: Args) -> Result<(), String> {
     // プラグインがキャッシュに存在するか確認
     // キャッシュが必要な理由: マニフェストから削除対象コンポーネントを特定するため
     if !cache.is_cached(Some(&args.marketplace), &args.name) {
-        eprintln!(
-            "Error: Plugin '{}' not found in cache (marketplace: {})",
+        return Err(format!(
+            "Error: Plugin '{}' not found in cache (marketplace: {})\nHint: Cache is required to identify components to remove.",
             args.name, args.marketplace
-        );
-        eprintln!("Hint: Cache is required to identify components to remove.");
-        process::exit(1);
+        ));
     }
 
     let project_root = env::current_dir().unwrap_or_else(|_| ".".into());
@@ -67,14 +64,28 @@ pub async fn run(args: Args) -> Result<(), String> {
     let plugin_path = cache.plugin_path(Some(&args.marketplace), &args.name);
     update_status_after_disable(&plugin_path, &result);
 
-    // 結果表示
-    display_result(&args.name, &result, target_filter);
-
-    // 終了コード
+    // 結果表示と終了コード
     if result.success {
+        display_result(&args.name, &result, target_filter);
         Ok(())
     } else {
-        process::exit(1);
+        // 部分成功の場合は先に表示
+        let successful_targets = result.affected_targets.target_names();
+        if !successful_targets.is_empty() {
+            println!(
+                "  Partially disabled: {} target(s) succeeded",
+                successful_targets.len()
+            );
+        }
+        // エラーメッセージを Err に格納
+        if let Some(error) = &result.error {
+            Err(format!(
+                "Error: Failed to disable plugin '{}': {}",
+                args.name, error
+            ))
+        } else {
+            Err(format!("Error: Failed to disable plugin '{}'", args.name))
+        }
     }
 }
 
@@ -98,31 +109,8 @@ fn update_status_after_disable(plugin_path: &std::path::Path, result: &Operation
     }
 }
 
-/// 結果を表示
+/// 成功時の結果を表示
 fn display_result(plugin_name: &str, result: &OperationResult, target_filter: Option<&str>) {
-    // エラーケースを先に処理
-    if !result.success {
-        if let Some(error) = &result.error {
-            eprintln!(
-                "Error: Failed to disable plugin '{}': {}",
-                plugin_name, error
-            );
-        } else {
-            eprintln!("Error: Failed to disable plugin '{}'", plugin_name);
-        }
-
-        // 部分成功の場合
-        let successful_targets = result.affected_targets.target_names();
-        if !successful_targets.is_empty() {
-            println!(
-                "  Partially disabled: {} target(s) succeeded",
-                successful_targets.len()
-            );
-        }
-        return;
-    }
-
-    // 空ターゲットケースを処理
     let targets = result.affected_targets.target_names();
     if targets.is_empty() {
         if let Some(filter) = target_filter {
@@ -133,14 +121,16 @@ fn display_result(plugin_name: &str, result: &OperationResult, target_filter: Op
         } else {
             println!("Disabled: Plugin '{}' (no components removed)", plugin_name);
         }
-        return;
+    } else {
+        let target_list = targets.join(", ");
+        let component_count = result.affected_targets.total_components();
+        println!(
+            "Disabled: Plugin '{}' ({} component(s) removed from {})",
+            plugin_name, component_count, target_list
+        );
     }
-
-    // 成功ケース
-    let target_list = targets.join(", ");
-    let component_count = result.affected_targets.total_components();
-    println!(
-        "Disabled: Plugin '{}' ({} component(s) removed from {})",
-        plugin_name, component_count, target_list
-    );
 }
+
+#[cfg(test)]
+#[path = "disable_test.rs"]
+mod tests;

--- a/src/commands/disable_test.rs
+++ b/src/commands/disable_test.rs
@@ -1,0 +1,35 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+use tempfile::TempDir;
+
+fn plm() -> Command {
+    Command::cargo_bin("plm").unwrap()
+}
+
+#[test]
+fn test_disable_cache_not_found_shows_error_once() {
+    let home = TempDir::new().unwrap();
+    plm()
+        .env("HOME", home.path())
+        .args(["disable", "nonexistent-plugin"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("not found in cache").count(1))
+        .stderr(predicate::str::contains("Hint:"));
+}
+
+#[test]
+fn test_disable_operation_failure_shows_error_once() {
+    let home = TempDir::new().unwrap();
+    // Create cache directory with no manifest so disable_plugin fails
+    let cache_dir = home.path().join(".plm/cache/plugins/github/broken-plugin");
+    fs::create_dir_all(&cache_dir).unwrap();
+
+    plm()
+        .env("HOME", home.path())
+        .args(["disable", "broken-plugin"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Failed to disable plugin").count(1));
+}

--- a/src/commands/enable_test.rs
+++ b/src/commands/enable_test.rs
@@ -1,0 +1,34 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+use tempfile::TempDir;
+
+fn plm() -> Command {
+    Command::cargo_bin("plm").unwrap()
+}
+
+#[test]
+fn test_enable_cache_not_found_shows_error_once() {
+    let home = TempDir::new().unwrap();
+    plm()
+        .env("HOME", home.path())
+        .args(["enable", "nonexistent-plugin"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("not found in cache").count(1));
+}
+
+#[test]
+fn test_enable_operation_failure_shows_error_once() {
+    let home = TempDir::new().unwrap();
+    // Create cache directory with no manifest so enable_plugin fails
+    let cache_dir = home.path().join(".plm/cache/plugins/github/broken-plugin");
+    fs::create_dir_all(&cache_dir).unwrap();
+
+    plm()
+        .env("HOME", home.path())
+        .args(["enable", "broken-plugin"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Failed to enable plugin").count(1));
+}


### PR DESCRIPTION
## Summary

- SKILL.md のスキル検出において、ファイルシステムのケース感度に依存しない厳密なファイル名一致判定を導入し、macOS (APFS) や Windows (NTFS) 等のケース非感知FSで `skill.md` や `SKILL.MD` が誤検出される問題を修正
- `SKILL.md` という名前のディレクトリがスキルとして誤検出される問題を修正（`is_file()` チェック追加）
- `enable` / `disable` コマンドから `process::exit(1)` を排除し、`Err(String)` を返却する方式に統一。エラーハンドリングを `main.rs` に一元化

## Changes

### Bug Fixes
- `src/scan/components.rs`: `list_skill_names` で `path.join("SKILL.md").exists()` を `read_dir` + `OsStr` 厳密比較に置換
- `src/scan/components.rs`: `has_exact_skill_manifest` に `is_file()` チェックを追加し、ディレクトリを除外

### Refactoring
- `src/commands/enable.rs`: `process::exit(1)` を `Err(format!(...))` に置換、`display_result` を成功ケースのみに簡素化
- `src/commands/disable.rs`: 同上

### Tests
- `src/scan/components/tests.rs`: 大文字拡張子 (`SKILL.MD`)、空サブディレクトリ、ディレクトリ名 `SKILL.md` の除外テストを追加
- `src/commands/enable_test.rs`: キャッシュ未検出時・操作失敗時のエラーメッセージ重複がないことを検証する統合テストを追加
- `src/commands/disable_test.rs`: 同上

## Related Issues

Closes #87

## Test Plan

- [x] `cargo test` で全テストが通ること
- [x] `SKILL.MD`（大文字拡張子）がスキルとして検出されないこと
- [x] `SKILL.md` という名前のディレクトリがスキルとして検出されないこと
- [x] `enable`/`disable` コマンドでキャッシュ未検出時にエラーメッセージが1回のみ表示されること
- [x] `enable`/`disable` コマンドで操作失敗時にエラーメッセージが重複しないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)