### PR TITLE
🐛 [Bug Fix]: #232 fire StartInstall on Enter in TUI PluginBrowse

### DIFF
--- a/src/tui/manager/screens/marketplaces/model.rs
+++ b/src/tui/manager/screens/marketplaces/model.rs
@@ -326,11 +326,10 @@ pub fn key_to_msg(key: KeyCode, model: &Model) -> Option<Msg> {
         match model {
             Model::PluginBrowse { .. } => match key {
                 KeyCode::Char(' ') => Some(Msg::ToggleSelect),
-                KeyCode::Char('i') => Some(Msg::StartInstall),
+                KeyCode::Char('i') | KeyCode::Enter => Some(Msg::StartInstall),
                 KeyCode::Up | KeyCode::Char('k') => Some(Msg::Up),
                 KeyCode::Down | KeyCode::Char('j') => Some(Msg::Down),
                 KeyCode::Esc => Some(Msg::Back),
-                KeyCode::Enter => None,
                 _ => None,
             },
             Model::TargetSelect { .. } => match key {

--- a/src/tui/manager/screens/marketplaces/model_test.rs
+++ b/src/tui/manager/screens/marketplaces/model_test.rs
@@ -208,9 +208,12 @@ fn key_to_msg_plugin_browse_i_returns_start_install() {
 }
 
 #[test]
-fn key_to_msg_plugin_browse_enter_returns_none() {
+fn key_to_msg_plugin_browse_enter_returns_start_install() {
     let model = make_plugin_browse_model();
-    assert!(key_to_msg(KeyCode::Enter, &model).is_none());
+    assert!(matches!(
+        key_to_msg(KeyCode::Enter, &model),
+        Some(Msg::StartInstall)
+    ));
 }
 
 #[test]

--- a/src/tui/manager/screens/marketplaces/view.rs
+++ b/src/tui/manager/screens/marketplaces/view.rs
@@ -687,7 +687,8 @@ fn view_plugin_browse(
     }
 
     // ヘルプ
-    let help = Paragraph::new(" Esc: back | q: quit").style(Style::default().fg(Color::DarkGray));
+    let help = Paragraph::new(" Space: select | Enter/i: install | Esc: back | q: quit")
+        .style(Style::default().fg(Color::DarkGray));
     f.render_widget(help, chunks[3]);
 }
 


### PR DESCRIPTION
## 概要

`plm managed` の TUI 「Browse plugins」画面で Enter キーが無反応となり、ユーザーがインストール開始操作に詰まる UX バグを修正。Enter を `Msg::StartInstall` に紐付け、ヘルプ文言にも反映する（Issue #232 方案A）。

## 変更の種類

- 🐛 Bug Fix（key bind の挙動修正）
- 💄 UI/UX 改善（ヘルプ文言の更新）

## 詳細な変更内容

### `src/tui/manager/screens/marketplaces/model.rs`

- `Model::PluginBrowse` の `key_to_msg` 分岐で、独立していた `KeyCode::Enter => None` を削除し、`KeyCode::Char('i') | KeyCode::Enter => Some(Msg::StartInstall)` の or-pattern に統合
- 既存の `KeyCode::Up | KeyCode::Char('k')` などと整合する記述スタイル
- 他の状態（`TargetSelect` / `ScopeSelect` / `InstallResult`）の Enter 挙動は変更なし

### `src/tui/manager/screens/marketplaces/view.rs`

- PluginBrowse 画面下部のヘルプ Paragraph 文言を更新
  - before: `" Esc: back | q: quit"`
  - after: `" Space: select | Enter/i: install | Esc: back | q: quit"`
- `.style(...)` チェーンとレンダリング先 (`chunks[3]`) は変更なし

### `src/tui/manager/screens/marketplaces/model_test.rs`

- 既存テスト `key_to_msg_plugin_browse_enter_returns_none` を仕様変更に合わせて書き換え
- 新テスト名: `key_to_msg_plugin_browse_enter_returns_start_install`
- アサーション: `is_none()` → `matches!(..., Some(Msg::StartInstall))`

## システム図

```mermaid
flowchart TD
    KE["KeyCode::Enter (PluginBrowse)"]
    KI["KeyCode::Char('i')"]
    KSP["KeyCode::Char(' ')"]

    KE -- "before: None ❌" --> NOOP[("画面遷移なし")]
    KE -- "after: Some(StartInstall) ✅" --> SI["Msg::StartInstall"]
    KI --> SI
    KSP --> TS["Msg::ToggleSelect"]

    SI --> SIF["start_install(model)"]
    SIF -- "selected_plugins.is_empty()" --> NOOP
    SIF -- "selected_plugins.non_empty()" --> TGT["Model::TargetSelect"]

    style KE fill:#ffe4b5
    style SI fill:#b5e7a0
```

> 図中の Enter → Some(StartInstall) ✅ の経路が今回の追加分。`start_install()` の `selected_plugins.is_empty()` ガードは既存のままなので、未選択時は画面が変化しない既存仕様を維持する。

## 関連Issue

Closes #232

## テスト

- [x] `cargo fmt` — 差分なし
- [x] `cargo check` — エラー 0、新規警告なし
- [x] `cargo test` — **1361 passed / 0 failed**
- [x] TDD: RED 確認（Enter テストが期待通り失敗）→ GREEN 確認（実装後 pass）
- [x] Codex CLI による全変更レビュー → **問題なし**

### 自動テストで担保した DoD 項目

- [x] PluginBrowse / Enter で `Some(Msg::StartInstall)` を返す
- [x] PluginBrowse / `'i'` で `Some(Msg::StartInstall)` を返す（後方互換）
- [x] PluginBrowse / Space, Up, Down, j, k, Esc の戻り値が変わらない
- [x] TargetSelect / ScopeSelect / InstallResult の Enter 挙動が変わらない
- [x] 1 件以上選択時に StartInstall を投入すると `Model::TargetSelect` に遷移
- [x] 未選択時に StartInstall を投入してもモデルが PluginBrowse のまま遷移しない

### 手動検証（レビュアー側で実施推奨）

- [ ] `cargo run -- managed` でヘルプ文言が ` Space: select | Enter/i: install | Esc: back | q: quit` と表示される
- [ ] `MarketList → MarketDetail → PluginBrowse → TargetSelect` を Enter キーのみで通せる
- [ ] `i` キーでも同フロー（後方互換）
- [ ] 未選択時に Enter / `i` を押下しても画面遷移しない

## レビューポイント

1. **or-pattern による統合の可読性** — `KeyCode::Char('i') | KeyCode::Enter` で同一右辺にまとめている。同ファイル内既存スタイル（`KeyCode::Up | KeyCode::Char('k')`、`KeyCode::Enter | KeyCode::Esc`）と整合
2. **Enter の他状態への影響なし** — `match model` のスコープが `Model::PluginBrowse { .. }` に限定されているため、他状態の Enter 挙動はソース上で隔離されている。Codex レビューでも確認済み
3. **テスト書き換えの妥当性** — 既存 `enter_returns_none` テストは仕様矛盾になるため書き換え。`'i'` 用テスト（`key_to_msg_plugin_browse_i_returns_start_install`）と同形のアサーションに揃えた
4. **ヘルプ文言の自動テスト不在** — `view_test.rs` には現状ヘルプ文言を検証するテストが存在しないため、文言は手動確認に委ねている。設計文書 `docs/design-marketplace-browse-install.md` の更新は本 Issue のスコープ外（必要に応じてフォローアップ Issue で対応）

🤖 Generated with [Claude Code](https://claude.com/claude-code)