### PR TITLE
✨ [New Feature]: Skills/Agents/Commands ネスト構造の平坦化インストール

### DIFF
--- a/src/application/catalog.rs
+++ b/src/application/catalog.rs
@@ -19,22 +19,26 @@ pub fn list_installed_plugins(cache: &dyn PackageCacheAccess) -> Result<Vec<Inst
     let project_root = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
     let deployed = list_all_placed(&project_root);
 
+    // 一覧取得経路ではスキャン失敗（重複検出など）は握りつぶして列挙を続行する。
+    // TUI 経由でも呼ばれるため stderr への直接出力は避ける。
+    // 厳密検証が必要な経路（install 等）は `Plugin::new` を直接呼ぶこと。
     let plugins = list_installed(cache)?
         .into_iter()
-        .map(|pkg| {
+        .filter_map(|pkg| {
             let name = pkg.manifest().name.clone();
             let marketplace_str = pkg.marketplace().unwrap_or("github");
             let ops_key = pkg.id().unwrap_or(&name);
             let origin = PluginOrigin::from_marketplace(marketplace_str, ops_key);
-            let plugin = Plugin::new(pkg.manifest().clone(), pkg.path().to_path_buf(), origin);
+            let plugin =
+                Plugin::new(pkg.manifest().clone(), pkg.path().to_path_buf(), origin).ok()?;
             let enabled = meta::is_enabled(pkg.path(), marketplace_str, ops_key, &deployed);
 
-            InstalledPlugin::from_cached_package(
+            Some(InstalledPlugin::from_cached_package(
                 plugin,
                 pkg.id().map(str::to_string),
                 pkg.marketplace().map(str::to_string),
                 enabled,
-            )
+            ))
         })
         .collect();
 

--- a/src/application/info.rs
+++ b/src/application/info.rs
@@ -217,7 +217,7 @@ fn build_plugin_info(content: MarketplaceContent) -> Result<PluginInfo> {
     // InstalledPlugin を組み立てる（list_installed_plugins と同じく marketplace は Option<String> を保つ）
     let id = Some(dir_name.clone());
     let origin = PluginOrigin::from_marketplace(marketplace_key, &dir_name);
-    let plugin = Plugin::new(manifest, cache_path, origin);
+    let plugin = Plugin::new(manifest, cache_path, origin)?;
     let installed = InstalledPlugin::from_cached_package(plugin, id, marketplace_opt, enabled);
 
     Ok(PluginInfo {

--- a/src/application/info_test.rs
+++ b/src/application/info_test.rs
@@ -230,7 +230,7 @@ fn create_marketplace_content(marketplace: &str, name: &str) -> MarketplaceConte
         commit_sha: "unknown".to_string(),
         marketplace_manifest: None,
     };
-    MarketplaceContent::from(cached)
+    MarketplaceContent::try_from(cached).unwrap()
 }
 
 #[test]

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -402,7 +402,8 @@ pub async fn run(args: Args) -> Result<(), String> {
         println!("  Description: {}", desc);
     }
 
-    let package = crate::plugin::MarketplaceContent::from(&cached_plugin);
+    let package =
+        crate::plugin::MarketplaceContent::try_from(&cached_plugin).map_err(|e| e.to_string())?;
     let components = package.components();
 
     let (filtered_components, skipped_paths) =

--- a/src/install.rs
+++ b/src/install.rs
@@ -126,7 +126,7 @@ pub async fn download_plugin_with_cache(
 ) -> crate::error::Result<MarketplaceContent> {
     let source = parse_source(source_str)?;
     let cached = source.download(cache, force).await?;
-    Ok(MarketplaceContent::from(cached))
+    MarketplaceContent::try_from(cached)
 }
 
 /// プラグインのコンポーネントをスキャン

--- a/src/install_test.rs
+++ b/src/install_test.rs
@@ -86,7 +86,7 @@ fn test_scan_plugin_returns_all_components_when_no_filter() {
         &["agent-a"],
         &["cmd-a"],
     );
-    let package = MarketplaceContent::from(cached);
+    let package = MarketplaceContent::try_from(cached).unwrap();
 
     let result = scan_plugin(&package, None).unwrap();
 
@@ -104,7 +104,7 @@ fn test_scan_plugin_filters_by_skill_only() {
         &["agent-a"],
         &["cmd-a"],
     );
-    let package = MarketplaceContent::from(cached);
+    let package = MarketplaceContent::try_from(cached).unwrap();
 
     let filter = [ComponentKind::Skill];
     let result = scan_plugin(&package, Some(&filter)).unwrap();
@@ -120,7 +120,7 @@ fn test_scan_plugin_filters_by_skill_only() {
 fn test_scan_plugin_empty_components() {
     let temp = TempDir::new().unwrap();
     let cached = create_test_cached_package(temp.path(), &[], &[], &[]);
-    let package = MarketplaceContent::from(cached);
+    let package = MarketplaceContent::try_from(cached).unwrap();
 
     let result = scan_plugin(&package, None).unwrap();
 
@@ -131,7 +131,7 @@ fn test_scan_plugin_empty_components() {
 fn test_scan_plugin_filter_with_no_match() {
     let temp = TempDir::new().unwrap();
     let cached = create_test_cached_package(temp.path(), &["skill-a"], &[], &[]);
-    let package = MarketplaceContent::from(cached);
+    let package = MarketplaceContent::try_from(cached).unwrap();
 
     let filter = [ComponentKind::Agent];
     let result = scan_plugin(&package, Some(&filter)).unwrap();
@@ -148,7 +148,7 @@ fn test_place_plugin_skill_to_codex() {
     let temp = TempDir::new().unwrap();
     let project_dir = TempDir::new().unwrap();
     let cached = create_test_cached_package(temp.path(), &["my-skill"], &[], &[]);
-    let package = MarketplaceContent::from(cached);
+    let package = MarketplaceContent::try_from(cached).unwrap();
     let scanned = scan_plugin(&package, None).unwrap();
 
     let targets: Vec<Box<dyn crate::target::Target>> = vec![Box::new(CodexTarget::new())];
@@ -163,7 +163,7 @@ fn test_place_plugin_skill_to_codex() {
     assert_eq!(result.plugin_name, "test-plugin");
     assert_eq!(result.successes.len(), 1);
     assert!(result.failures.is_empty());
-    assert_eq!(result.successes[0].component_name, "my-skill");
+    assert_eq!(result.successes[0].component_name, "test-plugin_my-skill");
     assert_eq!(result.successes[0].component_kind, ComponentKind::Skill);
     assert_eq!(result.successes[0].target, "codex");
 }
@@ -174,7 +174,7 @@ fn test_place_plugin_unsupported_component_skipped() {
     let project_dir = TempDir::new().unwrap();
     // Antigravity only supports Skills
     let cached = create_test_cached_package(temp.path(), &[], &["my-agent"], &[]);
-    let package = MarketplaceContent::from(cached);
+    let package = MarketplaceContent::try_from(cached).unwrap();
     let scanned = scan_plugin(&package, None).unwrap();
 
     let targets: Vec<Box<dyn crate::target::Target>> =
@@ -197,7 +197,7 @@ fn test_place_plugin_empty_components() {
     let temp = TempDir::new().unwrap();
     let project_dir = TempDir::new().unwrap();
     let cached = create_test_cached_package(temp.path(), &[], &[], &[]);
-    let package = MarketplaceContent::from(cached);
+    let package = MarketplaceContent::try_from(cached).unwrap();
     let scanned = scan_plugin(&package, None).unwrap();
 
     let targets: Vec<Box<dyn crate::target::Target>> = vec![Box::new(CodexTarget::new())];
@@ -218,7 +218,7 @@ fn test_place_plugin_multiple_targets() {
     let temp = TempDir::new().unwrap();
     let project_dir = TempDir::new().unwrap();
     let cached = create_test_cached_package(temp.path(), &["my-skill"], &[], &[]);
-    let package = MarketplaceContent::from(cached);
+    let package = MarketplaceContent::try_from(cached).unwrap();
     let scanned = scan_plugin(&package, None).unwrap();
 
     let targets: Vec<Box<dyn crate::target::Target>> =
@@ -246,7 +246,7 @@ fn test_scan_plugin_propagates_id() {
     let temp = TempDir::new().unwrap();
     let mut cached = create_test_cached_package(temp.path(), &["skill-a"], &[], &[]);
     cached.id = Some("owner--repo".to_string());
-    let package = MarketplaceContent::from(cached);
+    let package = MarketplaceContent::try_from(cached).unwrap();
 
     let result = scan_plugin(&package, None).unwrap();
 
@@ -257,7 +257,7 @@ fn test_scan_plugin_propagates_id() {
 fn test_scan_plugin_id_none_falls_back_to_name() {
     let temp = TempDir::new().unwrap();
     let cached = create_test_cached_package(temp.path(), &["skill-a"], &[], &[]);
-    let package = MarketplaceContent::from(cached);
+    let package = MarketplaceContent::try_from(cached).unwrap();
 
     let result = scan_plugin(&package, None).unwrap();
 
@@ -274,7 +274,7 @@ fn test_place_plugin_uses_id_for_origin() {
     cached.name = "My Plugin".to_string();
     cached.manifest.name = "My Plugin".to_string();
     cached.id = Some("owner--repo".to_string());
-    let package = MarketplaceContent::from(cached);
+    let package = MarketplaceContent::try_from(cached).unwrap();
     let scanned = scan_plugin(&package, None).unwrap();
 
     // id が "owner--repo" であることを確認

--- a/src/marketplace/download.rs
+++ b/src/marketplace/download.rs
@@ -26,7 +26,7 @@ pub async fn download_marketplace_plugin_with_cache(
 ) -> Result<MarketplaceContent> {
     let source = MarketplaceSource::new(plugin_name, marketplace_name);
     let cached = source.download(cache, force).await?;
-    Ok(MarketplaceContent::from(cached))
+    MarketplaceContent::try_from(cached)
 }
 
 /// レジストリを注入可能なマーケットプレイス経由のプラグインダウンロード（テスト用）
@@ -86,7 +86,7 @@ async fn download_marketplace_plugin_with_registry(
         }
     };
 
-    Ok(MarketplaceContent::from(cached))
+    MarketplaceContent::try_from(cached)
 }
 
 #[cfg(test)]

--- a/src/plugin/cache.rs
+++ b/src/plugin/cache.rs
@@ -33,6 +33,9 @@ impl From<(Option<String>, String)> for PluginCacheKey {
 ///
 /// * `cache` - package cache access used to enumerate stored plugins
 pub(crate) fn list_installed(cache: &dyn PackageCacheAccess) -> Result<Vec<MarketplaceContent>> {
+    // 一覧取得経路では個別プラグインのスキャン失敗を握りつぶし、列挙自体は続行する。
+    // TUI 経由でも呼ばれるため stderr への直接出力は避ける。スキャン失敗を厳密に
+    // 検出する必要のある経路（install 等）は `Plugin::new` / `try_from` を直接呼ぶこと。
     let packages = cache
         .list()?
         .into_iter()
@@ -42,7 +45,7 @@ pub(crate) fn list_installed(cache: &dyn PackageCacheAccess) -> Result<Vec<Marke
             cache
                 .load_package(key.marketplace.as_deref(), &key.name)
                 .ok()
-                .map(MarketplaceContent::from)
+                .and_then(|pkg| MarketplaceContent::try_from(pkg).ok())
         })
         .collect();
     Ok(packages)

--- a/src/plugin/loader.rs
+++ b/src/plugin/loader.rs
@@ -26,5 +26,5 @@ pub(crate) fn load_plugin(
     let origin = PluginOrigin::from_cached_plugin(marketplace, plugin_name);
     let plugin_path = cache.plugin_path(marketplace, plugin_name);
 
-    Ok(Plugin::new(manifest, plugin_path, origin))
+    Plugin::new(manifest, plugin_path, origin).map_err(|e| format!("Failed to build plugin: {}", e))
 }

--- a/src/plugin/marketplace_content.rs
+++ b/src/plugin/marketplace_content.rs
@@ -4,6 +4,7 @@
 //! マーケットプレイスのパッケージ。コンポーネントスキャン・パス解決を担う。
 
 use crate::component::{AgentFormat, CommandFormat, Component};
+use crate::error::PlmError;
 use crate::marketplace::MarketplaceManifest;
 use crate::plugin::PluginManifest;
 use crate::target::PluginOrigin;
@@ -114,31 +115,35 @@ impl MarketplaceContent {
     }
 }
 
-impl From<CachedPackage> for MarketplaceContent {
-    fn from(cached: CachedPackage) -> Self {
+impl TryFrom<CachedPackage> for MarketplaceContent {
+    type Error = PlmError;
+
+    fn try_from(cached: CachedPackage) -> Result<Self, Self::Error> {
         let origin = PluginOrigin::from_cached_plugin(cached.marketplace.as_deref(), cached.id());
-        let primary = Plugin::new(cached.manifest, cached.path, origin);
-        Self {
+        let primary = Plugin::new(cached.manifest, cached.path, origin)?;
+        Ok(Self {
             id: cached.id,
             marketplace: cached.marketplace,
             marketplace_manifest: cached.marketplace_manifest,
             primary,
             extra_plugins: Vec::new(),
-        }
+        })
     }
 }
 
-impl From<&CachedPackage> for MarketplaceContent {
-    fn from(cached: &CachedPackage) -> Self {
+impl TryFrom<&CachedPackage> for MarketplaceContent {
+    type Error = PlmError;
+
+    fn try_from(cached: &CachedPackage) -> Result<Self, Self::Error> {
         let origin = PluginOrigin::from_cached_plugin(cached.marketplace.as_deref(), cached.id());
-        let primary = Plugin::new(cached.manifest.clone(), cached.path.clone(), origin);
-        Self {
+        let primary = Plugin::new(cached.manifest.clone(), cached.path.clone(), origin)?;
+        Ok(Self {
             id: cached.id.clone(),
             marketplace: cached.marketplace.clone(),
             marketplace_manifest: cached.marketplace_manifest.clone(),
             primary,
             extra_plugins: Vec::new(),
-        }
+        })
     }
 }
 

--- a/src/plugin/marketplace_content_test.rs
+++ b/src/plugin/marketplace_content_test.rs
@@ -28,7 +28,7 @@ fn make_manifest(name: &str) -> PluginManifest {
 
 /// 空ディレクトリを伴う `MarketplaceContent` を生成する
 ///
-/// `MarketplaceContent::from()` は構築時にコンポーネントスキャンを行うため、
+/// `MarketplaceContent::try_from().unwrap()` は構築時にコンポーネントスキャンを行うため、
 /// 固定パス（`/tmp/test-plugin` 等）ではなく `TempDir` を渡して
 /// 暗黙の FS 依存を排除する。
 fn create_test_marketplace_content() -> (TempDir, MarketplaceContent) {
@@ -43,7 +43,7 @@ fn create_test_marketplace_content() -> (TempDir, MarketplaceContent) {
         commit_sha: "abc123".to_string(),
         marketplace_manifest: None,
     };
-    let content = MarketplaceContent::from(cached);
+    let content = MarketplaceContent::try_from(cached).unwrap();
     (temp, content)
 }
 
@@ -59,7 +59,7 @@ fn create_test_marketplace_content_with_id(key: &str) -> (TempDir, MarketplaceCo
         commit_sha: "abc123".to_string(),
         marketplace_manifest: None,
     };
-    let content = MarketplaceContent::from(cached);
+    let content = MarketplaceContent::try_from(cached).unwrap();
     (temp, content)
 }
 
@@ -75,7 +75,7 @@ fn create_test_marketplace_content_no_marketplace() -> (TempDir, MarketplaceCont
         commit_sha: "abc123".to_string(),
         marketplace_manifest: None,
     };
-    let content = MarketplaceContent::from(cached);
+    let content = MarketplaceContent::try_from(cached).unwrap();
     (temp, content)
 }
 
@@ -147,7 +147,7 @@ fn test_marketplace_manifest_returns_some_when_present() {
         commit_sha: "abc123".to_string(),
         marketplace_manifest: Some(mp_manifest),
     };
-    let pkg = MarketplaceContent::from(cached);
+    let pkg = MarketplaceContent::try_from(cached).unwrap();
     let result = pkg.marketplace_manifest();
     assert!(result.is_some());
     assert_eq!(result.unwrap().name, "test-mp");
@@ -178,9 +178,9 @@ fn test_marketplace_content_components_from_cached_package() {
         marketplace_manifest: None,
     };
 
-    let content = MarketplaceContent::from(cached);
+    let content = MarketplaceContent::try_from(cached).unwrap();
     let components = content.components();
     assert_eq!(components.len(), 1);
     assert_eq!(components[0].kind, ComponentKind::Skill);
-    assert_eq!(components[0].name, "my-skill");
+    assert_eq!(components[0].name, "test-plugin_my-skill");
 }

--- a/src/plugin/plugin_content.rs
+++ b/src/plugin/plugin_content.rs
@@ -140,21 +140,21 @@ impl Plugin {
         let plugin_name = manifest.name.as_str();
         let mut components = Vec::new();
 
-        push_components_with_collision_check(
+        register_flattened_components(
             &mut components,
             ComponentKind::Skill,
             plugin_name,
             list_skill_names(&manifest.skills_dir(path)),
         )?;
 
-        push_components_with_collision_check(
+        register_flattened_components(
             &mut components,
             ComponentKind::Agent,
             plugin_name,
             list_agent_names(&manifest.agents_dir(path)),
         )?;
 
-        push_components_with_collision_check(
+        register_flattened_components(
             &mut components,
             ComponentKind::Command,
             plugin_name,
@@ -264,7 +264,7 @@ impl Plugin {
 ///
 /// 重複が検出された場合は `PlmError::Validation` を返す。kind が異なる
 /// component とは衝突を判定しない（kind 単位で HashMap を分離するため）。
-fn push_components_with_collision_check(
+fn register_flattened_components(
     components: &mut Vec<Component>,
     kind: ComponentKind,
     plugin_name: &str,

--- a/src/plugin/plugin_content.rs
+++ b/src/plugin/plugin_content.rs
@@ -140,26 +140,24 @@ impl Plugin {
         let plugin_name = manifest.name.as_str();
         let mut components = Vec::new();
 
-        register_flattened_components(
-            &mut components,
-            ComponentKind::Skill,
-            plugin_name,
-            list_skill_names(&manifest.skills_dir(path)),
-        )?;
-
-        register_flattened_components(
-            &mut components,
-            ComponentKind::Agent,
-            plugin_name,
-            list_agent_names(&manifest.agents_dir(path)),
-        )?;
-
-        register_flattened_components(
-            &mut components,
-            ComponentKind::Command,
-            plugin_name,
-            list_command_names(&manifest.commands_dir(path)),
-        )?;
+        for (kind, items) in [
+            (
+                ComponentKind::Skill,
+                list_skill_names(&manifest.skills_dir(path)),
+            ),
+            (
+                ComponentKind::Agent,
+                list_agent_names(&manifest.agents_dir(path)),
+            ),
+            (
+                ComponentKind::Command,
+                list_command_names(&manifest.commands_dir(path)),
+            ),
+        ] {
+            let flattened = flatten_components(kind, plugin_name, items)?;
+            detect_name_collisions(&flattened)?;
+            components.extend(flattened);
+        }
 
         Self::build_instructions(path, manifest, &mut components);
 
@@ -259,34 +257,51 @@ impl Plugin {
     }
 }
 
-/// `flatten_name` を適用しながら `components` に追加し、同一 kind 内で
-/// 平坦化済み name が重複していないかを検証する。
+/// 元名のリストを平坦化済み `Component` のリストに変換する。
 ///
-/// 重複が検出された場合は `PlmError::Validation` を返す。kind が異なる
-/// component とは衝突を判定しない（kind 単位で HashMap を分離するため）。
-fn register_flattened_components(
-    components: &mut Vec<Component>,
+/// `plugin_name` および各 `original_name` を `validate_path_segment` で検証し、
+/// `flatten_name` で `"{plugin}_{original}"` 形式に変換する。検証に失敗した
+/// 場合は `PlmError::Validation` を返す。重複検出は行わない（呼び出し側で
+/// `detect_name_collisions` を使う）。
+fn flatten_components(
     kind: ComponentKind,
     plugin_name: &str,
     items: Vec<(String, PathBuf)>,
-) -> Result<()> {
+) -> Result<Vec<Component>> {
     validate_path_segment("plugin name", plugin_name)?;
-    let mut seen: HashMap<String, PathBuf> = HashMap::new();
-    for (original_name, path) in items {
-        validate_path_segment("component name", &original_name)?;
-        let name = flatten_name(plugin_name, &original_name);
-        if let Some(existing) = seen.get(&name) {
+    items
+        .into_iter()
+        .map(|(original_name, path)| {
+            validate_path_segment("component name", &original_name)?;
+            Ok(Component {
+                kind,
+                name: flatten_name(plugin_name, &original_name),
+                path,
+            })
+        })
+        .collect()
+}
+
+/// 同一スライス内で `Component.name` が重複していないかを検出する。
+///
+/// 重複があれば `PlmError::Validation` を返し、衝突した 2 パスをメッセージに
+/// 含める。スライスは同一 `kind` を前提とする（kind ごとに別呼び出しすること）。
+fn detect_name_collisions(components: &[Component]) -> Result<()> {
+    let mut seen: HashMap<&str, &Path> = HashMap::new();
+    for component in components {
+        if let Some(existing) = seen.get(component.name.as_str()) {
             return Err(PlmError::Validation(format!(
-                "duplicate component name '{name}' for kind {kind:?}: \
+                "duplicate component name '{}' for kind {:?}: \
                  '{}' conflicts with '{}'. \
                  Two source paths produce the same flattened name; \
                  rename one of the source directories/files to disambiguate.",
+                component.name,
+                component.kind,
                 existing.display(),
-                path.display(),
+                component.path.display(),
             )));
         }
-        seen.insert(name.clone(), path.clone());
-        components.push(Component { kind, name, path });
+        seen.insert(component.name.as_str(), component.path.as_path());
     }
     Ok(())
 }

--- a/src/plugin/plugin_content.rs
+++ b/src/plugin/plugin_content.rs
@@ -3,13 +3,27 @@
 //! パッケージ内の個別プラグインを表現する。コンポーネントスキャン・パス解決の責務を持つ。
 
 use crate::component::{Component, ComponentKind};
+use crate::error::{PlmError, Result};
 use crate::plugin::PluginManifest;
 use crate::scan::{
     file_stem_name, list_agent_names, list_command_names, list_hook_names, list_markdown_names,
     list_skill_names,
 };
 use crate::target::PluginOrigin;
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+
+/// プラグイン名と元名から平坦化済みの `Component.name` を組み立てる純粋関数。
+///
+/// 常に `"{plugin_name}_{original_name}"` 形式を返す。サニタイズは行わない。
+///
+/// # Arguments
+///
+/// * `plugin_name` - `PluginManifest.name`
+/// * `original_name` - スキャン層が返す元名（中間ディレクトリ名は含まない）
+pub(crate) fn flatten_name(plugin_name: &str, original_name: &str) -> String {
+    format!("{plugin_name}_{original_name}")
+}
 
 /// パッケージ内の個別プラグイン
 ///
@@ -35,14 +49,14 @@ impl Plugin {
     /// * `manifest` - Plugin manifest describing the plugin metadata and layout.
     /// * `path` - Root directory path of the plugin on disk.
     /// * `origin` - Plugin origin (marketplace and plugin identifier).
-    pub fn new(manifest: PluginManifest, path: PathBuf, origin: PluginOrigin) -> Self {
-        let components = Self::build_components(&path, &manifest);
-        Self {
+    pub fn new(manifest: PluginManifest, path: PathBuf, origin: PluginOrigin) -> Result<Self> {
+        let components = Self::build_components(&path, &manifest)?;
+        Ok(Self {
             manifest,
             path,
             origin,
             components,
-        }
+        })
     }
 
     /// テスト専用コンストラクタ: FS スキャンをバイパスしてコンポーネントを直接注入する
@@ -86,32 +100,30 @@ impl Plugin {
     ///
     /// * `path` - Plugin root directory used to resolve component directories.
     /// * `manifest` - Plugin manifest that defines component layout and names.
-    fn build_components(path: &Path, manifest: &PluginManifest) -> Vec<Component> {
+    fn build_components(path: &Path, manifest: &PluginManifest) -> Result<Vec<Component>> {
+        let plugin_name = manifest.name.as_str();
         let mut components = Vec::new();
 
-        for (name, p) in list_skill_names(&manifest.skills_dir(path)) {
-            components.push(Component {
-                kind: ComponentKind::Skill,
-                path: p,
-                name,
-            });
-        }
+        push_components_with_collision_check(
+            &mut components,
+            ComponentKind::Skill,
+            plugin_name,
+            list_skill_names(&manifest.skills_dir(path)),
+        )?;
 
-        for (name, p) in list_agent_names(&manifest.agents_dir(path)) {
-            components.push(Component {
-                kind: ComponentKind::Agent,
-                path: p,
-                name,
-            });
-        }
+        push_components_with_collision_check(
+            &mut components,
+            ComponentKind::Agent,
+            plugin_name,
+            list_agent_names(&manifest.agents_dir(path)),
+        )?;
 
-        for (name, p) in list_command_names(&manifest.commands_dir(path)) {
-            components.push(Component {
-                kind: ComponentKind::Command,
-                path: p,
-                name,
-            });
-        }
+        push_components_with_collision_check(
+            &mut components,
+            ComponentKind::Command,
+            plugin_name,
+            list_command_names(&manifest.commands_dir(path)),
+        )?;
 
         Self::build_instructions(path, manifest, &mut components);
 
@@ -123,7 +135,7 @@ impl Plugin {
             });
         }
 
-        components
+        Ok(components)
     }
 
     /// Append instruction components resolved from the manifest into `components`.
@@ -209,6 +221,36 @@ impl Plugin {
     pub fn components(&self) -> &[Component] {
         &self.components
     }
+}
+
+/// `flatten_name` を適用しながら `components` に追加し、同一 kind 内で
+/// 平坦化済み name が重複していないかを検証する。
+///
+/// 重複が検出された場合は `PlmError::Validation` を返す。kind が異なる
+/// component とは衝突を判定しない（kind 単位で HashMap を分離するため）。
+fn push_components_with_collision_check(
+    components: &mut Vec<Component>,
+    kind: ComponentKind,
+    plugin_name: &str,
+    items: Vec<(String, PathBuf)>,
+) -> Result<()> {
+    let mut seen: HashMap<String, PathBuf> = HashMap::new();
+    for (original_name, path) in items {
+        let name = flatten_name(plugin_name, &original_name);
+        if let Some(existing) = seen.get(&name) {
+            return Err(PlmError::Validation(format!(
+                "duplicate component name '{name}' for kind {kind:?}: \
+                 '{}' conflicts with '{}'. \
+                 Two source paths produce the same flattened name; \
+                 rename one of the source directories/files to disambiguate.",
+                existing.display(),
+                path.display(),
+            )));
+        }
+        seen.insert(name.clone(), path.clone());
+        components.push(Component { kind, name, path });
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/plugin/plugin_content.rs
+++ b/src/plugin/plugin_content.rs
@@ -25,6 +25,42 @@ pub(crate) fn flatten_name(plugin_name: &str, original_name: &str) -> String {
     format!("{plugin_name}_{original_name}")
 }
 
+/// 平坦化に使う名前（plugin_name / original_name）が単一パスセグメントとして
+/// 安全に扱えることを検証する。`placement_location` が `base.join(name)` や
+/// `format!("{name}.agent.md")` を直接行うため、パス区切り・null 文字・親参照
+/// などが含まれているとターゲットディレクトリの外へエスケープされる恐れがある。
+///
+/// # 拒否する条件
+/// - 空文字
+/// - `/` `\` `\0` を含む
+/// - `.` または `..` 単体
+/// - `Path::new(name).components()` が複数コンポーネントを返す
+fn validate_path_segment(label: &str, name: &str) -> Result<()> {
+    if name.is_empty() {
+        return Err(PlmError::Validation(format!(
+            "{label} must not be empty for component flattening"
+        )));
+    }
+    if name.contains('/') || name.contains('\\') || name.contains('\0') {
+        return Err(PlmError::Validation(format!(
+            "{label} '{name}' must not contain path separators or null bytes"
+        )));
+    }
+    if name == "." || name == ".." {
+        return Err(PlmError::Validation(format!(
+            "{label} '{name}' must not be a parent/current directory reference"
+        )));
+    }
+    let mut components = Path::new(name).components();
+    let first = components.next();
+    if components.next().is_some() || !matches!(first, Some(std::path::Component::Normal(_))) {
+        return Err(PlmError::Validation(format!(
+            "{label} '{name}' must be a single normal path segment"
+        )));
+    }
+    Ok(())
+}
+
 /// パッケージ内の個別プラグイン
 ///
 /// `manifest`, `path` を保持し、構築時にコンポーネントを一度だけスキャンしてキャッシュする。
@@ -234,8 +270,10 @@ fn push_components_with_collision_check(
     plugin_name: &str,
     items: Vec<(String, PathBuf)>,
 ) -> Result<()> {
+    validate_path_segment("plugin name", plugin_name)?;
     let mut seen: HashMap<String, PathBuf> = HashMap::new();
     for (original_name, path) in items {
+        validate_path_segment("component name", &original_name)?;
         let name = flatten_name(plugin_name, &original_name);
         if let Some(existing) = seen.get(&name) {
             return Err(PlmError::Validation(format!(

--- a/src/plugin/plugin_content_test.rs
+++ b/src/plugin/plugin_content_test.rs
@@ -496,3 +496,68 @@ fn test_plugin_new_collision_flat_and_nested_returns_validation_error() {
     );
     assert!(matches!(result, Err(PlmError::Validation(_))));
 }
+
+// =========================================================================
+// パストラバーサル / 不正な plugin name の拒否
+// =========================================================================
+
+#[test]
+fn test_plugin_new_rejects_plugin_name_with_path_separator() {
+    let temp = TempDir::new().unwrap();
+    let path = temp.path().to_path_buf();
+    write_file(&path.join("skills/foo/SKILL.md"), "# Skill");
+
+    let result = Plugin::new(
+        make_manifest("../evil"),
+        path,
+        PluginOrigin::from_marketplace("test", "test"),
+    );
+    let err = result.unwrap_err();
+    let msg = match err {
+        PlmError::Validation(s) => s,
+        other => panic!("expected Validation error, got {:?}", other),
+    };
+    assert!(msg.contains("plugin name"), "msg: {msg}");
+}
+
+#[test]
+fn test_plugin_new_rejects_plugin_name_with_backslash() {
+    let temp = TempDir::new().unwrap();
+    let path = temp.path().to_path_buf();
+    write_file(&path.join("skills/foo/SKILL.md"), "# Skill");
+
+    let result = Plugin::new(
+        make_manifest("a\\b"),
+        path,
+        PluginOrigin::from_marketplace("test", "test"),
+    );
+    assert!(matches!(result, Err(PlmError::Validation(_))));
+}
+
+#[test]
+fn test_plugin_new_rejects_empty_plugin_name() {
+    let temp = TempDir::new().unwrap();
+    let path = temp.path().to_path_buf();
+    write_file(&path.join("skills/foo/SKILL.md"), "# Skill");
+
+    let result = Plugin::new(
+        make_manifest(""),
+        path,
+        PluginOrigin::from_marketplace("test", "test"),
+    );
+    assert!(matches!(result, Err(PlmError::Validation(_))));
+}
+
+#[test]
+fn test_plugin_new_rejects_plugin_name_dotdot() {
+    let temp = TempDir::new().unwrap();
+    let path = temp.path().to_path_buf();
+    write_file(&path.join("skills/foo/SKILL.md"), "# Skill");
+
+    let result = Plugin::new(
+        make_manifest(".."),
+        path,
+        PluginOrigin::from_marketplace("test", "test"),
+    );
+    assert!(matches!(result, Err(PlmError::Validation(_))));
+}

--- a/src/plugin/plugin_content_test.rs
+++ b/src/plugin/plugin_content_test.rs
@@ -1,7 +1,8 @@
 //! Plugin のユニットテスト
 
-use super::Plugin;
+use super::{flatten_name, Plugin};
 use crate::component::{Component, ComponentKind};
+use crate::error::PlmError;
 use crate::plugin::PluginManifest;
 use crate::target::PluginOrigin;
 use std::fs;
@@ -46,12 +47,13 @@ fn test_plugin_new_with_skills() {
         make_manifest("test"),
         path.clone(),
         PluginOrigin::from_marketplace("test", "test"),
-    );
+    )
+    .unwrap();
 
     let components = plugin.components();
     assert_eq!(components.len(), 1);
     assert_eq!(components[0].kind, ComponentKind::Skill);
-    assert_eq!(components[0].name, "my-skill");
+    assert_eq!(components[0].name, "test_my-skill");
     assert_eq!(components[0].path, path.join("skills").join("my-skill"));
 }
 
@@ -64,7 +66,8 @@ fn test_plugin_new_empty_dir() {
         make_manifest("test"),
         path,
         PluginOrigin::from_marketplace("test", "test"),
-    );
+    )
+    .unwrap();
 
     assert!(plugin.components().is_empty());
 }
@@ -79,7 +82,8 @@ fn test_plugin_components_returns_slice() {
         make_manifest("test"),
         path,
         PluginOrigin::from_marketplace("test", "test"),
-    );
+    )
+    .unwrap();
 
     let components: &[Component] = plugin.components();
     assert_eq!(components.len(), 1);
@@ -95,12 +99,13 @@ fn test_plugin_new_with_agents() {
         make_manifest("test"),
         path.clone(),
         PluginOrigin::from_marketplace("test", "test"),
-    );
+    )
+    .unwrap();
 
     let components = plugin.components();
     assert_eq!(components.len(), 1);
     assert_eq!(components[0].kind, ComponentKind::Agent);
-    assert_eq!(components[0].name, "my-agent");
+    assert_eq!(components[0].name, "test_my-agent");
     assert_eq!(
         components[0].path,
         path.join("agents").join("my-agent.agent.md")
@@ -120,12 +125,13 @@ fn test_plugin_new_with_agent_single_file() {
         manifest,
         path.clone(),
         PluginOrigin::from_marketplace("test", "test"),
-    );
+    )
+    .unwrap();
 
     let components = plugin.components();
     assert_eq!(components.len(), 1);
     assert_eq!(components[0].kind, ComponentKind::Agent);
-    assert_eq!(components[0].name, "custom-agent");
+    assert_eq!(components[0].name, "test_custom-agent");
     assert_eq!(components[0].path, path.join("custom-agent.md"));
 }
 
@@ -139,12 +145,13 @@ fn test_plugin_new_with_commands() {
         make_manifest("test"),
         path.clone(),
         PluginOrigin::from_marketplace("test", "test"),
-    );
+    )
+    .unwrap();
 
     let components = plugin.components();
     assert_eq!(components.len(), 1);
     assert_eq!(components[0].kind, ComponentKind::Command);
-    assert_eq!(components[0].name, "my-command");
+    assert_eq!(components[0].name, "test_my-command");
     assert_eq!(
         components[0].path,
         path.join("commands").join("my-command.prompt.md")
@@ -161,12 +168,13 @@ fn test_plugin_new_with_command_md_fallback() {
         make_manifest("test"),
         path.clone(),
         PluginOrigin::from_marketplace("test", "test"),
-    );
+    )
+    .unwrap();
 
     let components = plugin.components();
     assert_eq!(components.len(), 1);
     assert_eq!(components[0].kind, ComponentKind::Command);
-    assert_eq!(components[0].name, "legacy-cmd");
+    assert_eq!(components[0].name, "test_legacy-cmd");
     assert_eq!(
         components[0].path,
         path.join("commands").join("legacy-cmd.md")
@@ -186,7 +194,8 @@ fn test_plugin_new_with_instructions() {
         manifest,
         path.clone(),
         PluginOrigin::from_marketplace("test", "test"),
-    );
+    )
+    .unwrap();
 
     let components = plugin.components();
     assert_eq!(components.len(), 1);
@@ -210,7 +219,8 @@ fn test_plugin_new_with_instructions_dir_containing_agents_md() {
         manifest,
         path.clone(),
         PluginOrigin::from_marketplace("test", "test"),
-    );
+    )
+    .unwrap();
 
     let components = plugin.components();
     assert_eq!(components.len(), 1);
@@ -229,7 +239,8 @@ fn test_plugin_new_with_default_agents_md_instruction() {
         make_manifest("test"),
         path.clone(),
         PluginOrigin::from_marketplace("test", "test"),
-    );
+    )
+    .unwrap();
 
     let components = plugin.components();
     assert_eq!(components.len(), 1);
@@ -248,7 +259,8 @@ fn test_plugin_new_with_hooks() {
         make_manifest("test"),
         path.clone(),
         PluginOrigin::from_marketplace("test", "test"),
-    );
+    )
+    .unwrap();
 
     let components = plugin.components();
     assert_eq!(components.len(), 1);
@@ -273,7 +285,8 @@ fn test_plugin_new_with_instruction_file_manifest() {
         manifest,
         path.clone(),
         PluginOrigin::from_marketplace("test", "test"),
-    );
+    )
+    .unwrap();
 
     let components = plugin.components();
     assert_eq!(components.len(), 1);
@@ -294,7 +307,8 @@ fn test_plugin_new_with_missing_instruction_path() {
         manifest,
         path,
         PluginOrigin::from_marketplace("test", "test"),
-    );
+    )
+    .unwrap();
 
     let instructions: Vec<&Component> = plugin
         .components()
@@ -315,7 +329,8 @@ fn test_plugin_new_with_hooks_same_stem_different_ext() {
         make_manifest("test"),
         path.clone(),
         PluginOrigin::from_marketplace("test", "test"),
-    );
+    )
+    .unwrap();
 
     let hooks: Vec<&Component> = plugin
         .components()
@@ -341,9 +356,143 @@ fn test_plugin_clone_preserves_components() {
         make_manifest("test"),
         path,
         PluginOrigin::from_marketplace("test", "test"),
-    );
+    )
+    .unwrap();
     let cloned = plugin.clone();
 
     assert_eq!(cloned.components().len(), 1);
-    assert_eq!(cloned.components()[0].name, "my-skill");
+    assert_eq!(cloned.components()[0].name, "test_my-skill");
+}
+
+// =========================================================================
+// flatten_name 純粋関数
+// =========================================================================
+
+#[test]
+fn test_flatten_name_basic() {
+    assert_eq!(flatten_name("myplugin", "foo"), "myplugin_foo");
+}
+
+#[test]
+fn test_flatten_name_original_with_underscore() {
+    assert_eq!(flatten_name("myplugin", "foo_bar"), "myplugin_foo_bar");
+}
+
+#[test]
+fn test_flatten_name_plugin_with_underscore() {
+    assert_eq!(flatten_name("my_plugin", "foo"), "my_plugin_foo");
+}
+
+#[test]
+fn test_flatten_name_empty_plugin_name() {
+    assert_eq!(flatten_name("", "foo"), "_foo");
+}
+
+// =========================================================================
+// build_components: ネスト + 平坦化
+// =========================================================================
+
+#[test]
+fn test_plugin_new_with_nested_skill_uses_flat_name() {
+    let temp = TempDir::new().unwrap();
+    let path = temp.path().to_path_buf();
+    write_file(&path.join("skills/bar/foo/SKILL.md"), "# Skill");
+
+    let plugin = Plugin::new(
+        make_manifest("myplugin"),
+        path.clone(),
+        PluginOrigin::from_marketplace("test", "test"),
+    )
+    .unwrap();
+
+    let components = plugin.components();
+    assert_eq!(components.len(), 1);
+    assert_eq!(components[0].kind, ComponentKind::Skill);
+    assert_eq!(components[0].name, "myplugin_foo");
+    assert_eq!(components[0].path, path.join("skills/bar/foo"));
+}
+
+#[test]
+fn test_plugin_new_skill_and_agent_same_name_no_collision() {
+    let temp = TempDir::new().unwrap();
+    let path = temp.path().to_path_buf();
+    write_file(&path.join("skills/foo/SKILL.md"), "# Skill");
+    write_file(&path.join("agents/foo.agent.md"), "# Agent");
+
+    let plugin = Plugin::new(
+        make_manifest("myplugin"),
+        path.clone(),
+        PluginOrigin::from_marketplace("test", "test"),
+    )
+    .unwrap();
+
+    let names: Vec<(_, _)> = plugin
+        .components()
+        .iter()
+        .map(|c| (c.kind, c.name.as_str()))
+        .collect();
+    assert!(names.contains(&(ComponentKind::Skill, "myplugin_foo")));
+    assert!(names.contains(&(ComponentKind::Agent, "myplugin_foo")));
+}
+
+#[test]
+fn test_plugin_new_distinct_basenames_no_collision() {
+    let temp = TempDir::new().unwrap();
+    let path = temp.path().to_path_buf();
+    write_file(&path.join("skills/foo/SKILL.md"), "# foo");
+    write_file(&path.join("skills/bar/baz/SKILL.md"), "# baz");
+
+    let plugin = Plugin::new(
+        make_manifest("myplugin"),
+        path,
+        PluginOrigin::from_marketplace("test", "test"),
+    )
+    .unwrap();
+
+    let mut skill_names: Vec<String> = plugin
+        .components()
+        .iter()
+        .filter(|c| c.kind == ComponentKind::Skill)
+        .map(|c| c.name.clone())
+        .collect();
+    skill_names.sort();
+    assert_eq!(skill_names, vec!["myplugin_baz", "myplugin_foo"]);
+}
+
+#[test]
+fn test_plugin_new_collision_in_nested_skills_returns_validation_error() {
+    let temp = TempDir::new().unwrap();
+    let path = temp.path().to_path_buf();
+    write_file(&path.join("skills/a/foo/SKILL.md"), "# a/foo");
+    write_file(&path.join("skills/b/foo/SKILL.md"), "# b/foo");
+
+    let result = Plugin::new(
+        make_manifest("myplugin"),
+        path,
+        PluginOrigin::from_marketplace("test", "test"),
+    );
+
+    let err = result.unwrap_err();
+    let msg = match err {
+        PlmError::Validation(s) => s,
+        other => panic!("expected Validation error, got: {:?}", other),
+    };
+    assert!(msg.contains("myplugin_foo"), "msg: {msg}");
+    assert!(msg.contains("Skill"), "msg: {msg}");
+    assert!(msg.contains("conflicts with"), "msg: {msg}");
+}
+
+#[test]
+fn test_plugin_new_collision_flat_and_nested_returns_validation_error() {
+    let temp = TempDir::new().unwrap();
+    let path = temp.path().to_path_buf();
+    write_file(&path.join("skills/foo/SKILL.md"), "# flat");
+    write_file(&path.join("skills/bar/foo/SKILL.md"), "# nested");
+
+    let result = Plugin::new(
+        make_manifest("myplugin"),
+        path,
+        PluginOrigin::from_marketplace("test", "test"),
+    );
+    assert!(matches!(result, Err(PlmError::Validation(_))));
 }

--- a/src/scan/components.rs
+++ b/src/scan/components.rs
@@ -99,11 +99,14 @@ pub fn list_agent_names(agents_path: &Path) -> Vec<(String, PathBuf)> {
         let Some(file_name) = agents_path.file_name().and_then(|n| n.to_str()) else {
             return Vec::new();
         };
-        let name = file_name
+        let Some(name) = file_name
             .strip_suffix(AGENT_SUFFIX)
             .or_else(|| file_name.strip_suffix(MARKDOWN_SUFFIX))
             .map(String::from)
-            .unwrap_or_else(|| file_name.to_string());
+        else {
+            // .agent.md / .md 以外の拡張子は対象外（ディレクトリ走査と挙動を揃える）
+            return Vec::new();
+        };
         return vec![(name, agents_path.to_path_buf())];
     }
 

--- a/src/scan/components.rs
+++ b/src/scan/components.rs
@@ -8,37 +8,61 @@ use crate::path_ext::PathExt;
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 
-/// スキル名一覧を取得
+/// スキル名一覧を取得（再帰）
 ///
-/// 指定されたディレクトリ配下で `SKILL.md` を持つサブディレクトリを列挙し、
-/// そのディレクトリ名を返す。ファイル名の判定はファイルシステムのケース感度に
-/// 依存しない厳密一致で行う。
+/// `skills_dir` 配下を再帰的に走査し、`SKILL.md` を直下に持つディレクトリを
+/// すべて採用する。中間ディレクトリ名は戻り値に含めない（例: `bar/foo/SKILL.md`
+/// は `("foo", path)` を返す）。
 ///
 /// # Arguments
 ///
 /// * `skills_dir` - スキルディレクトリのパス
 ///
 /// # Returns
-/// スキル名（ディレクトリ名）の一覧。順序は保証されない。
+/// `(SKILL.md があるディレクトリ名, そのディレクトリの絶対パス)` の一覧。
+/// 順序は保証されない。
 ///
 /// # Behavior
 /// - `skills_dir` がディレクトリでない場合は空配列を返す
-/// - サブディレクトリのうち `SKILL.md` が存在するものだけを抽出
+/// - SKILL.md を持つディレクトリを発見したらそれを採用し、配下にはさらに潜らない
+///   （Skill 内部の `assets/` 等に SKILL.md がある場合の誤検出を避ける）
 /// - UTF-8 変換不可のディレクトリ名は除外
 pub fn list_skill_names(skills_dir: &Path) -> Vec<(String, PathBuf)> {
     if !skills_dir.is_dir() {
         return Vec::new();
     }
+    let mut out = Vec::new();
+    collect_skills_recursive(skills_dir, &mut out);
+    out
+}
 
-    skills_dir
-        .read_dir_entries()
-        .into_iter()
-        .filter(|path| path.is_dir() && has_exact_skill_manifest(path))
-        .filter_map(|path| {
-            let name = path.file_name()?.to_str().map(String::from)?;
-            Some((name, path))
-        })
-        .collect()
+fn collect_skills_recursive(current: &Path, out: &mut Vec<(String, PathBuf)>) {
+    for entry in current.read_dir_entries() {
+        // symlink は無限ループ防止のため辿らない
+        if is_symlink(&entry) {
+            continue;
+        }
+        if !entry.is_dir() {
+            continue;
+        }
+        let Some(entry_name) = entry.file_name().and_then(|n| n.to_str()).map(String::from) else {
+            continue;
+        };
+        if has_exact_skill_manifest(&entry) {
+            out.push((entry_name, entry));
+            continue;
+        }
+        collect_skills_recursive(&entry, out);
+    }
+}
+
+/// symlink かどうかを判定する。`symlink_metadata` を使うため symlink 先は辿らない。
+/// メタデータ取得に失敗した場合は false（通常エントリ扱い）として呼び出し元の `is_dir`
+/// 判定に委ねる。
+fn is_symlink(path: &Path) -> bool {
+    std::fs::symlink_metadata(path)
+        .map(|m| m.file_type().is_symlink())
+        .unwrap_or(false)
 }
 
 /// サブディレクトリ内に正確に `SKILL.md` という名前のファイルが存在するか判定する。
@@ -56,79 +80,102 @@ fn has_exact_skill_manifest(dir: &Path) -> bool {
         .any(|entry| entry.file_name() == expected)
 }
 
-/// エージェント名一覧を取得
+/// エージェント名一覧を取得（再帰）
 ///
 /// 指定されたパスが単一ファイルの場合はそのファイル名（拡張子除去）を返す。
-/// ディレクトリの場合は .agent.md / .md ファイルを列挙する。
+/// ディレクトリの場合は配下を再帰的に走査し、`.agent.md` / `.md` ファイルを
+/// 列挙する。中間ディレクトリ名は戻り値に含めない。
 ///
 /// # Arguments
 ///
 /// * `agents_path` - エージェントファイルまたはディレクトリのパス
 ///
 /// # Returns
-/// エージェント名の一覧。
+/// `(エージェント名, ファイルパス)` の一覧。
 /// 単一ファイルで名前を導出できない場合や、`agents_path` がファイル/ディレクトリの
 /// いずれでもない場合は空配列を返す。
 pub fn list_agent_names(agents_path: &Path) -> Vec<(String, PathBuf)> {
     if agents_path.is_file() {
-        return file_stem_name(agents_path)
-            .map(|name| vec![(name, agents_path.to_path_buf())])
-            .unwrap_or_default();
+        let Some(file_name) = agents_path.file_name().and_then(|n| n.to_str()) else {
+            return Vec::new();
+        };
+        let name = file_name
+            .strip_suffix(AGENT_SUFFIX)
+            .or_else(|| file_name.strip_suffix(MARKDOWN_SUFFIX))
+            .map(String::from)
+            .unwrap_or_else(|| file_name.to_string());
+        return vec![(name, agents_path.to_path_buf())];
     }
 
     if !agents_path.is_dir() {
         return Vec::new();
     }
 
-    agents_path
-        .read_dir_entries()
-        .into_iter()
-        .filter(|path| path.is_file())
-        .filter_map(|path| {
-            let file_name = path.file_name()?.to_str()?;
-            let name = if file_name.ends_with(AGENT_SUFFIX) {
-                file_name.trim_end_matches(AGENT_SUFFIX).to_string()
-            } else if file_name.ends_with(MARKDOWN_SUFFIX) {
-                file_name.trim_end_matches(MARKDOWN_SUFFIX).to_string()
-            } else {
-                return None;
-            };
-            Some((name, path))
-        })
-        .collect()
+    let mut out = Vec::new();
+    collect_component_files_recursive(agents_path, AGENT_SUFFIX, true, &mut out);
+    out
 }
 
-/// コマンド名一覧を取得
+/// `current` 配下を再帰走査し、`primary_suffix` で終わるファイルを採取する。
 ///
-/// ディレクトリ内の .prompt.md / .md ファイルを列挙する。
+/// - `primary_suffix` で終わるファイルは、その suffix を取り除いた stem を name とする。
+/// - `is_root == true` のディレクトリ直下に限り、`.md` で終わるファイルも採取する
+///   （既存の Claude Code 互換: 直下 `agents/foo.md` 等）。
+///   ネスト先の `.md` は誤検出回避のため対象外とする。
+/// - その他のファイルは無視する。
+/// - サブディレクトリは再帰的に走査する（descended into のため `is_root = false`）。
+fn collect_component_files_recursive(
+    current: &Path,
+    primary_suffix: &str,
+    is_root: bool,
+    out: &mut Vec<(String, PathBuf)>,
+) {
+    for entry in current.read_dir_entries() {
+        // symlink は無限ループ防止のため辿らない（symlink 先がファイルでも対象外）
+        if is_symlink(&entry) {
+            continue;
+        }
+        if entry.is_file() {
+            let Some(file_name) = entry.file_name().and_then(|n| n.to_str()).map(String::from)
+            else {
+                continue;
+            };
+            if let Some(stem) = file_name.strip_suffix(primary_suffix) {
+                out.push((stem.to_string(), entry));
+                continue;
+            }
+            if is_root {
+                if let Some(stem) = file_name.strip_suffix(MARKDOWN_SUFFIX) {
+                    out.push((stem.to_string(), entry));
+                }
+            }
+            continue;
+        }
+        if entry.is_dir() {
+            collect_component_files_recursive(&entry, primary_suffix, false, out);
+        }
+    }
+}
+
+/// コマンド名一覧を取得（再帰）
+///
+/// `commands_dir` 配下を再帰的に走査し、`.prompt.md` / `.md` ファイルを列挙する。
+/// 中間ディレクトリ名は戻り値に含めない。
 ///
 /// # Arguments
 ///
 /// * `commands_dir` - コマンドディレクトリのパス
 ///
 /// # Returns
-/// コマンド名の一覧。
+/// `(コマンド名, ファイルパス)` の一覧。
 pub fn list_command_names(commands_dir: &Path) -> Vec<(String, PathBuf)> {
     if !commands_dir.is_dir() {
         return Vec::new();
     }
 
-    commands_dir
-        .read_dir_entries()
-        .into_iter()
-        .filter(|path| path.is_file())
-        .filter_map(|path| {
-            let file_name = path.file_name()?.to_str()?;
-            let name = if file_name.ends_with(PROMPT_SUFFIX) {
-                file_name.trim_end_matches(PROMPT_SUFFIX).to_string()
-            } else if file_name.ends_with(MARKDOWN_SUFFIX) {
-                file_name.trim_end_matches(MARKDOWN_SUFFIX).to_string()
-            } else {
-                return None;
-            };
-            Some((name, path))
-        })
-        .collect()
+    let mut out = Vec::new();
+    collect_component_files_recursive(commands_dir, PROMPT_SUFFIX, true, &mut out);
+    out
 }
 
 /// フック名一覧を取得

--- a/src/scan/components/tests.rs
+++ b/src/scan/components/tests.rs
@@ -69,7 +69,7 @@ fn test_list_agent_names_single_file() {
     let agent_file = temp_dir.path().join("my-agent.agent.md");
     fs::write(&agent_file, "# Agent").unwrap();
 
-    assert_eq!(names(list_agent_names(&agent_file)), vec!["my-agent.agent"]);
+    assert_eq!(names(list_agent_names(&agent_file)), vec!["my-agent"]);
 }
 
 #[test]
@@ -521,4 +521,217 @@ fn test_file_stem_name_double_extension() {
 fn test_file_stem_name_trailing_dot() {
     let path = Path::new("file.");
     assert_eq!(file_stem_name(path), Some("file".to_string()));
+}
+
+// =========================================================================
+// 再帰スキャン: list_skill_names
+// =========================================================================
+
+#[test]
+fn test_list_skill_names_one_level_nested() {
+    let temp_dir = TempDir::new().unwrap();
+    let skills_dir = temp_dir.path();
+
+    let nested = skills_dir.join("bar").join("foo");
+    fs::create_dir_all(&nested).unwrap();
+    fs::write(nested.join("SKILL.md"), "# Skill").unwrap();
+
+    let result = list_skill_names(skills_dir);
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].0, "foo");
+    assert_eq!(result[0].1, nested);
+}
+
+#[test]
+fn test_list_skill_names_multi_level_nested() {
+    let temp_dir = TempDir::new().unwrap();
+    let skills_dir = temp_dir.path();
+
+    let nested = skills_dir.join("a").join("b").join("baz");
+    fs::create_dir_all(&nested).unwrap();
+    fs::write(nested.join("SKILL.md"), "# Skill").unwrap();
+
+    let result = list_skill_names(skills_dir);
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].0, "baz");
+    assert_eq!(result[0].1, nested);
+}
+
+#[test]
+fn test_list_skill_names_does_not_descend_into_skill() {
+    let temp_dir = TempDir::new().unwrap();
+    let skills_dir = temp_dir.path();
+
+    // skill1 が SKILL.md を持つ
+    let skill1 = skills_dir.join("skill1");
+    fs::create_dir(&skill1).unwrap();
+    fs::write(skill1.join("SKILL.md"), "# Skill").unwrap();
+
+    // skill1/assets/inner にも SKILL.md がある（誤検出してはいけない）
+    let inner = skill1.join("assets").join("inner");
+    fs::create_dir_all(&inner).unwrap();
+    fs::write(inner.join("SKILL.md"), "# Inner").unwrap();
+
+    let result = list_skill_names(skills_dir);
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].0, "skill1");
+}
+
+#[test]
+fn test_list_skill_names_mixed_flat_and_nested() {
+    let temp_dir = TempDir::new().unwrap();
+    let skills_dir = temp_dir.path();
+
+    // 直下: skills/foo/SKILL.md
+    let flat = skills_dir.join("foo");
+    fs::create_dir(&flat).unwrap();
+    fs::write(flat.join("SKILL.md"), "# foo").unwrap();
+
+    // ネスト: skills/bar/baz/SKILL.md
+    let nested = skills_dir.join("bar").join("baz");
+    fs::create_dir_all(&nested).unwrap();
+    fs::write(nested.join("SKILL.md"), "# baz").unwrap();
+
+    let mut result = names(list_skill_names(skills_dir));
+    result.sort();
+    assert_eq!(result, vec!["baz", "foo"]);
+}
+
+#[test]
+fn test_list_skill_names_duplicate_basename_in_nested() {
+    let temp_dir = TempDir::new().unwrap();
+    let skills_dir = temp_dir.path();
+
+    let a = skills_dir.join("a").join("foo");
+    let b = skills_dir.join("b").join("foo");
+    fs::create_dir_all(&a).unwrap();
+    fs::create_dir_all(&b).unwrap();
+    fs::write(a.join("SKILL.md"), "# a/foo").unwrap();
+    fs::write(b.join("SKILL.md"), "# b/foo").unwrap();
+
+    // scan 層では衝突検出しない（呼び出し側 build_components の責務）
+    let mut result = names(list_skill_names(skills_dir));
+    result.sort();
+    assert_eq!(result, vec!["foo", "foo"]);
+}
+
+// =========================================================================
+// 再帰スキャン: list_agent_names
+// =========================================================================
+
+#[test]
+fn test_list_agent_names_one_level_nested() {
+    let temp_dir = TempDir::new().unwrap();
+    let agents_dir = temp_dir.path();
+
+    let nested = agents_dir.join("bar");
+    fs::create_dir(&nested).unwrap();
+    fs::write(nested.join("foo.agent.md"), "# Agent").unwrap();
+
+    let result = list_agent_names(agents_dir);
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].0, "foo");
+    assert_eq!(result[0].1, nested.join("foo.agent.md"));
+}
+
+#[test]
+fn test_list_agent_names_multi_level_nested() {
+    let temp_dir = TempDir::new().unwrap();
+    let agents_dir = temp_dir.path();
+
+    let nested = agents_dir.join("a").join("b");
+    fs::create_dir_all(&nested).unwrap();
+    fs::write(nested.join("foo.agent.md"), "# Agent").unwrap();
+
+    let result = list_agent_names(agents_dir);
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].0, "foo");
+    assert_eq!(result[0].1, nested.join("foo.agent.md"));
+}
+
+#[test]
+fn test_list_agent_names_recursive_skips_non_md() {
+    let temp_dir = TempDir::new().unwrap();
+    let agents_dir = temp_dir.path();
+
+    let nested = agents_dir.join("nested");
+    fs::create_dir(&nested).unwrap();
+    fs::write(nested.join("notes.txt"), "skip").unwrap();
+    fs::write(nested.join("foo.agent.md"), "# Agent").unwrap();
+
+    let result = names(list_agent_names(agents_dir));
+    assert_eq!(result, vec!["foo"]);
+}
+
+// =========================================================================
+// 再帰スキャン: list_command_names
+// =========================================================================
+
+#[test]
+fn test_list_command_names_one_level_nested() {
+    let temp_dir = TempDir::new().unwrap();
+    let commands_dir = temp_dir.path();
+
+    let nested = commands_dir.join("bar");
+    fs::create_dir(&nested).unwrap();
+    fs::write(nested.join("foo.prompt.md"), "# Cmd").unwrap();
+
+    let result = list_command_names(commands_dir);
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].0, "foo");
+    assert_eq!(result[0].1, nested.join("foo.prompt.md"));
+}
+
+// =========================================================================
+// 再帰スキャン: symlink ループ防止
+// =========================================================================
+
+#[cfg(unix)]
+#[test]
+fn test_list_skill_names_does_not_follow_symlinks() {
+    use std::os::unix::fs::symlink;
+
+    let temp_dir = TempDir::new().unwrap();
+    let skills_dir = temp_dir.path();
+
+    // 通常の skill
+    let skill1 = skills_dir.join("skill1");
+    fs::create_dir(&skill1).unwrap();
+    fs::write(skill1.join("SKILL.md"), "# Skill1").unwrap();
+
+    // 自分自身を指す symlink — 辿ったら無限ループ
+    symlink(skills_dir, skills_dir.join("loop")).unwrap();
+
+    let mut result = names(list_skill_names(skills_dir));
+    result.sort();
+    assert_eq!(result, vec!["skill1"]);
+}
+
+#[cfg(unix)]
+#[test]
+fn test_list_agent_names_does_not_follow_symlinks() {
+    use std::os::unix::fs::symlink;
+
+    let temp_dir = TempDir::new().unwrap();
+    let agents_dir = temp_dir.path();
+
+    fs::write(agents_dir.join("a.agent.md"), "# Agent").unwrap();
+    symlink(agents_dir, agents_dir.join("loop")).unwrap();
+
+    let result = names(list_agent_names(agents_dir));
+    assert_eq!(result, vec!["a"]);
+}
+
+#[test]
+fn test_list_command_names_multi_level_nested() {
+    let temp_dir = TempDir::new().unwrap();
+    let commands_dir = temp_dir.path();
+
+    let nested = commands_dir.join("a").join("b");
+    fs::create_dir_all(&nested).unwrap();
+    fs::write(nested.join("foo.prompt.md"), "# Cmd").unwrap();
+
+    let result = list_command_names(commands_dir);
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].0, "foo");
 }

--- a/src/target/antigravity_test.rs
+++ b/src/target/antigravity_test.rs
@@ -151,6 +151,25 @@ fn test_antigravity_placement_with_hierarchy() {
 }
 
 #[test]
+fn test_antigravity_placement_location_skill_with_prefixed_name() {
+    let target = AntigravityTarget::new();
+    let project_root = Path::new("/project");
+    let origin = PluginOrigin::from_marketplace("official", "my-plugin");
+
+    let ctx = PlacementContext {
+        component: ComponentRef::new(ComponentKind::Skill, "myplugin_foo"),
+        origin: &origin,
+        scope: PlacementScope::new(Scope::Project),
+        project: ProjectContext::new(project_root),
+    };
+    let location = target.placement_location(&ctx).unwrap();
+    assert_eq!(
+        location.as_path(),
+        Path::new("/project/.agent/skills/official/my-plugin/myplugin_foo")
+    );
+}
+
+#[test]
 fn test_antigravity_list_placed_empty_dir() {
     let target = AntigravityTarget::new();
     let temp_dir = TempDir::new().unwrap();

--- a/src/target/codex_test.rs
+++ b/src/target/codex_test.rs
@@ -102,6 +102,44 @@ fn test_codex_placement_location_instruction() {
 }
 
 #[test]
+fn test_codex_placement_location_skill_with_prefixed_name() {
+    let target = CodexTarget::new();
+    let project_root = Path::new("/project");
+    let origin = PluginOrigin::from_marketplace("official", "my-plugin");
+
+    let ctx = PlacementContext {
+        component: ComponentRef::new(ComponentKind::Skill, "myplugin_foo"),
+        origin: &origin,
+        scope: PlacementScope::new(Scope::Project),
+        project: ProjectContext::new(project_root),
+    };
+    let location = target.placement_location(&ctx).unwrap();
+    assert_eq!(
+        location.as_path(),
+        Path::new("/project/.codex/skills/official/my-plugin/myplugin_foo")
+    );
+}
+
+#[test]
+fn test_codex_placement_location_agent_with_prefixed_name() {
+    let target = CodexTarget::new();
+    let project_root = Path::new("/project");
+    let origin = PluginOrigin::from_marketplace("official", "my-plugin");
+
+    let ctx = PlacementContext {
+        component: ComponentRef::new(ComponentKind::Agent, "myplugin_foo"),
+        origin: &origin,
+        scope: PlacementScope::new(Scope::Project),
+        project: ProjectContext::new(project_root),
+    };
+    let location = target.placement_location(&ctx).unwrap();
+    assert_eq!(
+        location.as_path(),
+        Path::new("/project/.codex/agents/official/my-plugin/myplugin_foo.agent.md")
+    );
+}
+
+#[test]
 fn test_codex_command_not_supported() {
     let target = CodexTarget::new();
     let project_root = Path::new("/project");

--- a/src/target/copilot_test.rs
+++ b/src/target/copilot_test.rs
@@ -142,6 +142,35 @@ fn test_copilot_placement_location_instruction() {
     );
 }
 
+#[test]
+fn test_copilot_placement_location_with_prefixed_name() {
+    let target = CopilotTarget::new();
+    let project_root = Path::new("/project");
+    let origin = PluginOrigin::from_marketplace("official", "my-plugin");
+
+    let skill_ctx = PlacementContext {
+        component: ComponentRef::new(ComponentKind::Skill, "myplugin_foo"),
+        origin: &origin,
+        scope: PlacementScope::new(Scope::Project),
+        project: ProjectContext::new(project_root),
+    };
+    assert_eq!(
+        target.placement_location(&skill_ctx).unwrap().as_path(),
+        Path::new("/project/.github/skills/official/my-plugin/myplugin_foo")
+    );
+
+    let cmd_ctx = PlacementContext {
+        component: ComponentRef::new(ComponentKind::Command, "myplugin_foo"),
+        origin: &origin,
+        scope: PlacementScope::new(Scope::Project),
+        project: ProjectContext::new(project_root),
+    };
+    assert_eq!(
+        target.placement_location(&cmd_ctx).unwrap().as_path(),
+        Path::new("/project/.github/prompts/official/my-plugin/myplugin_foo.prompt.md")
+    );
+}
+
 // =============================================================================
 // Claude Code → Copilot 変換テスト
 // =============================================================================

--- a/src/target/gemini_cli_test.rs
+++ b/src/target/gemini_cli_test.rs
@@ -123,6 +123,25 @@ fn test_gemini_cli_placement_location_skill_project() {
 }
 
 #[test]
+fn test_gemini_cli_placement_location_skill_with_prefixed_name() {
+    let target = GeminiCliTarget::new();
+    let project_root = Path::new("/project");
+    let origin = PluginOrigin::from_marketplace("official", "my-plugin");
+
+    let ctx = PlacementContext {
+        component: ComponentRef::new(ComponentKind::Skill, "myplugin_foo"),
+        origin: &origin,
+        scope: PlacementScope::new(Scope::Project),
+        project: ProjectContext::new(project_root),
+    };
+    let location = target.placement_location(&ctx).unwrap();
+    assert_eq!(
+        location.as_path(),
+        Path::new("/project/.gemini/skills/official/my-plugin/myplugin_foo")
+    );
+}
+
+#[test]
 fn test_gemini_cli_placement_location_instruction_personal() {
     let target = GeminiCliTarget::new();
     let project_root = Path::new("/project");


### PR DESCRIPTION
## 概要

GitHub から取得した Skills (`SKILL.md`) / Agents (`*.agent.md`) / Commands (`*.prompt.md`) コンポーネントが、サブディレクトリにネストされた構造（例: `bar/foo/SKILL.md`）でも全 4 ターゲット（Codex / Copilot / Antigravity / Gemini CLI）で正しく検出・配置されるように、スキャンを再帰化し、`Component.name` 段階で「**プラグイン名 + アンダースコア + 元名**」（例: `myplugin_foo`）を付与する平坦化処理を導入した。

## 変更の種類

- ✨ [New Feature]: Component name 平坦化と同名衝突検出
- ♻️ [Refactoring]: scan 層 list_*_names の再帰化
- 🧪 [Tests]: target placement_location 回帰テスト追加
- 💥 [Breaking]: `Component.name` セマンティクス変更（`{plugin}_{base}` 形式）

## 詳細な変更内容

### scan 層 (`src/scan/components.rs`)

- `list_skill_names`: 再帰走査で `SKILL.md` を持つディレクトリを採取（中間ディレクトリ名は捨てる）
- `list_agent_names` / `list_command_names`: ヘルパー `collect_component_files_recursive` 経由で再帰化
  - ルート直下のみ `.md` フォールバックを許可、ネスト先は primary suffix (`.agent.md` / `.prompt.md`) のみ採取（誤検出防止）
- 単一ファイル Agent の name を `.agent.md` → `.md` の順で suffix strip するよう修正
- `is_symlink` ガードで symlink を再帰対象から除外（無限ループ防止）

### plugin/install 層 (`src/plugin/plugin_content.rs` 他)

- `flatten_name(plugin_name, original_name) -> String` 純粋関数を追加
- `Plugin::new` を `Result<Self>` に変更し、衝突検出を `?` 伝播
- `push_components_with_collision_check` で同一 kind 内の name 重複を `PlmError::Validation` で検出（部分インストール禁止）
- `From<CachedPackage> for MarketplaceContent` → `TryFrom` に変更
- 呼び出し元（`loader.rs` / `install.rs` / `marketplace/download.rs` / `commands/import.rs` / `application/info.rs`）を `?` 伝播対応
- 一覧取得経路（`cache.rs::list_installed` / `application/catalog.rs::list_installed_plugins`）は TUI 描画を汚さないため silent fallback（コメント明記）

### target 層

- 本体コードは無変更
- 4 ターゲット (Codex / Copilot / Antigravity / Gemini CLI) で prefix 付き name (`myplugin_foo`) に対する `placement_location` 回帰テストを追加

## システム図

```mermaid
flowchart TD
    Cache[plugin cache<br/>~/.plm/cache/...] --> Scan
    Scan[src/scan/components.rs<br/>list_*_names 再帰走査<br/>戻り値は元名のみ]
    Scan -->|Vec&lt;String, PathBuf&gt;<br/>'foo'| Build

    Build["Plugin::build_components<br/>plugin_name = manifest.name"]
    Build --> Flatten

    Flatten["flatten_name(plugin, original)<br/>→ 'myplugin_foo'"]
    Flatten --> Collision

    Collision{HashMap で<br/>同 kind 内重複?}
    Collision -- 重複なし --> Component[Vec&lt;Component&gt; を返す]
    Collision -- 重複あり --> Err["Err(PlmError::Validation)<br/>install 全体を中断"]

    Component --> Place
    Place[place_plugin → placement_location]
    Place --> Deploy
    Deploy["~/.codex/, ~/.copilot/,<br/>~/.gemini/antigravity/, ~/.gemini/skills/<br/>に myplugin_foo として配置"]

    style Flatten fill:#fff4ce
    style Collision fill:#fff4ce
    style Err fill:#ffd6d6
```

## 関連Issue

なし（spec 004 の自律実装）

## テスト

- [x] `cargo fmt` 適用済み
- [x] `cargo check --all-targets`: エラー 0 件
- [x] `cargo test`: **1387 passed / 0 failed**
- [x] Codex CLI による多段レビュー実施 (review-001 → review-003)
  - review-001 で 3 件指摘 → 修正
  - review-002 で 2 件指摘（symlink 無限再帰、`eprintln!` が TUI 描画を汚す）→ 修正
  - review-003 で「問題なし」を確認

### 追加した主なテスト

- `flatten_name` 純粋関数（基本／元名にアンダースコア／プラグイン名にアンダースコア／空文字）
- `list_skill_names` 再帰: 1階層／多階層ネスト／skill 内部誤検出回避／直下＋ネスト混在
- `list_agent_names` / `list_command_names` 再帰: 各種ネスト＋拡張子フィルタ
- symlink 無限再帰防止（cfg(unix) ガード）
- `Plugin::build_components` 衝突検出: kind 内重複／kind 間 OK／エラーメッセージ内容
- 4 ターゲットの `placement_location` で prefix 付き name 入力

## レビューポイント

1. **破壊的変更の影響範囲**: `Component.name` が `{plugin}_{base}` 形式に変わるため、既存の `list` / `info` / `uninstall` でユーザーが指定する名前が prefix 付きになります。release notes での明記が必要です。
2. **`From<CachedPackage>` → `TryFrom` への移行**: API 形状の変更により、`MarketplaceContent::try_from(cached)` を呼ぶすべての callsite で `?` 伝播か `unwrap()` が必要になります。テスト fixture は機械的に `.unwrap()` を追加しました。
3. **list 系経路の silent fallback**: TUI 経由で呼ばれる `list_installed` / `list_installed_plugins` は `eprintln!` を避け silent skip にしています。install 経路では Validation エラーが厳密に伝播されます。
4. **`.md` フォールバックのスコープ**: ネスト先での誤検出を避けるため、ルート直下のみ `.md` フォールバックを許可しています（既存の Claude Code 互換挙動）。
5. **link / unlink / import コマンドはスコープ外**: `Component.name` のセマンティクス変更が link 系のキー一致に影響する可能性は別タスクで対応予定です。

## チェックリスト

- [x] セルフレビュー実施
- [x] cargo fmt でフォーマット済み
- [x] cargo check でコンパイルエラーなし
- [x] cargo test で全テスト通過
- [x] 破壊的変更を明記