### PR TITLE
♻️ [Refactoring]: cache_key / install_id を id に統一リネーム

### DIFF
--- a/src/application/catalog.rs
+++ b/src/application/catalog.rs
@@ -25,12 +25,12 @@ pub fn list_installed_plugins(cache: &dyn PackageCacheAccess) -> Result<Vec<Inst
             let name = pkg.manifest().name.clone();
             let plugin = Plugin::new(pkg.manifest().clone(), pkg.path().to_path_buf());
             let marketplace_str = pkg.marketplace().unwrap_or("github");
-            let ops_key = pkg.cache_key().unwrap_or(&name);
+            let ops_key = pkg.id().unwrap_or(&name);
             let enabled = meta::is_enabled(pkg.path(), marketplace_str, ops_key, &deployed);
 
             InstalledPlugin::from_cached_package(
                 plugin,
-                pkg.cache_key().map(str::to_string),
+                pkg.id().map(str::to_string),
                 pkg.marketplace().map(str::to_string),
                 enabled,
             )

--- a/src/application/info.rs
+++ b/src/application/info.rs
@@ -215,10 +215,9 @@ fn build_plugin_info(content: MarketplaceContent) -> Result<PluginInfo> {
     let enabled = resolve_enabled(&cache_path, marketplace_key, &dir_name);
 
     // InstalledPlugin を組み立てる（list_installed_plugins と同じく marketplace は Option<String> を保つ）
-    let install_id = Some(dir_name);
+    let id = Some(dir_name);
     let plugin = Plugin::new(manifest, cache_path);
-    let installed =
-        InstalledPlugin::from_cached_package(plugin, install_id, marketplace_opt, enabled);
+    let installed = InstalledPlugin::from_cached_package(plugin, id, marketplace_opt, enabled);
 
     Ok(PluginInfo {
         installed,
@@ -235,11 +234,11 @@ fn build_plugin_info(content: MarketplaceContent) -> Result<PluginInfo> {
 ///
 /// * `cache_path` - Path to the plugin's cache directory.
 /// * `marketplace` - Marketplace key (e.g. `"github"`).
-/// * `install_id` - Install identifier used to match deployed entries.
-fn resolve_enabled(cache_path: &Path, marketplace: &str, install_id: &str) -> bool {
+/// * `id` - Install identifier used to match deployed entries.
+fn resolve_enabled(cache_path: &Path, marketplace: &str, id: &str) -> bool {
     let project_root = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
     let deployed = list_all_placed(&project_root);
-    meta::is_enabled(cache_path, marketplace, install_id, &deployed)
+    meta::is_enabled(cache_path, marketplace, id, &deployed)
 }
 
 #[cfg(test)]

--- a/src/application/info.rs
+++ b/src/application/info.rs
@@ -234,7 +234,7 @@ fn build_plugin_info(content: MarketplaceContent) -> Result<PluginInfo> {
 ///
 /// * `cache_path` - Path to the plugin's cache directory.
 /// * `marketplace` - Marketplace key (e.g. `"github"`).
-/// * `id` - Install identifier used to match deployed entries.
+/// * `id` - identifier used to match deployed entries.
 fn resolve_enabled(cache_path: &Path, marketplace: &str, id: &str) -> bool {
     let project_root = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
     let deployed = list_all_placed(&project_root);

--- a/src/application/info.rs
+++ b/src/application/info.rs
@@ -199,7 +199,7 @@ fn restore_github_repo(dir_name: &str) -> String {
 fn build_plugin_info(content: MarketplaceContent) -> Result<PluginInfo> {
     let marketplace_opt = content.marketplace().map(str::to_string);
     let dir_name = content
-        .cache_key()
+        .id()
         .map(str::to_string)
         .unwrap_or_else(|| content.name().to_string());
     let cache_path = content.path().to_path_buf();

--- a/src/application/info_test.rs
+++ b/src/application/info_test.rs
@@ -222,7 +222,7 @@ fn create_marketplace_content(marketplace: &str, name: &str) -> MarketplaceConte
     };
     let cached = CachedPackage {
         name: name.to_string(),
-        cache_key: Some(name.to_string()),
+        id: Some(name.to_string()),
         marketplace: Some(marketplace.to_string()),
         path: PathBuf::from(format!("/cache/{}/{}", marketplace, name)),
         manifest,

--- a/src/application/lifecycle.rs
+++ b/src/application/lifecycle.rs
@@ -22,7 +22,7 @@ use std::path::Path;
 /// # Arguments
 ///
 /// * `cache` - プラグインを検索するためのパッケージキャッシュアクセサ
-/// * `plugin_name` - プラグインのキャッシュキー（キャッシュディレクトリ名。GitHub なら `owner--repo`、Marketplace でも `cache.is_cached` / `load_plugin_deployment` に渡すディレクトリ名で、Marketplace 登録名とは一致しない場合がある。`InstalledPlugin::install_id()` 相当）
+/// * `plugin_name` - プラグインの id（キャッシュディレクトリ名。GitHub なら `owner--repo`、Marketplace でも `cache.is_cached` / `load_plugin_deployment` に渡すディレクトリ名で、Marketplace 登録名とは一致しない場合がある。`InstalledPlugin::id()` 相当）
 /// * `marketplace` - マーケットプレイス名（任意）
 /// * `project_root` - プロジェクトルートパス
 /// * `target_filter` - ターゲットフィルタ（None で全ターゲット）
@@ -80,7 +80,7 @@ pub fn disable_plugin(
 /// # Arguments
 ///
 /// * `cache` - プラグインを検索するためのパッケージキャッシュアクセサ
-/// * `plugin_name` - プラグインのキャッシュキー（キャッシュディレクトリ名。GitHub なら `owner--repo`、Marketplace でも `cache.is_cached` / `load_plugin_deployment` に渡すディレクトリ名で、Marketplace 登録名とは一致しない場合がある。`InstalledPlugin::install_id()` 相当）
+/// * `plugin_name` - プラグインの id（キャッシュディレクトリ名。GitHub なら `owner--repo`、Marketplace でも `cache.is_cached` / `load_plugin_deployment` に渡すディレクトリ名で、Marketplace 登録名とは一致しない場合がある。`InstalledPlugin::id()` 相当）
 /// * `marketplace` - マーケットプレイス名（任意）
 /// * `project_root` - プロジェクトルートパス
 /// * `target_filter` - ターゲットフィルタ（None で全ターゲット）
@@ -124,7 +124,7 @@ pub fn enable_plugin(
 /// # Arguments
 ///
 /// * `cache` - プラグインを検索するためのパッケージキャッシュアクセサ
-/// * `plugin_name` - プラグインのキャッシュキー（キャッシュディレクトリ名。GitHub なら `owner--repo`、Marketplace でも `cache.is_cached` / `load_plugin_deployment` に渡すディレクトリ名で、Marketplace 登録名とは一致しない場合がある。`InstalledPlugin::install_id()` 相当）
+/// * `plugin_name` - プラグインの id（キャッシュディレクトリ名。GitHub なら `owner--repo`、Marketplace でも `cache.is_cached` / `load_plugin_deployment` に渡すディレクトリ名で、Marketplace 登録名とは一致しない場合がある。`InstalledPlugin::id()` 相当）
 /// * `marketplace` - マーケットプレイス名（任意、デフォルト: "github"）
 ///
 /// # Returns
@@ -179,7 +179,7 @@ pub struct UninstallInfo {
 /// # Arguments
 ///
 /// * `cache` - プラグインを検索するためのパッケージキャッシュアクセサ
-/// * `plugin_name` - プラグインのキャッシュキー（キャッシュディレクトリ名。GitHub なら `owner--repo`、Marketplace でも `cache.is_cached` / `load_plugin_deployment` に渡すディレクトリ名で、Marketplace 登録名とは一致しない場合がある。`InstalledPlugin::install_id()` 相当）
+/// * `plugin_name` - プラグインの id（キャッシュディレクトリ名。GitHub なら `owner--repo`、Marketplace でも `cache.is_cached` / `load_plugin_deployment` に渡すディレクトリ名で、Marketplace 登録名とは一致しない場合がある。`InstalledPlugin::id()` 相当）
 /// * `marketplace` - マーケットプレイス名（任意）
 /// * `project_root` - プロジェクトルートパス
 pub fn uninstall_plugin(

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -416,10 +416,8 @@ pub async fn run(args: Args) -> Result<(), String> {
     }
 
     let project_root = env::current_dir().map_err(|e| e.to_string())?;
-    let origin = PluginOrigin::from_cached_plugin(
-        cached_plugin.marketplace.as_deref(),
-        cached_plugin.cache_key(),
-    );
+    let origin =
+        PluginOrigin::from_cached_plugin(cached_plugin.marketplace.as_deref(), cached_plugin.id());
 
     let ctx = ImportContext {
         origin: &origin,

--- a/src/commands/list/outdated.rs
+++ b/src/commands/list/outdated.rs
@@ -47,9 +47,9 @@ pub(super) async fn run_outdated(
     let plugin_metas: Vec<(String, PluginMeta)> = plugins
         .iter()
         .map(|plugin| {
-            let plugin_path = cache.plugin_path(plugin.marketplace(), plugin.install_id());
+            let plugin_path = cache.plugin_path(plugin.marketplace(), plugin.id());
             let plugin_meta = meta::load_meta(&plugin_path).unwrap_or_default();
-            (plugin.install_id().to_string(), plugin_meta)
+            (plugin.id().to_string(), plugin_meta)
         })
         .collect();
 

--- a/src/commands/list/wire.rs
+++ b/src/commands/list/wire.rs
@@ -13,7 +13,8 @@ use serde::{Serialize, Serializer};
 pub(super) struct Wire<'a> {
     pub(super) name: &'a str,
     pub(super) version: &'a str,
-    pub(super) install_id: &'a str,
+    #[serde(rename = "install_id")]
+    pub(super) id: &'a str,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(super) marketplace: Option<&'a str>,
     pub(super) enabled: bool,
@@ -30,7 +31,7 @@ impl<'a> Wire<'a> {
         Self {
             name: plugin.name(),
             version: plugin.version(),
-            install_id: plugin.install_id(),
+            id: plugin.id(),
             marketplace: plugin.marketplace(),
             enabled: plugin.enabled(),
             components: ComponentsWire(plugin.components()),

--- a/src/commands/list/wire_test.rs
+++ b/src/commands/list/wire_test.rs
@@ -63,7 +63,7 @@ fn wire_from_installed_snapshot_full() {
 }
 
 #[test]
-fn wire_install_id_fallback_to_name() {
+fn wire_id_fallback_to_name() {
     let plugin = InstalledPlugin::new_for_test(
         "no-install-id",
         "0.1.0",

--- a/src/install.rs
+++ b/src/install.rs
@@ -22,9 +22,9 @@ impl ScannedPlugin {
         self.package.name()
     }
 
-    /// キャッシュディレクトリ名を返す（`cache_key` が `None` の場合は `name` にフォールバック）
-    pub fn cache_key(&self) -> &str {
-        crate::plugin::resolve_cache_key(self.package.cache_key(), self.package.name())
+    /// キャッシュディレクトリ名を返す（`id` が `None` の場合は `name` にフォールバック）
+    pub fn id(&self) -> &str {
+        crate::plugin::resolve_cache_key(self.package.id(), self.package.name())
     }
 
     /// マーケットプレイス名を取得
@@ -162,10 +162,8 @@ pub fn place_plugin(request: &PlaceRequest) -> PlaceResult {
     let mut successes = Vec::new();
     let mut failures = Vec::new();
 
-    let origin = PluginOrigin::from_cached_plugin(
-        request.scanned.marketplace(),
-        request.scanned.cache_key(),
-    );
+    let origin =
+        PluginOrigin::from_cached_plugin(request.scanned.marketplace(), request.scanned.id());
 
     for target in request.targets {
         for component in &request.scanned.components {

--- a/src/install.rs
+++ b/src/install.rs
@@ -24,7 +24,7 @@ impl ScannedPlugin {
 
     /// キャッシュディレクトリ名を返す（`id` が `None` の場合は `name` にフォールバック）
     pub fn id(&self) -> &str {
-        crate::plugin::resolve_cache_key(self.package.id(), self.package.name())
+        crate::plugin::resolve_id(self.package.id(), self.package.name())
     }
 
     /// マーケットプレイス名を取得

--- a/src/install_test.rs
+++ b/src/install_test.rs
@@ -63,7 +63,7 @@ fn create_test_cached_package(
 
     CachedPackage {
         name: "test-plugin".to_string(),
-        cache_key: None,
+        id: None,
         marketplace: Some("test-marketplace".to_string()),
         path: base_dir.to_path_buf(),
         manifest,
@@ -238,47 +238,47 @@ fn test_place_plugin_multiple_targets() {
 }
 
 // =============================================================================
-// cache_key 伝搬テスト
+// id 伝搬テスト
 // =============================================================================
 
 #[test]
-fn test_scan_plugin_propagates_cache_key() {
+fn test_scan_plugin_propagates_id() {
     let temp = TempDir::new().unwrap();
     let mut cached = create_test_cached_package(temp.path(), &["skill-a"], &[], &[]);
-    cached.cache_key = Some("owner--repo".to_string());
+    cached.id = Some("owner--repo".to_string());
     let package = MarketplaceContent::from(cached);
 
     let result = scan_plugin(&package, None).unwrap();
 
-    assert_eq!(result.cache_key(), "owner--repo");
+    assert_eq!(result.id(), "owner--repo");
 }
 
 #[test]
-fn test_scan_plugin_cache_key_none_falls_back_to_name() {
+fn test_scan_plugin_id_none_falls_back_to_name() {
     let temp = TempDir::new().unwrap();
     let cached = create_test_cached_package(temp.path(), &["skill-a"], &[], &[]);
     let package = MarketplaceContent::from(cached);
 
     let result = scan_plugin(&package, None).unwrap();
 
-    assert_eq!(result.cache_key(), "test-plugin");
+    assert_eq!(result.id(), "test-plugin");
 }
 
-/// place_plugin が cache_key を使って PluginOrigin を構成することを検証
+/// place_plugin が id を使って PluginOrigin を構成することを検証
 #[test]
-fn test_place_plugin_uses_cache_key_for_origin() {
+fn test_place_plugin_uses_id_for_origin() {
     let temp = TempDir::new().unwrap();
     let project_dir = TempDir::new().unwrap();
     let mut cached = create_test_cached_package(temp.path(), &["my-skill"], &[], &[]);
-    // name はマニフェスト名、cache_key はキャッシュディレクトリ名
+    // name はマニフェスト名、id はキャッシュディレクトリ名
     cached.name = "My Plugin".to_string();
     cached.manifest.name = "My Plugin".to_string();
-    cached.cache_key = Some("owner--repo".to_string());
+    cached.id = Some("owner--repo".to_string());
     let package = MarketplaceContent::from(cached);
     let scanned = scan_plugin(&package, None).unwrap();
 
-    // cache_key が "owner--repo" であることを確認
-    assert_eq!(scanned.cache_key(), "owner--repo");
+    // id が "owner--repo" であることを確認
+    assert_eq!(scanned.id(), "owner--repo");
     assert_eq!(scanned.name(), "My Plugin");
 
     let targets: Vec<Box<dyn crate::target::Target>> = vec![Box::new(CodexTarget::new())];
@@ -290,14 +290,14 @@ fn test_place_plugin_uses_cache_key_for_origin() {
         project_root: project_dir.path(),
     });
 
-    // PluginOrigin の plugin フィールドが cache_key() ("owner--repo") を使用していることを
+    // PluginOrigin の plugin フィールドが id() ("owner--repo") を使用していることを
     // 配置先パスに "owner--repo" が含まれることで間接的に検証
     assert_eq!(result.plugin_name, "My Plugin");
     assert_eq!(result.successes.len(), 1);
     let target_path = result.successes[0].target_path.to_string_lossy();
     assert!(
         target_path.contains("owner--repo"),
-        "target path should contain cache_key 'owner--repo', got: {}",
+        "target path should contain id 'owner--repo', got: {}",
         target_path
     );
 }

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -20,14 +20,14 @@ pub use installed::InstalledPlugin;
 pub use intent::PluginIntent;
 pub use manifest::{Author, PluginManifest};
 
-/// cache_key フォールバック: cache_key が None なら name を返す
+/// id フォールバック: id が None なら name を返す
 ///
 /// # Arguments
 ///
-/// * `cache_key` - optional cache directory key
-/// * `name` - plugin name used as fallback when `cache_key` is `None`
-pub(crate) fn resolve_cache_key<'a>(cache_key: Option<&'a str>, name: &'a str) -> &'a str {
-    cache_key.unwrap_or(name)
+/// * `id` - optional identifier (cache directory name)
+/// * `name` - plugin name used as fallback when `id` is `None`
+pub(crate) fn resolve_id<'a>(id: Option<&'a str>, name: &'a str) -> &'a str {
+    id.unwrap_or(name)
 }
 pub use marketplace_content::MarketplaceContent;
 pub use meta::PluginMeta;

--- a/src/plugin/cache.rs
+++ b/src/plugin/cache.rs
@@ -161,7 +161,7 @@ pub trait PackageCacheAccess: Send + Sync {
 
         Ok(CachedPackage {
             name: manifest.name.clone(),
-            cache_key: Some(name.to_string()),
+            id: Some(name.to_string()),
             marketplace: marketplace.map(String::from),
             path,
             manifest,

--- a/src/plugin/cached_package.rs
+++ b/src/plugin/cached_package.rs
@@ -42,7 +42,7 @@ pub struct CachedPackage {
 impl CachedPackage {
     /// キャッシュディレクトリ名を返す（`id` が `None` の場合は `name` にフォールバック）
     pub fn id(&self) -> &str {
-        super::resolve_cache_key(self.id.as_deref(), &self.name)
+        super::resolve_id(self.id.as_deref(), &self.name)
     }
 
     /// プラグインのバージョンを取得

--- a/src/plugin/cached_package.rs
+++ b/src/plugin/cached_package.rs
@@ -20,14 +20,14 @@ pub const UNKNOWN_GIT_VALUE: &str = "unknown";
 /// ドメインロジックは `MarketplaceContent` に委譲。
 ///
 /// **`name` フィールド**: 表示用のプラグイン名（`manifest.name`）。
-/// **`cache_key` フィールド**: ファイル操作用のキャッシュディレクトリ名。
-/// `cache_key` が `None` の場合は `name` にフォールバックする。
+/// **`id` フィールド**: ファイル操作用のキャッシュディレクトリ名。
+/// `id` が `None` の場合は `name` にフォールバックする。
 #[derive(Debug, Clone)]
 pub struct CachedPackage {
     pub name: String,
     /// キャッシュディレクトリ名（ファイル操作用）
     /// `None` の場合は `name` にフォールバック
-    pub cache_key: Option<String>,
+    pub id: Option<String>,
     /// マーケットプレイス名（marketplace経由の場合）
     /// None の場合は直接GitHubからインストール
     pub marketplace: Option<String>,
@@ -40,9 +40,9 @@ pub struct CachedPackage {
 }
 
 impl CachedPackage {
-    /// キャッシュディレクトリ名を返す（`cache_key` が `None` の場合は `name` にフォールバック）
-    pub fn cache_key(&self) -> &str {
-        super::resolve_cache_key(self.cache_key.as_deref(), &self.name)
+    /// キャッシュディレクトリ名を返す（`id` が `None` の場合は `name` にフォールバック）
+    pub fn id(&self) -> &str {
+        super::resolve_cache_key(self.id.as_deref(), &self.name)
     }
 
     /// プラグインのバージョンを取得

--- a/src/plugin/cached_package_test.rs
+++ b/src/plugin/cached_package_test.rs
@@ -23,10 +23,10 @@ fn make_manifest(name: &str) -> PluginManifest {
 }
 
 #[test]
-fn cache_key_returns_some_value_when_set() {
+fn id_returns_some_value_when_set() {
     let pkg = CachedPackage {
         name: "my-plugin".to_string(),
-        cache_key: Some("owner--repo".to_string()),
+        id: Some("owner--repo".to_string()),
         marketplace: None,
         path: PathBuf::from("/tmp/test"),
         manifest: make_manifest("my-plugin"),
@@ -34,14 +34,14 @@ fn cache_key_returns_some_value_when_set() {
         commit_sha: "abc123".to_string(),
         marketplace_manifest: None,
     };
-    assert_eq!(pkg.cache_key(), "owner--repo");
+    assert_eq!(pkg.id(), "owner--repo");
 }
 
 #[test]
-fn cache_key_falls_back_to_name_when_none() {
+fn id_falls_back_to_name_when_none() {
     let pkg = CachedPackage {
         name: "my-plugin".to_string(),
-        cache_key: None,
+        id: None,
         marketplace: None,
         path: PathBuf::from("/tmp/test"),
         manifest: make_manifest("my-plugin"),
@@ -49,5 +49,5 @@ fn cache_key_falls_back_to_name_when_none() {
         commit_sha: "abc123".to_string(),
         marketplace_manifest: None,
     };
-    assert_eq!(pkg.cache_key(), "my-plugin");
+    assert_eq!(pkg.id(), "my-plugin");
 }

--- a/src/plugin/deployment.rs
+++ b/src/plugin/deployment.rs
@@ -34,7 +34,7 @@ impl PluginDeployment {
 ///
 /// * `cache` - package cache access used to read the manifest and path
 /// * `marketplace` - marketplace name (`None` defaults to `"github"`)
-/// * `plugin_name` - cache key / install id (cache directory name; e.g. `owner--repo` for GitHub)
+/// * `plugin_name` - id (cache directory name; e.g. `owner--repo` for GitHub)
 pub(crate) fn load_plugin_deployment(
     cache: &dyn PackageCacheAccess,
     marketplace: Option<&str>,

--- a/src/plugin/installed.rs
+++ b/src/plugin/installed.rs
@@ -73,7 +73,7 @@ impl InstalledPlugin {
         self.enabled = enabled;
     }
 
-    /// インストール識別子（`id` が `None` の場合は `name` にフォールバック）
+    /// プラグインID（`id` が `None` の場合は `name` にフォールバック）
     pub fn id(&self) -> &str {
         crate::plugin::resolve_id(self.id.as_deref(), self.plugin.name())
     }

--- a/src/plugin/installed.rs
+++ b/src/plugin/installed.rs
@@ -22,7 +22,7 @@ impl InstalledPlugin {
     /// # Arguments
     ///
     /// * `plugin` - cached plugin data (manifest, path, components)
-    /// * `id` - optional install identifier (falls back to `plugin.name()`)
+    /// * `id` - optional identifier (falls back to `plugin.name()`)
     /// * `marketplace` - optional marketplace name of origin
     /// * `enabled` - whether the plugin is currently deployed
     pub(crate) fn from_cached_package(

--- a/src/plugin/installed.rs
+++ b/src/plugin/installed.rs
@@ -1,7 +1,7 @@
 //! インストール済みプラグイン DTO
 //!
 //! `Plugin`（manifest + path + components）を内部に所有し、
-//! 起源情報（marketplace / install_id）とデプロイ状態（enabled）を追加で保持する。
+//! 起源情報（marketplace / id）とデプロイ状態（enabled）を追加で保持する。
 //! serde 属性は持たず、wire format は commands 層が責任を持つ。
 
 use crate::component::{Component, ComponentKind};
@@ -11,7 +11,7 @@ use std::path::Path;
 #[derive(Debug, Clone)]
 pub struct InstalledPlugin {
     plugin: Plugin,
-    install_id: Option<String>,
+    id: Option<String>,
     marketplace: Option<String>,
     enabled: bool,
 }
@@ -22,18 +22,18 @@ impl InstalledPlugin {
     /// # Arguments
     ///
     /// * `plugin` - cached plugin data (manifest, path, components)
-    /// * `install_id` - optional install identifier (falls back to `plugin.name()`)
+    /// * `id` - optional install identifier (falls back to `plugin.name()`)
     /// * `marketplace` - optional marketplace name of origin
     /// * `enabled` - whether the plugin is currently deployed
     pub(crate) fn from_cached_package(
         plugin: Plugin,
-        install_id: Option<String>,
+        id: Option<String>,
         marketplace: Option<String>,
         enabled: bool,
     ) -> Self {
         Self {
             plugin,
-            install_id,
+            id,
             marketplace,
             enabled,
         }
@@ -73,9 +73,9 @@ impl InstalledPlugin {
         self.enabled = enabled;
     }
 
-    /// インストール識別子（`install_id` が `None` の場合は `name` にフォールバック）
-    pub fn install_id(&self) -> &str {
-        crate::plugin::resolve_cache_key(self.install_id.as_deref(), self.plugin.name())
+    /// インストール識別子（`id` が `None` の場合は `name` にフォールバック）
+    pub fn id(&self) -> &str {
+        crate::plugin::resolve_cache_key(self.id.as_deref(), self.plugin.name())
     }
 
     /// コンポーネント種別ごとの件数を取得（空でないもののみ）
@@ -128,7 +128,7 @@ impl InstalledPlugin {
         name: &str,
         version: &str,
         components: Vec<Component>,
-        install_id: Option<String>,
+        id: Option<String>,
         marketplace: Option<String>,
         enabled: bool,
     ) -> Self {
@@ -155,7 +155,7 @@ impl InstalledPlugin {
         let plugin = Plugin::new_for_test(manifest, PathBuf::from("/test"), components);
         Self {
             plugin,
-            install_id,
+            id,
             marketplace,
             enabled,
         }
@@ -168,14 +168,14 @@ impl InstalledPlugin {
         manifest: crate::plugin::PluginManifest,
         cache_path: std::path::PathBuf,
         components: Vec<Component>,
-        install_id: Option<String>,
+        id: Option<String>,
         marketplace: Option<String>,
         enabled: bool,
     ) -> Self {
         let plugin = Plugin::new_for_test(manifest, cache_path, components);
         Self {
             plugin,
-            install_id,
+            id,
             marketplace,
             enabled,
         }

--- a/src/plugin/installed.rs
+++ b/src/plugin/installed.rs
@@ -75,7 +75,7 @@ impl InstalledPlugin {
 
     /// インストール識別子（`id` が `None` の場合は `name` にフォールバック）
     pub fn id(&self) -> &str {
-        crate::plugin::resolve_cache_key(self.id.as_deref(), self.plugin.name())
+        crate::plugin::resolve_id(self.id.as_deref(), self.plugin.name())
     }
 
     /// コンポーネント種別ごとの件数を取得（空でないもののみ）

--- a/src/plugin/installed_test.rs
+++ b/src/plugin/installed_test.rs
@@ -37,11 +37,11 @@ fn create_full_summary() -> InstalledPlugin {
 }
 
 // ========================================
-// install_id tests
+// id tests
 // ========================================
 
 #[test]
-fn test_installed_plugin_install_id_returns_some_value() {
+fn test_installed_plugin_id_returns_some_value() {
     let summary = InstalledPlugin::new_for_test(
         "test-plugin",
         "1.0.0",
@@ -50,13 +50,13 @@ fn test_installed_plugin_install_id_returns_some_value() {
         None,
         true,
     );
-    assert_eq!(summary.install_id(), "owner--repo");
+    assert_eq!(summary.id(), "owner--repo");
 }
 
 #[test]
-fn test_installed_plugin_install_id_falls_back_to_name() {
+fn test_installed_plugin_id_falls_back_to_name() {
     let summary = create_empty_summary();
-    assert_eq!(summary.install_id(), "test-plugin");
+    assert_eq!(summary.id(), "test-plugin");
 }
 
 // ========================================

--- a/src/plugin/marketplace_content.rs
+++ b/src/plugin/marketplace_content.rs
@@ -18,7 +18,7 @@ use super::plugin_content::Plugin;
 #[derive(Debug, Clone)]
 pub struct MarketplaceContent {
     /// キャッシュディレクトリ名（ファイル操作用、CachedPackage から伝搬）
-    pub(crate) cache_key: Option<String>,
+    pub(crate) id: Option<String>,
     pub(crate) marketplace: Option<String>,
     pub(crate) marketplace_manifest: Option<MarketplaceManifest>,
     /// 代表プラグイン（型レベルで非空を保証）
@@ -33,9 +33,9 @@ impl MarketplaceContent {
         self.primary.name()
     }
 
-    /// キャッシュキーを取得
-    pub fn cache_key(&self) -> Option<&str> {
-        self.cache_key.as_deref()
+    /// id を取得
+    pub fn id(&self) -> Option<&str> {
+        self.id.as_deref()
     }
 
     /// マーケットプレイス名を取得
@@ -117,7 +117,7 @@ impl From<CachedPackage> for MarketplaceContent {
     fn from(cached: CachedPackage) -> Self {
         let primary = Plugin::new(cached.manifest, cached.path);
         Self {
-            cache_key: cached.cache_key,
+            id: cached.id,
             marketplace: cached.marketplace,
             marketplace_manifest: cached.marketplace_manifest,
             primary,
@@ -130,7 +130,7 @@ impl From<&CachedPackage> for MarketplaceContent {
     fn from(cached: &CachedPackage) -> Self {
         let primary = Plugin::new(cached.manifest.clone(), cached.path.clone());
         Self {
-            cache_key: cached.cache_key.clone(),
+            id: cached.id.clone(),
             marketplace: cached.marketplace.clone(),
             marketplace_manifest: cached.marketplace_manifest.clone(),
             primary,

--- a/src/plugin/marketplace_content_test.rs
+++ b/src/plugin/marketplace_content_test.rs
@@ -35,7 +35,7 @@ fn create_test_marketplace_content() -> (TempDir, MarketplaceContent) {
     let temp = TempDir::new().unwrap();
     let cached = CachedPackage {
         name: "test-plugin".to_string(),
-        cache_key: None,
+        id: None,
         marketplace: Some("test-marketplace".to_string()),
         path: temp.path().to_path_buf(),
         manifest: make_manifest("test-plugin"),
@@ -47,11 +47,11 @@ fn create_test_marketplace_content() -> (TempDir, MarketplaceContent) {
     (temp, content)
 }
 
-fn create_test_marketplace_content_with_cache_key(key: &str) -> (TempDir, MarketplaceContent) {
+fn create_test_marketplace_content_with_id(key: &str) -> (TempDir, MarketplaceContent) {
     let temp = TempDir::new().unwrap();
     let cached = CachedPackage {
         name: "test-plugin".to_string(),
-        cache_key: Some(key.to_string()),
+        id: Some(key.to_string()),
         marketplace: Some("test-marketplace".to_string()),
         path: temp.path().to_path_buf(),
         manifest: make_manifest("test-plugin"),
@@ -67,7 +67,7 @@ fn create_test_marketplace_content_no_marketplace() -> (TempDir, MarketplaceCont
     let temp = TempDir::new().unwrap();
     let cached = CachedPackage {
         name: "test-plugin".to_string(),
-        cache_key: None,
+        id: None,
         marketplace: None,
         path: temp.path().to_path_buf(),
         manifest: make_manifest("test-plugin"),
@@ -87,16 +87,16 @@ fn test_name_returns_package_name() {
 }
 
 #[test]
-fn test_cache_key_returns_some_when_present() {
-    let (_temp, pkg) = create_test_marketplace_content_with_cache_key("owner--repo");
-    let key: Option<&str> = pkg.cache_key();
+fn test_id_returns_some_when_present() {
+    let (_temp, pkg) = create_test_marketplace_content_with_id("owner--repo");
+    let key: Option<&str> = pkg.id();
     assert_eq!(key, Some("owner--repo"));
 }
 
 #[test]
-fn test_cache_key_returns_none_when_absent() {
+fn test_id_returns_none_when_absent() {
     let (_temp, pkg) = create_test_marketplace_content();
-    let key: Option<&str> = pkg.cache_key();
+    let key: Option<&str> = pkg.id();
     assert_eq!(key, None);
 }
 
@@ -139,7 +139,7 @@ fn test_marketplace_manifest_returns_some_when_present() {
     };
     let cached = CachedPackage {
         name: "test-plugin".to_string(),
-        cache_key: None,
+        id: None,
         marketplace: Some("test-marketplace".to_string()),
         path: temp.path().to_path_buf(),
         manifest: make_manifest("test-plugin"),
@@ -169,7 +169,7 @@ fn test_marketplace_content_components_from_cached_package() {
 
     let cached = CachedPackage {
         name: "test-plugin".to_string(),
-        cache_key: None,
+        id: None,
         marketplace: Some("test-marketplace".to_string()),
         path: plugin_path.clone(),
         manifest: make_manifest("test-plugin"),

--- a/src/source/github_source.rs
+++ b/src/source/github_source.rs
@@ -126,7 +126,7 @@ impl PackageSource for GitHubSource {
 
             Ok(CachedPackage {
                 name: manifest.name.clone(),
-                cache_key: Some(cache_name.clone()),
+                id: Some(cache_name.clone()),
                 marketplace: self.marketplace.clone(),
                 path: plugin_path,
                 manifest,

--- a/src/target.rs
+++ b/src/target.rs
@@ -95,12 +95,12 @@ impl PluginOrigin {
     /// キャッシュされたプラグイン情報から PluginOrigin を生成する
     ///
     /// `marketplace` が `None` の場合は `"github"` を既定値として使用し、
-    /// `plugin_name` はキャッシュキー（ディレクトリ名）としてそのまま保持する。
+    /// `plugin_name` は id（ディレクトリ名）としてそのまま保持する。
     ///
     /// # Arguments
     ///
     /// * `marketplace` - Optional marketplace name; falls back to `"github"` when `None`.
-    /// * `plugin_name` - Cache key (directory name) used as the plugin identifier.
+    /// * `plugin_name` - id (directory name) used as the plugin identifier.
     pub fn from_cached_plugin(marketplace: Option<&str>, plugin_name: &str) -> Self {
         Self {
             marketplace: marketplace.unwrap_or("github").to_string(),

--- a/src/tui/manager/core/app.rs
+++ b/src/tui/manager/core/app.rs
@@ -327,18 +327,18 @@ fn clamp_selection(model: &mut Model) {
         } = m
         {
             if let Some(id) = selected_id.as_ref() {
-                if let Some(idx) = filtered.iter().position(|p| p.install_id() == id.as_str()) {
+                if let Some(idx) = filtered.iter().position(|p| p.id() == id.as_str()) {
                     state.select(Some(idx));
                 } else if !filtered.is_empty() {
                     state.select(Some(0));
-                    *selected_id = Some(filtered[0].install_id().to_string());
+                    *selected_id = Some(filtered[0].id().to_string());
                 } else {
                     state.select(None);
                     *selected_id = None;
                 }
             } else if !filtered.is_empty() {
                 state.select(Some(0));
-                *selected_id = Some(filtered[0].install_id().to_string());
+                *selected_id = Some(filtered[0].id().to_string());
             } else {
                 state.select(None);
             }

--- a/src/tui/manager/core/data.rs
+++ b/src/tui/manager/core/data.rs
@@ -9,7 +9,7 @@ use crate::marketplace::{to_display_source, MarketplaceConfig, MarketplaceRegist
 use crate::plugin::PackageCache;
 use std::io;
 
-/// プラグインID（`InstalledPlugin::install_id()` の値で識別。リポジトリ名と異なる場合あり）
+/// プラグインID（`InstalledPlugin::id()` の値で識別。リポジトリ名と異なる場合あり）
 pub type PluginId = String;
 
 /// マーケットプレイスアイテム（TUI表示用）
@@ -65,31 +65,29 @@ impl DataStore {
     ///
     /// # Arguments
     ///
-    /// * `id` - the plugin install id to look up
+    /// * `id` - the plugin id to look up
     pub fn find_plugin(&self, id: &PluginId) -> Option<&InstalledPlugin> {
-        self.plugins.iter().find(|p| p.install_id() == id.as_str())
+        self.plugins.iter().find(|p| p.id() == id.as_str())
     }
 
-    /// `plugin_id` は `InstalledPlugin.install_id()`（= 操作用キー）と完全一致で比較される。
+    /// `plugin_id` は `InstalledPlugin.id()`（= 操作用キー）と完全一致で比較される。
     /// marketplace の区別はしない（既存の `find_plugin` と同じ設計）。
     /// `enabled` の状態に関わらず、`plugins` に存在すれば `true` を返す。
     ///
     /// # Arguments
     ///
-    /// * `plugin_id` - the install id to match exactly against `InstalledPlugin.install_id()`
+    /// * `plugin_id` - the id to match exactly against `InstalledPlugin.id()`
     pub fn is_plugin_installed(&self, plugin_id: &str) -> bool {
-        self.plugins.iter().any(|p| p.install_id() == plugin_id)
+        self.plugins.iter().any(|p| p.id() == plugin_id)
     }
 
     /// プラグインIDでインデックスを検索
     ///
     /// # Arguments
     ///
-    /// * `id` - the plugin install id to look up
+    /// * `id` - the plugin id to look up
     pub fn plugin_index(&self, id: &PluginId) -> Option<usize> {
-        self.plugins
-            .iter()
-            .position(|p| p.install_id() == id.as_str())
+        self.plugins.iter().position(|p| p.id() == id.as_str())
     }
 
     /// プラグインの空でないコンポーネント種別を取得
@@ -118,23 +116,22 @@ impl DataStore {
     ///
     /// # Arguments
     ///
-    /// * `plugin_id` - the install id of the plugin to remove
+    /// * `plugin_id` - the id of the plugin to remove
     pub fn remove_plugin(&mut self, plugin_id: &PluginId) {
-        self.plugins
-            .retain(|p| p.install_id() != plugin_id.as_str());
+        self.plugins.retain(|p| p.id() != plugin_id.as_str());
     }
 
     /// プラグインの有効状態を更新
     ///
     /// # Arguments
     ///
-    /// * `plugin_id` - the install id of the plugin to update
+    /// * `plugin_id` - the id of the plugin to update
     /// * `enabled` - the new enabled state to apply
     pub fn set_plugin_enabled(&mut self, plugin_id: &PluginId, enabled: bool) {
         if let Some(plugin) = self
             .plugins
             .iter_mut()
-            .find(|p| p.install_id() == plugin_id.as_str())
+            .find(|p| p.id() == plugin_id.as_str())
         {
             plugin.set_enabled(enabled);
         }

--- a/src/tui/manager/core/data_test.rs
+++ b/src/tui/manager/core/data_test.rs
@@ -5,15 +5,8 @@ fn make_plugin(name: &str) -> InstalledPlugin {
     InstalledPlugin::new_for_test(name, "1.0.0", Vec::new(), None, None, true)
 }
 
-fn make_plugin_with_install_id(name: &str, install_id: &str) -> InstalledPlugin {
-    InstalledPlugin::new_for_test(
-        name,
-        "1.0.0",
-        Vec::new(),
-        Some(install_id.to_string()),
-        None,
-        true,
-    )
+fn make_plugin_with_id(name: &str, id: &str) -> InstalledPlugin {
+    InstalledPlugin::new_for_test(name, "1.0.0", Vec::new(), Some(id.to_string()), None, true)
 }
 
 #[test]
@@ -75,26 +68,26 @@ fn returns_true_when_plugin_disabled() {
 }
 
 // ============================================================================
-// install_id が設定されている場合のテスト
+// id が設定されている場合のテスト
 // ============================================================================
 
 #[test]
-fn is_plugin_installed_matches_by_install_id() {
-    let plugin = make_plugin_with_install_id("Display Name", "owner--repo");
+fn is_plugin_installed_matches_by_id() {
+    let plugin = make_plugin_with_id("Display Name", "owner--repo");
     let (_tmp, store) = DataStore::for_test(vec![plugin], vec![], None);
     assert!(store.is_plugin_installed("owner--repo"));
 }
 
 #[test]
-fn is_plugin_installed_does_not_match_by_display_name_when_install_id_set() {
-    let plugin = make_plugin_with_install_id("Display Name", "owner--repo");
+fn is_plugin_installed_does_not_match_by_display_name_when_id_set() {
+    let plugin = make_plugin_with_id("Display Name", "owner--repo");
     let (_tmp, store) = DataStore::for_test(vec![plugin], vec![], None);
     assert!(!store.is_plugin_installed("Display Name"));
 }
 
 #[test]
-fn find_plugin_matches_by_install_id() {
-    let plugin = make_plugin_with_install_id("Display Name", "owner--repo");
+fn find_plugin_matches_by_id() {
+    let plugin = make_plugin_with_id("Display Name", "owner--repo");
     let (_tmp, store) = DataStore::for_test(vec![plugin], vec![], None);
     let found = store.find_plugin(&"owner--repo".to_string());
     assert!(found.is_some());
@@ -102,31 +95,31 @@ fn find_plugin_matches_by_install_id() {
 }
 
 #[test]
-fn find_plugin_does_not_match_by_display_name_when_install_id_set() {
-    let plugin = make_plugin_with_install_id("Display Name", "owner--repo");
+fn find_plugin_does_not_match_by_display_name_when_id_set() {
+    let plugin = make_plugin_with_id("Display Name", "owner--repo");
     let (_tmp, store) = DataStore::for_test(vec![plugin], vec![], None);
     assert!(store.find_plugin(&"Display Name".to_string()).is_none());
 }
 
 #[test]
-fn plugin_index_matches_by_install_id() {
-    let plugin = make_plugin_with_install_id("Display Name", "owner--repo");
+fn plugin_index_matches_by_id() {
+    let plugin = make_plugin_with_id("Display Name", "owner--repo");
     let (_tmp, store) = DataStore::for_test(vec![plugin], vec![], None);
     assert_eq!(store.plugin_index(&"owner--repo".to_string()), Some(0));
     assert_eq!(store.plugin_index(&"Display Name".to_string()), None);
 }
 
 #[test]
-fn remove_plugin_works_by_install_id() {
-    let plugin = make_plugin_with_install_id("Display Name", "owner--repo");
+fn remove_plugin_works_by_id() {
+    let plugin = make_plugin_with_id("Display Name", "owner--repo");
     let (_tmp, mut store) = DataStore::for_test(vec![plugin], vec![], None);
     store.remove_plugin(&"owner--repo".to_string());
     assert!(!store.is_plugin_installed("owner--repo"));
 }
 
 #[test]
-fn set_plugin_enabled_works_by_install_id() {
-    let plugin = make_plugin_with_install_id("Display Name", "owner--repo");
+fn set_plugin_enabled_works_by_id() {
+    let plugin = make_plugin_with_id("Display Name", "owner--repo");
     let (_tmp, mut store) = DataStore::for_test(vec![plugin], vec![], None);
     store.set_plugin_enabled(&"owner--repo".to_string(), false);
     let found = store.find_plugin(&"owner--repo".to_string()).unwrap();

--- a/src/tui/manager/screens/installed/actions.rs
+++ b/src/tui/manager/screens/installed/actions.rs
@@ -38,7 +38,7 @@ fn new_cache() -> Result<PackageCache, String> {
 ///
 /// # Arguments
 ///
-/// * `plugin_name` - Target plugin install id.
+/// * `plugin_name` - Target plugin id.
 /// * `marketplace` - Optional marketplace name the plugin belongs to.
 pub fn disable_plugin(plugin_name: &str, marketplace: Option<&str>) -> ActionResult {
     let cache = match new_cache() {
@@ -53,7 +53,7 @@ pub fn disable_plugin(plugin_name: &str, marketplace: Option<&str>) -> ActionRes
 ///
 /// # Arguments
 ///
-/// * `plugin_name` - Target plugin install id.
+/// * `plugin_name` - Target plugin id.
 /// * `marketplace` - Optional marketplace name the plugin belongs to.
 pub fn uninstall_plugin(plugin_name: &str, marketplace: Option<&str>) -> ActionResult {
     let cache = match new_cache() {
@@ -68,7 +68,7 @@ pub fn uninstall_plugin(plugin_name: &str, marketplace: Option<&str>) -> ActionR
 ///
 /// # Arguments
 ///
-/// * `plugin_name` - Target plugin install id.
+/// * `plugin_name` - Target plugin id.
 /// * `marketplace` - Optional marketplace name the plugin belongs to.
 pub fn enable_plugin(plugin_name: &str, marketplace: Option<&str>) -> ActionResult {
     let cache = match new_cache() {
@@ -86,7 +86,7 @@ pub fn enable_plugin(plugin_name: &str, marketplace: Option<&str>) -> ActionResu
 ///
 /// # Arguments
 ///
-/// * `plugin_names` - Plugin install ids to update in order.
+/// * `plugin_names` - Plugin ids to update in order.
 pub fn batch_update_plugins(plugin_names: &[String]) -> Vec<(String, UpdateStatusDisplay)> {
     let project_root = env::current_dir().unwrap_or_else(|_| ".".into());
 
@@ -108,7 +108,7 @@ pub fn batch_update_plugins(plugin_names: &[String]) -> Vec<(String, UpdateStatu
 ///
 /// # Arguments
 ///
-/// * `plugin_name` - Target plugin install id.
+/// * `plugin_name` - Target plugin id.
 /// * `project_root` - Project root directory used for deployment paths.
 fn run_update_plugin(plugin_name: &str, project_root: &Path) -> UpdateStatusDisplay {
     let handle = match tokio::runtime::Handle::try_current() {

--- a/src/tui/manager/screens/installed/model.rs
+++ b/src/tui/manager/screens/installed/model.rs
@@ -150,7 +150,7 @@ impl Model {
     ///
     /// * `data` - Data store providing the installed plugin list.
     pub fn new(data: &DataStore) -> Self {
-        let selected_id = data.plugins.first().map(|p| p.install_id().to_string());
+        let selected_id = data.plugins.first().map(|p| p.id().to_string());
         let mut state = ListState::default();
         if selected_id.is_some() {
             state.select(Some(0));
@@ -174,7 +174,7 @@ impl Model {
             .selected_plugin_id
             .clone()
             .filter(|id| data.find_plugin(id).is_some())
-            .or_else(|| data.plugins.first().map(|p| p.install_id().to_string()));
+            .or_else(|| data.plugins.first().map(|p| p.id().to_string()));
 
         let index = selected_id
             .as_ref()

--- a/src/tui/manager/screens/installed/update.rs
+++ b/src/tui/manager/screens/installed/update.rs
@@ -205,17 +205,17 @@ fn execute_batch_with(
         state,
     } = model
     {
-        // update_statuses から Updating のプラグイン名を収集
+        // update_statuses から Updating のプラグイン ID を収集
         // O(n) の HashSet で存在チェックし、find_plugin の線形探索 O(n^2) を回避
-        let existing_names: HashSet<&str> = data.plugins.iter().map(|p| p.id()).collect();
-        let plugin_names: Vec<String> = update_statuses
+        let existing_ids: HashSet<&str> = data.plugins.iter().map(|p| p.id()).collect();
+        let plugin_ids: Vec<String> = update_statuses
             .iter()
             .filter(|(_, status)| matches!(status, UpdateStatusDisplay::Updating))
-            .map(|(name, _)| name.clone())
-            .filter(|name| existing_names.contains(name.as_str()))
+            .map(|(id, _)| id.clone())
+            .filter(|id| existing_ids.contains(id.as_str()))
             .collect();
 
-        let results = run_updates(&plugin_names);
+        let results = run_updates(&plugin_ids);
 
         let mut new_statuses = HashMap::new();
         let mut batch_errors: Vec<String> = Vec::new();

--- a/src/tui/manager/screens/installed/update.rs
+++ b/src/tui/manager/screens/installed/update.rs
@@ -116,15 +116,15 @@ fn toggle_all_marks(model: &mut Model, data: &DataStore, filter_text: &str) {
         let all_marked = !filtered.is_empty()
             && filtered
                 .iter()
-                .all(|plugin| marked_ids.contains(plugin.install_id()));
+                .all(|plugin| marked_ids.contains(plugin.id()));
 
         if all_marked {
             for plugin in &filtered {
-                marked_ids.remove(plugin.install_id());
+                marked_ids.remove(plugin.id());
             }
         } else {
             for plugin in &filtered {
-                marked_ids.insert(plugin.install_id().to_string());
+                marked_ids.insert(plugin.id().to_string());
             }
         }
     }
@@ -167,10 +167,7 @@ fn update_all(model: &mut Model, data: &DataStore) -> UpdateEffect {
         // 前回の古いステータスをクリアしてから全プラグインに Updating をセット
         update_statuses.clear();
         for plugin in &data.plugins {
-            update_statuses.insert(
-                plugin.install_id().to_string(),
-                UpdateStatusDisplay::Updating,
-            );
+            update_statuses.insert(plugin.id().to_string(), UpdateStatusDisplay::Updating);
         }
 
         return UpdateEffect::execute_batch();
@@ -210,7 +207,7 @@ fn execute_batch_with(
     {
         // update_statuses から Updating のプラグイン名を収集
         // O(n) の HashSet で存在チェックし、find_plugin の線形探索 O(n^2) を回避
-        let existing_names: HashSet<&str> = data.plugins.iter().map(|p| p.install_id()).collect();
+        let existing_names: HashSet<&str> = data.plugins.iter().map(|p| p.id()).collect();
         let plugin_names: Vec<String> = update_statuses
             .iter()
             .filter(|(_, status)| matches!(status, UpdateStatusDisplay::Updating))
@@ -264,12 +261,11 @@ fn execute_batch_with(
         let filtered = filter_plugins(&data.plugins, filter_text);
         let current_selected = selected_id.as_ref();
         let new_idx = current_selected
-            .and_then(|id| filtered.iter().position(|p| p.install_id() == id.as_str()))
+            .and_then(|id| filtered.iter().position(|p| p.id() == id.as_str()))
             .or(if filtered.is_empty() { None } else { Some(0) });
 
         state.select(new_idx);
-        *selected_id =
-            new_idx.and_then(|idx| filtered.get(idx).map(|p| p.install_id().to_string()));
+        *selected_id = new_idx.and_then(|idx| filtered.get(idx).map(|p| p.id().to_string()));
     }
 }
 
@@ -399,7 +395,7 @@ fn enter(model: &mut Model, data: &mut DataStore, filter_text: &str) -> UpdateEf
                             let mut new_state = ListState::default();
                             let selected_id = if !filtered.is_empty() {
                                 new_state.select(Some(0));
-                                Some(filtered[0].install_id().to_string())
+                                Some(filtered[0].id().to_string())
                             } else {
                                 None
                             };
@@ -436,13 +432,13 @@ fn enter(model: &mut Model, data: &mut DataStore, filter_text: &str) -> UpdateEf
                     let restored_statuses = std::mem::take(saved_update_statuses);
                     let filtered = filter_plugins(&data.plugins, filter_text);
                     let mut new_state = ListState::default();
-                    let idx = filtered.iter().position(|p| p.install_id() == id);
+                    let idx = filtered.iter().position(|p| p.id() == id);
                     let selected_id = if let Some(idx) = idx {
                         new_state.select(Some(idx));
                         Some(id)
                     } else if !filtered.is_empty() {
                         new_state.select(Some(0));
-                        Some(filtered[0].install_id().to_string())
+                        Some(filtered[0].id().to_string())
                     } else {
                         None
                     };
@@ -464,13 +460,13 @@ fn enter(model: &mut Model, data: &mut DataStore, filter_text: &str) -> UpdateEf
                     // PluginList に遷移（フィルタ済みリストで選択位置を同期）
                     let filtered = filter_plugins(&data.plugins, filter_text);
                     let mut new_state = ListState::default();
-                    let idx = filtered.iter().position(|p| p.install_id() == target_id);
+                    let idx = filtered.iter().position(|p| p.id() == target_id);
                     let selected_id = if let Some(idx) = idx {
                         new_state.select(Some(idx));
                         Some(target_id)
                     } else if !filtered.is_empty() {
                         new_state.select(Some(0));
-                        Some(filtered[0].install_id().to_string())
+                        Some(filtered[0].id().to_string())
                     } else {
                         None
                     };
@@ -544,13 +540,13 @@ fn back(model: &mut Model, filter_text: &str, data: &DataStore) {
             let restored_statuses = std::mem::take(saved_update_statuses);
             let filtered = filter_plugins(&data.plugins, filter_text);
             let mut new_state = ListState::default();
-            let idx = filtered.iter().position(|p| p.install_id() == id);
+            let idx = filtered.iter().position(|p| p.id() == id);
             let selected_id = if let Some(idx) = idx {
                 new_state.select(Some(idx));
                 Some(id)
             } else if !filtered.is_empty() {
                 new_state.select(Some(0));
-                Some(filtered[0].install_id().to_string())
+                Some(filtered[0].id().to_string())
             } else {
                 None
             };
@@ -638,7 +634,7 @@ fn update_selected_id(model: &mut Model, data: &DataStore, filter_text: &str) {
     {
         if let Some(idx) = state.selected() {
             let filtered = filter_plugins(&data.plugins, filter_text);
-            *selected_id = filtered.get(idx).map(|p| p.install_id().to_string());
+            *selected_id = filtered.get(idx).map(|p| p.id().to_string());
         }
     }
 }

--- a/src/tui/manager/screens/installed/view.rs
+++ b/src/tui/manager/screens/installed/view.rs
@@ -206,7 +206,7 @@ fn view_plugin_list(
         let items: Vec<ListItem> = filtered
             .iter()
             .map(|p| {
-                let is_marked = marked_ids.contains(p.install_id());
+                let is_marked = marked_ids.contains(p.id());
                 let mark_indicator = if is_marked { "[x] " } else { "[ ] " };
 
                 let marketplace_str = p
@@ -240,7 +240,7 @@ fn view_plugin_list(
                 spans.push(Span::styled(name_text, base_style));
 
                 // 更新ステータス
-                if let Some(update_status) = update_statuses.get(p.install_id()) {
+                if let Some(update_status) = update_statuses.get(p.id()) {
                     spans.push(update_status_span(update_status));
                 }
 

--- a/src/tui/manager/screens/marketplaces/actions.rs
+++ b/src/tui/manager/screens/marketplaces/actions.rs
@@ -234,7 +234,7 @@ fn build_browse_plugins(
             description: p.description.clone(),
             version: p.version.clone(),
             source: p.source.clone(),
-            installed: installed_plugins.iter().any(|ip| ip.install_id() == p.name),
+            installed: installed_plugins.iter().any(|ip| ip.id() == p.name),
         })
         .collect()
 }

--- a/src/tui/manager/screens/marketplaces/actions.rs
+++ b/src/tui/manager/screens/marketplaces/actions.rs
@@ -222,6 +222,13 @@ fn get_browse_plugins_with_registry(
 ///
 /// * `cache` - Marketplace cache snapshot to convert.
 /// * `installed_plugins` - Currently installed plugins used to flag `installed`.
+///
+/// # Note
+///
+/// `installed` 判定は `InstalledPlugin::id()`（キャッシュディレクトリ名、
+/// GitHub 経由では `repo.name`）と `MarketplacePlugin.name`（marketplace.json
+/// 登録名）が一致することを前提とする。両者が乖離する marketplace 定義では
+/// インストール済みでも `installed=false` となり得る。
 fn build_browse_plugins(
     cache: &MarketplaceCache,
     installed_plugins: &[InstalledPlugin],

--- a/src/tui/manager/screens/marketplaces/actions.rs
+++ b/src/tui/manager/screens/marketplaces/actions.rs
@@ -225,9 +225,12 @@ fn get_browse_plugins_with_registry(
 ///
 /// # Note
 ///
-/// `installed` 判定は `InstalledPlugin::id()`（キャッシュディレクトリ名、
-/// GitHub 経由では `repo.name`）と `MarketplacePlugin.name`（marketplace.json
-/// 登録名）が一致することを前提とする。両者が乖離する marketplace 定義では
+/// `installed` 判定は `InstalledPlugin::id()`（キャッシュディレクトリ名）と
+/// `MarketplacePlugin.name`（marketplace.json 登録名）が一致することを前提とする。
+/// GitHub ソースでは marketplace 経由のプラグインは登録名と同じ ID になる一方、
+/// 直接 GitHub から入れたプラグインは `owner--repo` 形式の別 ID になる。
+/// そのため marketplace の登録名が `owner--repo` と乖離するケースや、
+/// 同名プラグインを直接 GitHub からインストールしたケースでは、
 /// インストール済みでも `installed=false` となり得る。
 fn build_browse_plugins(
     cache: &MarketplaceCache,

--- a/src/tui/manager/screens/marketplaces/actions_test.rs
+++ b/src/tui/manager/screens/marketplaces/actions_test.rs
@@ -182,7 +182,7 @@ fn disabled_plugin_still_counts_as_installed() {
 }
 
 #[test]
-fn installed_detected_by_install_id_when_name_differs() {
+fn installed_detected_by_id_when_name_differs() {
     let cache = make_cache("test-mp", vec![make_marketplace_plugin("owner--repo")]);
     let plugin = InstalledPlugin::new_for_test(
         "Display Name",


### PR DESCRIPTION
## 概要

`CachedPackage.cache_key` / `MarketplaceContent.cache_key` / `InstalledPlugin.install_id` および `plugin::resolve_cache_key` ヘルパーを `id` / `resolve_id` に統一し、「キャッシュディレクトリ名 = 一意識別子」を表す命名をプロジェクト全体で揃える純粋なリファクタリング。挙動は完全に同一。`plm list --json` / `plm list --outdated --json` の出力キー `"install_id"` は `#[serde(rename = "install_id")]` で維持する。

## 変更の種類

- ♻️ Refactoring

## 詳細な変更内容

### `cache_key` → `id`（ae04b4c）

- `CachedPackage` のフィールド / アクセサを `id` にリネーム
- `MarketplaceContent` のフィールド / アクセサ（戻り型 `Option<&str>`）を `id` にリネーム
- `ScannedPlugin::cache_key()` → `::id()`
- 呼び出し側（`install.rs`, `plugin/cache.rs`, `source/github_source.rs`, `application/info.rs`, `application/catalog.rs`, `commands/import.rs`）を更新
- `target.rs` / `plugin/deployment.rs` の doc コメント内「Cache key」「キャッシュキー」を `id` に書き換え
- 関連テスト（`cached_package_test.rs` / `marketplace_content_test.rs` / `install_test.rs` / `application/info_test.rs`）を更新

### `install_id` → `id`（6e0d7ac）

- `InstalledPlugin` のフィールド / アクセサ / `from_cached_package` 引数 / テストヘルパー引数を `id` にリネーム
- `application/info.rs` の `let install_id = ...;` ローカル変数と `resolve_enabled` 関数の引数名を `id` に
- `application/lifecycle.rs` の doc コメント（4 箇所）を新命名へ追従
- TUI 側の `.install_id()` 呼び出し（`core/data.rs` / `core/app.rs` / `screens/installed/*` / `screens/marketplaces/actions.rs`）を `.id()` に置換、関連テストも更新
- **JSON 契約維持**: `src/commands/list/wire.rs` の `Wire.install_id` を `Wire.id` に改名しつつ `#[serde(rename = "install_id")]` を付与。`wire_test.rs` / `outdated_test.rs` の JSON 期待値文字列 `"install_id"` はそのまま据え置き

### `resolve_cache_key` → `resolve_id`（aea2c7f）

- `plugin::resolve_cache_key` ヘルパー関数名・引数名・doc を `resolve_id` / `id` にリネーム
- 呼び出し元 3 箇所（`cached_package.rs` / `installed.rs` / `install.rs`）を追従

### doc wording 整理（58db678）

- `info.rs` / `installed.rs` の doc コメントに残っていた「Install identifier」文言を素の `identifier` に置換（DoD grep `install id` 検出の取りこぼし対策）

## システム図

### リネーム後のデータフロー

\`\`\`mermaid
flowchart TD
    A[GitHubSource::download] --> B[\"CachedPackage { id: Option&lt;String&gt; }\"]
    B -- \".id()\" --> C[resolve_id&#40;Option&lt;&amp;str&gt;, name&#41;]
    B --> D[\"MarketplaceContent { id: Option&lt;String&gt; }\"]
    B --> E[\"ScannedPlugin\"]
    B --> F[\"InstalledPlugin { id: Option&lt;String&gt; }\"]
    D -- \".id() -> Option&lt;&amp;str&gt;\" --> G[application / catalog]
    E -- \".id() -> &amp;str\" --> H[place_plugin / PluginOrigin]
    F -- \".id() -> &amp;str\" --> I[\"wire.rs Wire\"]
    I -- \"#[serde(rename = \\\"install_id\\\")]\" --> J[\"JSON { \\\"install_id\\\": ... }\"]

    style C fill:#e3f2fd
    style I fill:#fff3e0
    style J fill:#fff3e0
\`\`\`

## 関連Issue

（関連 Issue なし）

## テスト

- [x] \`cargo fmt --all\` 適用済み（Task tool 経由）
- [x] \`cargo check\` 通過（\`rust-workflow-plugin:type-check\` スキル経由、エラー 0・警告 0）
- [x] \`cargo test\` 通過（\`rust-workflow-plugin:test\` スキル経由、**1343 passed, 0 failed, 0 ignored** とベースライン一致）
- [x] Codex CLI による一括コードレビュー完了（「問題なし」・1343 tests 再確認済み）
- [x] JSON 契約検証: \`wire_test.rs\` / \`outdated_test.rs\` の JSON snapshot テストが \`\"install_id\"\` キーを含む期待値と一致
- [x] DoD grep:
  - \`grep -rn \"cache_key\" src/\` ヒット 0
  - \`grep -rn \"resolve_cache_key\" src/\` ヒット 0
  - \`grep -rn \"install_id\" src/\` は \`wire.rs\` の serde rename 属性値・\`wire_test.rs\` / \`outdated_test.rs\` の JSON 期待値のみ
  - \`grep -rniE \"cache key|install id|キャッシュキー\" src/\` は \`src/source/github_source.rs\` L94 の user-facing CLI println のみ（スコープ外として許容）

## レビューポイント

1. **JSON 契約維持**: \`src/commands/list/wire.rs\` の \`#[serde(rename = \"install_id\")]\` により、Rust 側フィールド \`id\` を持ちつつ出力キーは従来どおり \`\"install_id\"\` のままになっていること
2. **戻り型の非対称**: \`MarketplaceContent::id() -> Option&lt;&amp;str&gt;\` / \`CachedPackage::id() -> &amp;str\` / \`ScannedPlugin::id() -> &amp;str\` / \`InstalledPlugin::id() -> &amp;str\` の差は今回のスコープ外として維持
3. **user-facing 文言のスコープ外**: \`src/source/github_source.rs\` L94 の \`println!(\"Using cached plugin: {} (cache key: {})\", ...)\` は出力文言のため今回は据え置き