### PR TITLE
♻️ [Refactoring]: convert.rs MAP をレコード指向テーブルに置換

### DIFF
--- a/src/parser/convert.rs
+++ b/src/parser/convert.rs
@@ -19,7 +19,6 @@ pub enum TargetType {
     Codex,
 }
 
-use crate::format::lookup_forward;
 pub use crate::format::Format;
 
 struct ToolRow {
@@ -179,6 +178,7 @@ pub(crate) fn map_tools(tools: &[String], from: Format, to: Format) -> Vec<Strin
 }
 
 /// Keys are lowercase-normalized
+#[allow(dead_code)]
 const MODEL_CLAUDE_COPILOT_MAP: &[(&str, &str)] = &[
     ("haiku", "GPT-4o-mini"),
     ("sonnet", "GPT-4o"),
@@ -186,6 +186,7 @@ const MODEL_CLAUDE_COPILOT_MAP: &[(&str, &str)] = &[
 ];
 
 /// Keys are lowercase-normalized (reverse of MODEL_CLAUDE_COPILOT_MAP)
+#[allow(dead_code)]
 const MODEL_COPILOT_CLAUDE_MAP: &[(&str, &str)] = &[
     ("gpt-4o-mini", "haiku"),
     ("gpt-4o", "sonnet"),
@@ -193,11 +194,62 @@ const MODEL_COPILOT_CLAUDE_MAP: &[(&str, &str)] = &[
 ];
 
 /// Keys are lowercase-normalized
+#[allow(dead_code)]
 const MODEL_CLAUDE_CODEX_MAP: &[(&str, &str)] = &[
     ("haiku", "gpt-4.1-mini"),
     ("sonnet", "gpt-4.1"),
     ("opus", "o3"),
 ];
+
+struct ModelRow {
+    claude_code: &'static str,
+    copilot: Option<&'static str>,
+    codex: Option<&'static str>,
+}
+
+type ModelColumn = fn(&ModelRow) -> Option<&'static str>;
+
+fn model_col_claude_code(row: &ModelRow) -> Option<&'static str> {
+    Some(row.claude_code)
+}
+fn model_col_copilot(row: &ModelRow) -> Option<&'static str> {
+    row.copilot
+}
+fn model_col_codex(row: &ModelRow) -> Option<&'static str> {
+    row.codex
+}
+
+const MODEL_TABLE: &[ModelRow] = &[
+    ModelRow {
+        claude_code: "haiku",
+        copilot: Some("GPT-4o-mini"),
+        codex: Some("gpt-4.1-mini"),
+    },
+    ModelRow {
+        claude_code: "sonnet",
+        copilot: Some("GPT-4o"),
+        codex: Some("gpt-4.1"),
+    },
+    ModelRow {
+        claude_code: "opus",
+        copilot: Some("o1"),
+        codex: Some("o3"),
+    },
+];
+
+/// `from_col(row)` を lowercase 化した値が `key_lower` と一致する最初の行の `to_col` を返す。
+/// 入力 `key_lower` は呼び出し側で lowercase 化済みの前提（map_model で `to_lowercase()` 済み）。
+/// 列値が大文字混じり（例: "GPT-4o-mini"）の Copilot 列でも、lowercase 比較で双方向に引ける。
+fn find_model_lower(
+    key_lower: &str,
+    from_col: ModelColumn,
+    to_col: ModelColumn,
+) -> Option<&'static str> {
+    MODEL_TABLE
+        .iter()
+        .find(|row| from_col(row).map(|s| s.to_lowercase()).as_deref() == Some(key_lower))
+        .and_then(to_col)
+}
 
 /// Model name conversion between formats.
 ///
@@ -213,15 +265,15 @@ const MODEL_CLAUDE_CODEX_MAP: &[(&str, &str)] = &[
 /// * `to` - Destination format to convert the model name into.
 pub(crate) fn map_model(model: &str, from: Format, to: Format) -> String {
     let normalized = model.to_lowercase();
-    let table = match (from, to) {
-        (Format::ClaudeCode, Format::Copilot) => Some(MODEL_CLAUDE_COPILOT_MAP),
-        (Format::Copilot, Format::ClaudeCode) => Some(MODEL_COPILOT_CLAUDE_MAP),
-        (Format::ClaudeCode, Format::Codex) => Some(MODEL_CLAUDE_CODEX_MAP),
+    let columns: Option<(ModelColumn, ModelColumn)> = match (from, to) {
+        (Format::ClaudeCode, Format::Copilot) => Some((model_col_claude_code, model_col_copilot)),
+        (Format::Copilot, Format::ClaudeCode) => Some((model_col_copilot, model_col_claude_code)),
+        (Format::ClaudeCode, Format::Codex) => Some((model_col_claude_code, model_col_codex)),
         _ => None,
     };
 
-    match table {
-        Some(table) => lookup_forward(table, &normalized)
+    match columns {
+        Some((from_col, to_col)) => find_model_lower(&normalized, from_col, to_col)
             .map(|v| v.to_string())
             .unwrap_or(normalized),
         None => normalized,

--- a/src/parser/convert.rs
+++ b/src/parser/convert.rs
@@ -177,30 +177,6 @@ pub(crate) fn map_tools(tools: &[String], from: Format, to: Format) -> Vec<Strin
     result
 }
 
-/// Keys are lowercase-normalized
-#[allow(dead_code)]
-const MODEL_CLAUDE_COPILOT_MAP: &[(&str, &str)] = &[
-    ("haiku", "GPT-4o-mini"),
-    ("sonnet", "GPT-4o"),
-    ("opus", "o1"),
-];
-
-/// Keys are lowercase-normalized (reverse of MODEL_CLAUDE_COPILOT_MAP)
-#[allow(dead_code)]
-const MODEL_COPILOT_CLAUDE_MAP: &[(&str, &str)] = &[
-    ("gpt-4o-mini", "haiku"),
-    ("gpt-4o", "sonnet"),
-    ("o1", "opus"),
-];
-
-/// Keys are lowercase-normalized
-#[allow(dead_code)]
-const MODEL_CLAUDE_CODEX_MAP: &[(&str, &str)] = &[
-    ("haiku", "gpt-4.1-mini"),
-    ("sonnet", "gpt-4.1"),
-    ("opus", "o3"),
-];
-
 struct ModelRow {
     claude_code: &'static str,
     copilot: Option<&'static str>,

--- a/src/parser/convert.rs
+++ b/src/parser/convert.rs
@@ -21,28 +21,40 @@ pub enum TargetType {
 
 pub use crate::format::Format;
 
+/// Record-oriented row of [`TOOL_TABLE`].
+///
+/// Each row represents a single logical tool with its name in every supported
+/// format. `claude_code` is required; other format columns are `Option` because
+/// not every tool has a counterpart in every format.
 struct ToolRow {
     claude_code: &'static str,
     copilot: Option<&'static str>,
     /// 将来拡張用（Codex Tool 名マッピングが仕様化されたら Some(...) を埋める）
     #[allow(dead_code)]
     codex: Option<&'static str>,
+    /// Marks the canonical row to use when an N:1 reverse lookup hits multiple
+    /// candidates (e.g. `codebase` -> `Read` rather than `Write`/`Edit`).
     reverse_canonical: bool,
 }
 
+/// Column accessor: extracts one format's name from a [`ToolRow`].
 type ToolColumn = fn(&ToolRow) -> Option<&'static str>;
 
+/// Column accessor for the Claude Code name (always present).
 fn tool_col_claude_code(row: &ToolRow) -> Option<&'static str> {
     Some(row.claude_code)
 }
+/// Column accessor for the Copilot name.
 fn tool_col_copilot(row: &ToolRow) -> Option<&'static str> {
     row.copilot
 }
+/// Column accessor for the Codex name (reserved for future use).
 #[allow(dead_code)]
 fn tool_col_codex(row: &ToolRow) -> Option<&'static str> {
     row.codex
 }
 
+/// Tool name conversion table (rows = logical tools, columns = formats).
 const TOOL_TABLE: &[ToolRow] = &[
     ToolRow {
         claude_code: "Read",
@@ -94,6 +106,7 @@ const TOOL_TABLE: &[ToolRow] = &[
     },
 ];
 
+/// Returns the `to_col` value of the first row whose `from_col` equals `Some(key)`.
 fn find_forward_tool(key: &str, from_col: ToolColumn, to_col: ToolColumn) -> Option<&'static str> {
     TOOL_TABLE
         .iter()
@@ -101,6 +114,10 @@ fn find_forward_tool(key: &str, from_col: ToolColumn, to_col: ToolColumn) -> Opt
         .and_then(to_col)
 }
 
+/// Returns the `to_col` value of the canonical row (`reverse_canonical: true`)
+/// whose `from_col` equals `Some(value)`. Used for N:1 reverse lookups where
+/// multiple rows share the same source value but only one is the canonical
+/// representative.
 fn find_reverse_canonical_tool(
     value: &str,
     from_col: ToolColumn,
@@ -112,6 +129,8 @@ fn find_reverse_canonical_tool(
         .and_then(to_col)
 }
 
+/// Special case (table-external) for Claude Code -> Copilot tool conversion:
+/// any `Bash(git...)` invocation maps to Copilot's `githubRepo`.
 fn apply_tool_special_forward(trimmed: &str) -> Option<String> {
     if trimmed.starts_with("Bash(git") {
         Some("githubRepo".to_string())
@@ -120,6 +139,8 @@ fn apply_tool_special_forward(trimmed: &str) -> Option<String> {
     }
 }
 
+/// Special case (table-external) for Copilot -> Claude Code tool conversion:
+/// the Copilot-only `githubRepo` maps back to plain `Bash`.
 fn apply_tool_special_reverse(trimmed: &str) -> Option<String> {
     if trimmed == "githubRepo" {
         Some("Bash".to_string())
@@ -177,24 +198,34 @@ pub(crate) fn map_tools(tools: &[String], from: Format, to: Format) -> Vec<Strin
     result
 }
 
+/// Record-oriented row of [`MODEL_TABLE`].
+///
+/// Each row represents a single logical model with its name in every supported
+/// format. `claude_code` is required; other format columns are `Option` because
+/// not every model has a counterpart in every format.
 struct ModelRow {
     claude_code: &'static str,
     copilot: Option<&'static str>,
     codex: Option<&'static str>,
 }
 
+/// Column accessor: extracts one format's name from a [`ModelRow`].
 type ModelColumn = fn(&ModelRow) -> Option<&'static str>;
 
+/// Column accessor for the Claude Code name (always present).
 fn model_col_claude_code(row: &ModelRow) -> Option<&'static str> {
     Some(row.claude_code)
 }
+/// Column accessor for the Copilot name.
 fn model_col_copilot(row: &ModelRow) -> Option<&'static str> {
     row.copilot
 }
+/// Column accessor for the Codex name.
 fn model_col_codex(row: &ModelRow) -> Option<&'static str> {
     row.codex
 }
 
+/// Model name conversion table (rows = logical models, columns = formats).
 const MODEL_TABLE: &[ModelRow] = &[
     ModelRow {
         claude_code: "haiku",

--- a/src/parser/convert.rs
+++ b/src/parser/convert.rs
@@ -20,7 +20,7 @@ pub enum TargetType {
 }
 
 pub use crate::format::Format;
-use crate::format::{lookup_forward, lookup_reverse};
+use crate::format::lookup_forward;
 
 const PROMPT_TOOL_MAP: &[(&str, &str)] = &[
     ("Read", "codebase"), // representative for reverse lookup
@@ -33,23 +33,20 @@ const PROMPT_TOOL_MAP: &[(&str, &str)] = &[
     ("WebSearch", "websearch"),
 ];
 
-#[allow(dead_code)]
 struct ToolRow {
     claude_code: &'static str,
     copilot: Option<&'static str>,
     /// 将来拡張用（Codex Tool 名マッピングが仕様化されたら Some(...) を埋める）
+    #[allow(dead_code)]
     codex: Option<&'static str>,
     reverse_canonical: bool,
 }
 
-#[allow(dead_code)]
 type ToolColumn = fn(&ToolRow) -> Option<&'static str>;
 
-#[allow(dead_code)]
 fn tool_col_claude_code(row: &ToolRow) -> Option<&'static str> {
     Some(row.claude_code)
 }
-#[allow(dead_code)]
 fn tool_col_copilot(row: &ToolRow) -> Option<&'static str> {
     row.copilot
 }
@@ -58,7 +55,6 @@ fn tool_col_codex(row: &ToolRow) -> Option<&'static str> {
     row.codex
 }
 
-#[allow(dead_code)]
 const TOOL_TABLE: &[ToolRow] = &[
     ToolRow {
         claude_code: "Read",
@@ -110,18 +106,22 @@ const TOOL_TABLE: &[ToolRow] = &[
     },
 ];
 
-#[allow(dead_code)]
-fn find_forward_tool(_key: &str, _from: ToolColumn, _to: ToolColumn) -> Option<&'static str> {
-    todo!("T3 で実装")
+fn find_forward_tool(key: &str, from_col: ToolColumn, to_col: ToolColumn) -> Option<&'static str> {
+    TOOL_TABLE
+        .iter()
+        .find(|row| from_col(row) == Some(key))
+        .and_then(to_col)
 }
 
-#[allow(dead_code)]
 fn find_reverse_canonical_tool(
-    _value: &str,
-    _from: ToolColumn,
-    _to: ToolColumn,
+    value: &str,
+    from_col: ToolColumn,
+    to_col: ToolColumn,
 ) -> Option<&'static str> {
-    todo!("T3 で実装")
+    TOOL_TABLE
+        .iter()
+        .find(|row| row.reverse_canonical && from_col(row) == Some(value))
+        .and_then(to_col)
 }
 
 /// Tool name conversion between Claude Code and Copilot (Prompt/Agent context).
@@ -138,7 +138,7 @@ pub(crate) fn map_tool(tool: &str, from: Format, to: Format) -> String {
     let trimmed = tool.trim();
     match (from, to) {
         (Format::ClaudeCode, Format::Copilot) => {
-            if let Some(v) = lookup_forward(PROMPT_TOOL_MAP, trimmed) {
+            if let Some(v) = find_forward_tool(trimmed, tool_col_claude_code, tool_col_copilot) {
                 return v.to_string();
             }
             if trimmed.starts_with("Bash(git") {
@@ -150,7 +150,7 @@ pub(crate) fn map_tool(tool: &str, from: Format, to: Format) -> String {
             if trimmed == "githubRepo" {
                 return "Bash".to_string();
             }
-            lookup_reverse(PROMPT_TOOL_MAP, trimmed)
+            find_reverse_canonical_tool(trimmed, tool_col_copilot, tool_col_claude_code)
                 .map(|v| v.to_string())
                 .unwrap_or_else(|| trimmed.to_string())
         }

--- a/src/parser/convert.rs
+++ b/src/parser/convert.rs
@@ -19,8 +19,8 @@ pub enum TargetType {
     Codex,
 }
 
-pub use crate::format::Format;
 use crate::format::lookup_forward;
+pub use crate::format::Format;
 
 const PROMPT_TOOL_MAP: &[(&str, &str)] = &[
     ("Read", "codebase"), // representative for reverse lookup
@@ -124,6 +124,22 @@ fn find_reverse_canonical_tool(
         .and_then(to_col)
 }
 
+fn apply_tool_special_forward(trimmed: &str) -> Option<String> {
+    if trimmed.starts_with("Bash(git") {
+        Some("githubRepo".to_string())
+    } else {
+        None
+    }
+}
+
+fn apply_tool_special_reverse(trimmed: &str) -> Option<String> {
+    if trimmed == "githubRepo" {
+        Some("Bash".to_string())
+    } else {
+        None
+    }
+}
+
 /// Tool name conversion between Claude Code and Copilot (Prompt/Agent context).
 ///
 /// N:1 reverse lookups return the first table entry as the representative value
@@ -141,14 +157,14 @@ pub(crate) fn map_tool(tool: &str, from: Format, to: Format) -> String {
             if let Some(v) = find_forward_tool(trimmed, tool_col_claude_code, tool_col_copilot) {
                 return v.to_string();
             }
-            if trimmed.starts_with("Bash(git") {
-                return "githubRepo".to_string();
+            if let Some(v) = apply_tool_special_forward(trimmed) {
+                return v;
             }
             trimmed.to_string()
         }
         (Format::Copilot, Format::ClaudeCode) => {
-            if trimmed == "githubRepo" {
-                return "Bash".to_string();
+            if let Some(v) = apply_tool_special_reverse(trimmed) {
+                return v;
             }
             find_reverse_canonical_tool(trimmed, tool_col_copilot, tool_col_claude_code)
                 .map(|v| v.to_string())

--- a/src/parser/convert.rs
+++ b/src/parser/convert.rs
@@ -22,17 +22,6 @@ pub enum TargetType {
 use crate::format::lookup_forward;
 pub use crate::format::Format;
 
-const PROMPT_TOOL_MAP: &[(&str, &str)] = &[
-    ("Read", "codebase"), // representative for reverse lookup
-    ("Write", "codebase"),
-    ("Edit", "codebase"),
-    ("Grep", "search/codebase"), // representative for reverse lookup
-    ("Glob", "search/codebase"),
-    ("Bash", "terminal"),
-    ("WebFetch", "fetch"),
-    ("WebSearch", "websearch"),
-];
-
 struct ToolRow {
     claude_code: &'static str,
     copilot: Option<&'static str>,

--- a/src/parser/convert.rs
+++ b/src/parser/convert.rs
@@ -33,6 +33,97 @@ const PROMPT_TOOL_MAP: &[(&str, &str)] = &[
     ("WebSearch", "websearch"),
 ];
 
+#[allow(dead_code)]
+struct ToolRow {
+    claude_code: &'static str,
+    copilot: Option<&'static str>,
+    /// 将来拡張用（Codex Tool 名マッピングが仕様化されたら Some(...) を埋める）
+    codex: Option<&'static str>,
+    reverse_canonical: bool,
+}
+
+#[allow(dead_code)]
+type ToolColumn = fn(&ToolRow) -> Option<&'static str>;
+
+#[allow(dead_code)]
+fn tool_col_claude_code(row: &ToolRow) -> Option<&'static str> {
+    Some(row.claude_code)
+}
+#[allow(dead_code)]
+fn tool_col_copilot(row: &ToolRow) -> Option<&'static str> {
+    row.copilot
+}
+#[allow(dead_code)]
+fn tool_col_codex(row: &ToolRow) -> Option<&'static str> {
+    row.codex
+}
+
+#[allow(dead_code)]
+const TOOL_TABLE: &[ToolRow] = &[
+    ToolRow {
+        claude_code: "Read",
+        copilot: Some("codebase"),
+        codex: None,
+        reverse_canonical: true,
+    },
+    ToolRow {
+        claude_code: "Write",
+        copilot: Some("codebase"),
+        codex: None,
+        reverse_canonical: false,
+    },
+    ToolRow {
+        claude_code: "Edit",
+        copilot: Some("codebase"),
+        codex: None,
+        reverse_canonical: false,
+    },
+    ToolRow {
+        claude_code: "Grep",
+        copilot: Some("search/codebase"),
+        codex: None,
+        reverse_canonical: true,
+    },
+    ToolRow {
+        claude_code: "Glob",
+        copilot: Some("search/codebase"),
+        codex: None,
+        reverse_canonical: false,
+    },
+    ToolRow {
+        claude_code: "Bash",
+        copilot: Some("terminal"),
+        codex: None,
+        reverse_canonical: true,
+    },
+    ToolRow {
+        claude_code: "WebFetch",
+        copilot: Some("fetch"),
+        codex: None,
+        reverse_canonical: true,
+    },
+    ToolRow {
+        claude_code: "WebSearch",
+        copilot: Some("websearch"),
+        codex: None,
+        reverse_canonical: true,
+    },
+];
+
+#[allow(dead_code)]
+fn find_forward_tool(_key: &str, _from: ToolColumn, _to: ToolColumn) -> Option<&'static str> {
+    todo!("T3 で実装")
+}
+
+#[allow(dead_code)]
+fn find_reverse_canonical_tool(
+    _value: &str,
+    _from: ToolColumn,
+    _to: ToolColumn,
+) -> Option<&'static str> {
+    todo!("T3 で実装")
+}
+
 /// Tool name conversion between Claude Code and Copilot (Prompt/Agent context).
 ///
 /// N:1 reverse lookups return the first table entry as the representative value

--- a/src/parser/convert_test.rs
+++ b/src/parser/convert_test.rs
@@ -155,6 +155,62 @@ fn test_map_tool_copilot_to_claude_n_to_1_representative() {
     );
 }
 
+#[test]
+fn test_map_tool_claude_to_copilot_n_to_1_forward_all_rows() {
+    // forward は全行で機能する（Read/Write/Edit すべて codebase に飛ぶ）
+    assert_eq!(
+        map_tool("Read", Format::ClaudeCode, Format::Copilot),
+        "codebase"
+    );
+    assert_eq!(
+        map_tool("Write", Format::ClaudeCode, Format::Copilot),
+        "codebase"
+    );
+    assert_eq!(
+        map_tool("Edit", Format::ClaudeCode, Format::Copilot),
+        "codebase"
+    );
+    assert_eq!(
+        map_tool("Grep", Format::ClaudeCode, Format::Copilot),
+        "search/codebase"
+    );
+    assert_eq!(
+        map_tool("Glob", Format::ClaudeCode, Format::Copilot),
+        "search/codebase"
+    );
+}
+
+#[test]
+fn test_map_tool_copilot_to_claude_n_to_1_canonical_grep() {
+    // reverse は代表行のみがヒット
+    assert_eq!(
+        map_tool("search/codebase", Format::Copilot, Format::ClaudeCode),
+        "Grep"
+    );
+    assert_eq!(
+        map_tool("codebase", Format::Copilot, Format::ClaudeCode),
+        "Read"
+    );
+}
+
+#[test]
+fn test_map_tool_claude_to_copilot_bash_git_prefix_match() {
+    // PIN: Bash(git で始まる入力は githubRepo に変換される（既存挙動）
+    assert_eq!(
+        map_tool("Bash(git:*)", Format::ClaudeCode, Format::Copilot),
+        "githubRepo"
+    );
+    assert_eq!(
+        map_tool("Bash(git commit*)", Format::ClaudeCode, Format::Copilot),
+        "githubRepo"
+    );
+
+    // NOTE: Bash(github) のような入力も現行の starts_with("Bash(git") では
+    // 偶発的に githubRepo にマッチする。これは本リファクタの保証範囲外
+    // (non-guaranteed incidental match) であり、将来仕様化する余地を残す。
+    // 意図的に assert はせず、振る舞いをコメントとして記録する。
+}
+
 // ============================================================================
 // Model name conversion tests
 // ============================================================================

--- a/src/parser/convert_test.rs
+++ b/src/parser/convert_test.rs
@@ -305,6 +305,28 @@ fn test_map_model_passthrough_normalization() {
     );
 }
 
+#[test]
+fn test_map_model_copilot_to_claude_lowercase_table_canonical() {
+    assert_eq!(
+        map_model("gpt-4o-mini", Format::Copilot, Format::ClaudeCode),
+        "haiku"
+    );
+    assert_eq!(
+        map_model("gpt-4o", Format::Copilot, Format::ClaudeCode),
+        "sonnet"
+    );
+    assert_eq!(map_model("o1", Format::Copilot, Format::ClaudeCode), "opus");
+}
+
+#[test]
+fn test_map_model_unsupported_pair_passthrough_lowercase() {
+    // (Codex, ClaudeCode) は未対応ペア。lowercase 化された値が返る。
+    assert_eq!(
+        map_model("Sonnet", Format::Codex, Format::ClaudeCode),
+        "sonnet"
+    );
+}
+
 // ============================================================================
 // Body variable conversion tests
 // ============================================================================


### PR DESCRIPTION
## 概要

`src/parser/convert.rs` の 4 本のタプル型 MAP（`PROMPT_TOOL_MAP` / `MODEL_*_MAP` 3 本）を、行=論理エンティティ・列=各フォーマットでの名称というレコード指向（DB テーブル風）の構造体テーブル（`TOOL_TABLE` / `MODEL_TABLE`）に置換する。`map_tool` / `map_tools` / `map_model` の公開シグネチャと既存挙動は完全に保持。

## 変更の種類

- ♻️ Refactoring

## 詳細な変更内容

### `src/parser/convert.rs`（変更）

- **追加**: `ToolRow` / `ModelRow` 構造体、`ToolColumn` / `ModelColumn` 関数ポインタ型、列セレクタ群（`tool_col_*` / `model_col_*`）、`TOOL_TABLE` / `MODEL_TABLE` 定数
- **追加**: `find_forward_tool` / `find_reverse_canonical_tool` / `find_model_lower` ヘルパ
- **追加**: `apply_tool_special_forward` / `apply_tool_special_reverse`（`Bash(git…)` ↔ `githubRepo` 特殊変換をテーブル外関数に切り出し）
- **書き換え**: `map_tool` / `map_model` を新ヘルパ経由に変更（公開シグネチャ・戻り値は不変）
- **削除**: 旧 `PROMPT_TOOL_MAP` / `MODEL_CLAUDE_COPILOT_MAP` / `MODEL_COPILOT_CLAUDE_MAP` / `MODEL_CLAUDE_CODEX_MAP`
- **削除**: `use crate::format::{lookup_forward, lookup_reverse}`（`pub use crate::format::Format` は維持）
- **追加**: 全主要型・関数に doc コメント

### `src/parser/convert_test.rs`（追加のみ）

エッジケース characterization tests を 5 件追加:

- `test_map_tool_claude_to_copilot_n_to_1_forward_all_rows` — N:1 forward 全行
- `test_map_tool_copilot_to_claude_n_to_1_canonical_grep` — N:1 reverse 代表行
- `test_map_tool_claude_to_copilot_bash_git_prefix_match` — `Bash(git*)` 境界（`Bash(github)` 偶発マッチは保証範囲外として明記）
- `test_map_model_copilot_to_claude_lowercase_table_canonical` — Cp→CC lowercase 比較
- `test_map_model_unsupported_pair_passthrough_lowercase` — 未対応ペアの passthrough

### 不変ファイル

`src/format.rs` / `src/parser/claude_code.rs` / `src/parser/claude_code_agent.rs` / `src/parser.rs` には**変更なし**。

## システム図

### `map_tool` の処理フロー

```mermaid
flowchart TD
    A[map_tool tool, from, to] --> B[trim 入力]
    B --> C{from, to}
    C -->|ClaudeCode → Copilot| D[find_forward_tool<br/>tool_col_claude_code → tool_col_copilot]
    C -->|Copilot → ClaudeCode| E[apply_tool_special_reverse<br/>githubRepo → Bash]
    C -->|その他| Z[trimmed.to_string]

    D -->|Hit| H[v.to_string]
    D -->|Miss| F[apply_tool_special_forward<br/>Bash git* → githubRepo]
    F -->|Hit| H
    F -->|Miss| Z

    E -->|Hit| H
    E -->|Miss| G[find_reverse_canonical_tool<br/>tool_col_copilot → tool_col_claude_code]
    G -->|Hit| H
    G -->|Miss| Z

    style D fill:#e1f5ff
    style E fill:#e1f5ff
    style F fill:#e1f5ff
    style G fill:#e1f5ff
```

### TOOL_TABLE / MODEL_TABLE のレコード指向構造

```
TOOL_TABLE (rows = tools, columns = formats)
┌───────────┬───────────────────┬───────┬───────────────────┐
│claude_code│ copilot           │ codex │ reverse_canonical │
├───────────┼───────────────────┼───────┼───────────────────┤
│ Read      │ codebase          │ None  │ true  ← 代表       │
│ Write     │ codebase          │ None  │ false             │
│ Edit      │ codebase          │ None  │ false             │
│ Grep      │ search/codebase   │ None  │ true  ← 代表       │
│ Glob      │ search/codebase   │ None  │ false             │
│ Bash      │ terminal          │ None  │ true              │
│ WebFetch  │ fetch             │ None  │ true              │
│ WebSearch │ websearch         │ None  │ true              │
└───────────┴───────────────────┴───────┴───────────────────┘

MODEL_TABLE (rows = models, columns = formats)
┌───────────┬──────────────┬───────────────┐
│claude_code│ copilot      │ codex         │
├───────────┼──────────────┼───────────────┤
│ haiku     │ GPT-4o-mini  │ gpt-4.1-mini  │
│ sonnet    │ GPT-4o       │ gpt-4.1       │
│ opus      │ o1           │ o3            │
└───────────┴──────────────┴───────────────┘
```

## 関連Issue

なし（仕様書 `.plugin-workspace/.specs/002-convert-map-refactor/` 由来のリファクタリング）

## テスト

- [x] `cargo fmt` — 差分なし
- [x] `cargo check` — エラーなし
- [x] `cargo test parser::convert_test::` — 49 件 pass（既存 44 + 追加 5）
- [x] `cargo test`（全件）— 1361 件 pass（回帰なし）
- [x] `cargo clippy --all-targets` — 本リファクタ起因の新規警告ゼロ
- [x] `git diff src/format.rs` 空 / `git diff src/parser/claude_code*.rs src/parser.rs` 空（不変条件確認）
- [x] Codex CLI コードレビュー — 実装本体は「問題なし」評価

## レビューポイント

1. **`find_model_lower` の lowercase 比較**: 旧 `MODEL_CLAUDE_COPILOT_MAP`（値が `GPT-4o-mini` など大文字混じり）と `MODEL_COPILOT_CLAUDE_MAP`（キーが `gpt-4o-mini` lowercase）の二重管理を、行側の値を `to_lowercase()` してから比較する 1 本のテーブルに統合した（`src/parser/convert.rs:243-252`）。Cp→CC 双方向で同一行から引ける
2. **関数ポインタ列セレクタ**: `enum ToolColumn { ... }` ではなく `type ToolColumn = fn(&ToolRow) -> Option<&'static str>` を採用。列追加 = 新しい `*_col_*` 関数を 1 つ生やすだけで走査ロジック側に変更不要（`src/parser/convert.rs:41,210`）
3. **`reverse_canonical` フラグ**: N:1 reverse での代表行を 1 つに絞る。1:1 行（Bash/WebFetch/WebSearch）も `true` にして「reverse は代表行のみヒット」というルールに統一
4. **`codex` 列は `None` 埋めで先取り**: Tool 側の Codex マッピングが仕様化されたら値を埋め、`map_tool` に対応 match arm を追加するだけで拡張完了