### PR TITLE
🏷️ [Types] TUI マーケットプレイス画面にプラグインブラウズ&インストールの型定義を追加

### DIFF
--- a/src/tui/manager/screens/marketplaces/model.rs
+++ b/src/tui/manager/screens/marketplaces/model.rs
@@ -2,9 +2,12 @@
 //!
 //! 画面状態とメッセージ型を定義。
 
+use crate::component::Scope;
+use crate::marketplace::PluginSource;
 use crate::tui::manager::core::DataStore;
 use crossterm::event::KeyCode;
 use ratatui::widgets::ListState;
+use std::collections::HashSet;
 
 // ============================================================================
 // OperationStatus（非同期操作の状態）
@@ -37,6 +40,7 @@ pub enum DetailAction {
     Update,
     Remove,
     ShowPlugins,
+    BrowsePlugins,
     Back,
 }
 
@@ -46,6 +50,7 @@ impl DetailAction {
             DetailAction::Update,
             DetailAction::Remove,
             DetailAction::ShowPlugins,
+            DetailAction::BrowsePlugins,
             DetailAction::Back,
         ]
     }
@@ -55,6 +60,7 @@ impl DetailAction {
             DetailAction::Update => "Update",
             DetailAction::Remove => "Remove",
             DetailAction::ShowPlugins => "Show plugins",
+            DetailAction::BrowsePlugins => "Browse plugins",
             DetailAction::Back => "Back to list",
         }
     }
@@ -96,6 +102,34 @@ pub enum AddFormModel {
 }
 
 // ============================================================================
+// BrowsePlugin / PluginInstallResult / InstallSummary
+// ============================================================================
+
+/// マーケットプレイスのプラグイン情報（ブラウズ画面用）
+pub struct BrowsePlugin {
+    pub name: String,
+    pub description: Option<String>,
+    pub version: Option<String>,
+    pub source: PluginSource,
+    pub installed: bool,
+}
+
+/// プラグインインストール結果（1件分）
+pub struct PluginInstallResult {
+    pub plugin_name: String,
+    pub success: bool,
+    pub error: Option<String>,
+}
+
+/// インストールサマリー
+pub struct InstallSummary {
+    pub results: Vec<PluginInstallResult>,
+    pub total: usize,
+    pub succeeded: usize,
+    pub failed: usize,
+}
+
+// ============================================================================
 // Model（画面状態）
 // ============================================================================
 
@@ -124,6 +158,48 @@ pub enum Model {
     },
     /// 新規マーケットプレイス追加フォーム
     AddForm(AddFormModel),
+    /// プラグインブラウズ画面
+    PluginBrowse {
+        marketplace_name: String,
+        plugins: Vec<BrowsePlugin>,
+        selected_plugins: HashSet<String>,
+        highlighted_idx: usize,
+        state: ListState,
+    },
+    /// ターゲット選択画面
+    TargetSelect {
+        marketplace_name: String,
+        plugins: Vec<BrowsePlugin>,
+        selected_plugins: HashSet<String>,
+        targets: Vec<(String, String, bool)>,
+        highlighted_idx: usize,
+        state: ListState,
+    },
+    /// スコープ選択画面
+    ScopeSelect {
+        marketplace_name: String,
+        plugins: Vec<BrowsePlugin>,
+        selected_plugins: HashSet<String>,
+        target_names: Vec<String>,
+        highlighted_idx: usize,
+        state: ListState,
+    },
+    /// インストール実行中
+    Installing {
+        marketplace_name: String,
+        plugins: Vec<BrowsePlugin>,
+        plugin_names: Vec<String>,
+        target_names: Vec<String>,
+        scope: Scope,
+        current_idx: usize,
+        total: usize,
+    },
+    /// インストール結果表示
+    InstallResult {
+        marketplace_name: String,
+        plugins: Vec<BrowsePlugin>,
+        summary: InstallSummary,
+    },
 }
 
 impl Model {
@@ -182,6 +258,23 @@ impl Model {
                 selected_id: Some(marketplace_name.clone()),
             },
             Model::AddForm(_) => CacheState { selected_id: None },
+            Model::PluginBrowse {
+                marketplace_name, ..
+            }
+            | Model::TargetSelect {
+                marketplace_name, ..
+            }
+            | Model::ScopeSelect {
+                marketplace_name, ..
+            }
+            | Model::Installing {
+                marketplace_name, ..
+            }
+            | Model::InstallResult {
+                marketplace_name, ..
+            } => CacheState {
+                selected_id: Some(marketplace_name.clone()),
+            },
         }
     }
 
@@ -218,6 +311,12 @@ pub enum Msg {
     UpdateAll,
     ExecuteUpdate,
     ExecuteRemove,
+    ToggleSelect,
+    StartInstall,
+    ExecuteInstall,
+    ConfirmTargets,
+    ConfirmScope,
+    BackToPluginBrowse,
 }
 
 /// キーコードをメッセージに変換

--- a/src/tui/manager/screens/marketplaces/update.rs
+++ b/src/tui/manager/screens/marketplaces/update.rs
@@ -63,6 +63,12 @@ pub fn update(model: &mut Model, msg: Msg, data: &mut DataStore) -> UpdateEffect
         Msg::UpdateAll => update_all(model, data),
         Msg::ExecuteUpdate => execute_update(model, data),
         Msg::ExecuteRemove => execute_remove(model, data),
+        Msg::ToggleSelect
+        | Msg::StartInstall
+        | Msg::ExecuteInstall
+        | Msg::ConfirmTargets
+        | Msg::ConfirmScope
+        | Msg::BackToPluginBrowse => UpdateEffect::none(),
     }
 }
 
@@ -114,7 +120,7 @@ fn select_prev(model: &mut Model, data: &DataStore) {
                 state.select(Some(*selected_idx));
             }
         }
-        Model::AddForm(_) => {}
+        _ => {}
     }
 }
 
@@ -149,7 +155,7 @@ fn select_next(model: &mut Model, data: &DataStore) {
             *selected_idx = next;
             state.select(Some(next));
         }
-        Model::AddForm(_) => {}
+        _ => {}
     }
 }
 
@@ -216,6 +222,7 @@ fn enter(model: &mut Model, data: &mut DataStore) -> UpdateEffect {
                     };
                     UpdateEffect::phase2(Msg::ExecuteRemove)
                 }
+                Some(DetailAction::BrowsePlugins) => UpdateEffect::none(),
                 Some(DetailAction::ShowPlugins) => {
                     let name = marketplace_name.clone();
                     let plugins = actions::get_marketplace_plugins(&name);
@@ -244,6 +251,7 @@ fn enter(model: &mut Model, data: &mut DataStore) -> UpdateEffect {
             UpdateEffect::none()
         }
         Model::AddForm(_) => enter_form(model, data),
+        _ => UpdateEffect::none(),
     }
 }
 
@@ -409,6 +417,7 @@ fn back(model: &mut Model, data: &DataStore) {
                 error_message: None,
             };
         }
+        _ => {}
     }
 }
 

--- a/src/tui/manager/screens/marketplaces/update_test.rs
+++ b/src/tui/manager/screens/marketplaces/update_test.rs
@@ -352,7 +352,8 @@ fn detail_back_action_returns_to_market_list() {
     // Enter -> MarketDetail
     update(&mut model, Msg::Enter, &mut data);
 
-    // Move to Back (index 3)
+    // Move to Back (index 4: Update, Remove, ShowPlugins, BrowsePlugins, Back)
+    update(&mut model, Msg::Down, &mut data);
     update(&mut model, Msg::Down, &mut data);
     update(&mut model, Msg::Down, &mut data);
     update(&mut model, Msg::Down, &mut data);
@@ -1318,5 +1319,10 @@ fn model_variant(model: &Model) -> &'static str {
         Model::MarketDetail { .. } => "MarketDetail",
         Model::PluginList { .. } => "PluginList",
         Model::AddForm(_) => "AddForm",
+        Model::PluginBrowse { .. } => "PluginBrowse",
+        Model::TargetSelect { .. } => "TargetSelect",
+        Model::ScopeSelect { .. } => "ScopeSelect",
+        Model::Installing { .. } => "Installing",
+        Model::InstallResult { .. } => "InstallResult",
     }
 }

--- a/src/tui/manager/screens/marketplaces/view.rs
+++ b/src/tui/manager/screens/marketplaces/view.rs
@@ -63,6 +63,7 @@ pub fn view(
         Model::AddForm(form) => {
             view_add_form(f, form, filter_text, filter_focused);
         }
+        _ => {}
     }
 }
 


### PR DESCRIPTION
## 概要

TUI マーケットプレイス画面にプラグインブラウズ&インストール機能の型定義を追加する。
本 PR は型定義とコンパイル通過のみをスコープとし、ロジック・描画実装は後続 Issue で行う。

## 変更内容

### 🎯 変更の種類

- [x] ✨ 新機能 (New feature)

### 📝 詳細な変更内容

#### 追加された機能・修正

- `BrowsePlugin` 構造体: マーケットプレイスのプラグイン情報（ブラウズ画面用）
- `PluginInstallResult` 構造体: プラグインインストール結果（1件分）
- `InstallSummary` 構造体: インストールサマリー（成功/失敗件数）
- `Model` enum に 5 新バリアント追加:
  - `PluginBrowse` - プラグインブラウズ画面
  - `TargetSelect` - ターゲット選択画面
  - `ScopeSelect` - スコープ選択画面
  - `Installing` - インストール実行中
  - `InstallResult` - インストール結果表示
- `Msg` enum に 6 新バリアント追加:
  - `ToggleSelect`, `StartInstall`, `ExecuteInstall`, `ConfirmTargets`, `ConfirmScope`, `BackToPluginBrowse`
- `DetailAction::BrowsePlugins` バリアント追加（`all()` と `label()` に反映）
- `update.rs` に新 `Msg` バリアントの no-op match arm 追加
- `update.rs` の `select_prev` / `select_next` / `enter` / `back` に新 `Model` バリアント用のワイルドカード match arm 追加
- `view.rs` に新 `Model` バリアント用のワイルドカード match arm 追加
- `update_test.rs` の `model_variant()` ヘルパーに 5 新バリアント追加
- `detail_back_action_returns_to_market_list` テストの Down 回数を更新（BrowsePlugins 追加分）

#### 変更されたファイル

- `src/tui/manager/screens/marketplaces/model.rs` - 型定義の追加
- `src/tui/manager/screens/marketplaces/update.rs` - no-op match arm 追加
- `src/tui/manager/screens/marketplaces/update_test.rs` - テストヘルパー更新
- `src/tui/manager/screens/marketplaces/view.rs` - no-op match arm 追加

#### 削除されたファイル・機能

- なし

## 📋 関連 Issue

- 関連 Issue なし（型定義の先行追加）

## 🧪 テスト

### テスト実行方法

```bash
cargo test
```

### テスト項目

- [x] 単体テスト (Unit tests)
- [ ] 統合テスト (Integration tests)
- [ ] E2E テスト (End-to-end tests)
- [ ] 手動テスト (Manual testing)

### テスト結果

- `cargo check`: パス
- `cargo test`: 1004 テスト全パス
- `cargo fmt`: 差分なし
- `cargo clippy`: 変更箇所に新規警告なし

## 📸 スクリーンショット/動画

UI の描画実装は本 PR に含まれないため、スクリーンショットなし。

## 🔍 レビューポイント

- `BrowsePlugin` / `PluginInstallResult` / `InstallSummary` のフィールド設計が後続実装に十分か
- `Model` の新バリアントが持つフィールド構成（特に `TargetSelect` の `targets: Vec<(String, String, bool)>` のタプル設計）
- `update.rs` / `view.rs` のワイルドカード match arm が既存動作に影響しないか

## ⚠️ 破壊的変更

- [ ] この変更は既存の API に破壊的変更を含みます

## 📚 追加情報

### 注意事項

- 本 PR は型定義のみのスコープであり、ロジック・描画実装は後続 Issue で行う
- `update.rs` / `view.rs` の新バリアント用 match arm は現時点では no-op（`UpdateEffect::none()` / `{}` を返す）

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [x] ドキュメントが更新されている（必要に応じて）
- [x] コミットメッセージが適切な形式で書かれている
- [ ] 関連する Issue が PR の「Development」に Linked されている
- [ ] PR 本文に `Closes #` / `Fixes #` / `Refs #` などで Issue が記載されている
- [x] セルフレビューを実施した
- [x] 破壊的変更がある場合は明記されている

🤖 Generated with [Claude Code](https://claude.com/claude-code)