### PR TITLE
TargetSelect/ScopeSelect render improvement

### DIFF
--- a/src/tui/manager/screens/marketplaces/view.rs
+++ b/src/tui/manager/screens/marketplaces/view.rs
@@ -924,11 +924,7 @@ fn scope_radio(is_current: bool) -> (&'static str, Style) {
 /// ScopeSelect 用のリストアイテムを構築
 fn build_scope_list_items(highlighted_idx: usize) -> Vec<ListItem<'static>> {
     let scopes = [(Scope::Personal, "(~/.plm/)"), (Scope::Project, "(./)")];
-    let clamped = if highlighted_idx < scopes.len() {
-        highlighted_idx
-    } else {
-        0
-    };
+    let clamped = highlighted_idx.min(scopes.len() - 1);
     scopes
         .iter()
         .enumerate()

--- a/src/tui/manager/screens/marketplaces/view_test.rs
+++ b/src/tui/manager/screens/marketplaces/view_test.rs
@@ -245,17 +245,17 @@ fn build_scope_list_items_project_selected() {
 }
 
 #[test]
-fn build_scope_list_items_out_of_range_clamps_to_personal() {
+fn build_scope_list_items_out_of_range_clamps_to_last() {
     let items = build_scope_list_items(99);
     assert_eq!(items.len(), 2);
-    // Out-of-range clamps to 0 (Personal selected)
+    // Out-of-range clamps to last valid index (Project selected)
     let expected_personal = ListItem::new(format!(
-        "  (x) {} (~/.plm/)",
+        "  ( ) {} (~/.plm/)",
         Scope::Personal.display_name()
     ))
-    .style(Style::default().fg(Color::Yellow));
-    let expected_project = ListItem::new(format!("  ( ) {} (./)", Scope::Project.display_name()))
-        .style(Style::default());
+    .style(Style::default());
+    let expected_project = ListItem::new(format!("  (x) {} (./)", Scope::Project.display_name()))
+        .style(Style::default().fg(Color::Yellow));
     assert_eq!(items[0], expected_personal);
     assert_eq!(items[1], expected_project);
 }


### PR DESCRIPTION
## 概要

マーケットプレイスのインストールフローにおける TargetSelect / ScopeSelect 画面の描画ロジックを改善。

## 変更の種類

- ♻️ リファクタリング: TargetSelect の描画ロジックをテスト可能な純粋関数に抽出
- 🎨 UI/UX改善: ScopeSelect にラジオボタンマーク `(x)`/`( )` と Yellow ハイライトを追加
- 🚨 テスト: 新規ヘルパー関数に対する 11 件のユニットテスト追加

## 詳細な変更内容

### 追加

- `target_checkbox(selected: bool)` — ターゲット選択のチェックボックスマーク+スタイル決定
- `build_target_list_items(targets)` — TargetSelect 用 ListItem 構築
- `scope_radio(is_current: bool)` — スコープ選択のラジオボタンマーク+スタイル決定
- `build_scope_list_items(highlighted_idx)` — ScopeSelect 用 ListItem 構築（ラジオマーク付き）
- ユニットテスト 11 件（target_checkbox: 2, scope_radio: 2, build_target_list_items: 4, build_scope_list_items: 3）

### 変更

- `view_target_select` — インラインロジックを `build_target_list_items` 呼び出しに置換
- `view_scope_select` — インラインロジックを `build_scope_list_items` 呼び出しに置換、`_highlighted_idx` を活用して描画と `confirm_scope` の選択判定を同じソースに統一

## 関連Issue

Closes #139

## テスト

- `cargo test` — 1097 テスト全パス
- `cargo clippy` — 新規警告なし
- `cargo fmt` — フォーマット適用済み
- 新規テスト 11 件すべてパス

## レビューポイント

- `build_scope_list_items` の `highlighted_idx` 範囲外ガード（`highlighted_idx < scopes.len()`）の妥当性
- ScopeSelect のラジオマーク `(x)`/`( )` が dialog.rs の既存パターンと統一されているか

🤖 Generated with [Claude Code](https://claude.com/claude-code)