### PR TITLE
💥 [Breaking] / ✨ / ♻️ install パスを 3 階層から 2 階層（フラット）へ変更

### DIFF
--- a/src/application/catalog.rs
+++ b/src/application/catalog.rs
@@ -23,7 +23,18 @@ pub fn list_installed_plugins(cache: &dyn PackageCacheAccess) -> Result<Vec<Inst
     // 一覧取得経路ではスキャン失敗（重複検出など）は握りつぶして列挙を続行する。
     // TUI 経由でも呼ばれるため stderr への直接出力は避ける。
     // 厳密検証が必要な経路（install 等）は `Plugin::new` を直接呼ぶこと。
-    let plugins = list_installed(cache)?
+    let packages: Vec<_> = list_installed(cache)?.into_iter().collect();
+
+    // 「プラグイン数 × 配置済みコンポーネント数」の線形走査を避けるため、
+    // 既知 plugin_name 集合と deployed から「配置済みコンポーネントを 1 件以上
+    // 持つ plugin_name 集合」を 1 度だけ構築し、各 is_enabled 判定を O(1) に。
+    let known_plugin_names: HashSet<String> = packages
+        .iter()
+        .map(|pkg| pkg.manifest().name.clone())
+        .collect();
+    let deployed_plugins = meta::build_deployed_plugin_set(&deployed, &known_plugin_names);
+
+    let plugins = packages
         .into_iter()
         .filter_map(|pkg| {
             let name = pkg.manifest().name.clone();
@@ -33,8 +44,8 @@ pub fn list_installed_plugins(cache: &dyn PackageCacheAccess) -> Result<Vec<Inst
             let plugin =
                 Plugin::new(pkg.manifest().clone(), pkg.path().to_path_buf(), origin).ok()?;
             // flatten_name の prefix は manifest.name に基づくため
-            // is_enabled には manifest.name を渡す。
-            let enabled = meta::is_enabled(pkg.path(), marketplace_str, name.as_str(), &deployed);
+            // is_enabled_indexed には manifest.name を渡す。
+            let enabled = meta::is_enabled_indexed(pkg.path(), name.as_str(), &deployed_plugins);
 
             Some(InstalledPlugin::from_cached_package(
                 plugin,

--- a/src/application/catalog.rs
+++ b/src/application/catalog.rs
@@ -23,7 +23,7 @@ pub fn list_installed_plugins(cache: &dyn PackageCacheAccess) -> Result<Vec<Inst
     // 一覧取得経路ではスキャン失敗（重複検出など）は握りつぶして列挙を続行する。
     // TUI 経由でも呼ばれるため stderr への直接出力は避ける。
     // 厳密検証が必要な経路（install 等）は `Plugin::new` を直接呼ぶこと。
-    let packages: Vec<_> = list_installed(cache)?.into_iter().collect();
+    let packages = list_installed(cache)?;
 
     // 「プラグイン数 × 配置済みコンポーネント数」の線形走査を避けるため、
     // 既知 plugin_name 集合と deployed から「配置済みコンポーネントを 1 件以上

--- a/src/application/catalog.rs
+++ b/src/application/catalog.rs
@@ -5,6 +5,7 @@
 use crate::error::Result;
 use crate::plugin::{list_installed, meta, InstalledPlugin, PackageCacheAccess, Plugin};
 use crate::target::{list_all_placed, PluginOrigin};
+use std::collections::HashSet;
 use std::path::PathBuf;
 
 /// インストール済みプラグインの一覧を取得
@@ -15,9 +16,9 @@ use std::path::PathBuf;
 ///
 /// * `cache` - インストール済みプラグインを列挙するためのパッケージキャッシュアクセサ
 pub fn list_installed_plugins(cache: &dyn PackageCacheAccess) -> Result<Vec<InstalledPlugin>> {
-    // デプロイ済みプラグイン集合を事前取得（パフォーマンス改善）
+    // デプロイ済みコンポーネントの flattened_name 集合を事前取得（パフォーマンス改善）
     let project_root = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-    let deployed = list_all_placed(&project_root);
+    let deployed: HashSet<String> = list_all_placed(&project_root);
 
     // 一覧取得経路ではスキャン失敗（重複検出など）は握りつぶして列挙を続行する。
     // TUI 経由でも呼ばれるため stderr への直接出力は避ける。
@@ -31,7 +32,9 @@ pub fn list_installed_plugins(cache: &dyn PackageCacheAccess) -> Result<Vec<Inst
             let origin = PluginOrigin::from_marketplace(marketplace_str, ops_key);
             let plugin =
                 Plugin::new(pkg.manifest().clone(), pkg.path().to_path_buf(), origin).ok()?;
-            let enabled = meta::is_enabled(pkg.path(), marketplace_str, ops_key, &deployed);
+            // flatten_name の prefix は manifest.name に基づくため
+            // is_enabled には manifest.name を渡す。
+            let enabled = meta::is_enabled(pkg.path(), marketplace_str, name.as_str(), &deployed);
 
             Some(InstalledPlugin::from_cached_package(
                 plugin,

--- a/src/application/info.rs
+++ b/src/application/info.rs
@@ -212,7 +212,9 @@ fn build_plugin_info(content: MarketplaceContent) -> Result<PluginInfo> {
 
     let installed_at = meta::resolve_installed_at(&cache_path, Some(&manifest));
 
-    let enabled = resolve_enabled(&cache_path, marketplace_key, &dir_name);
+    // flatten_name の prefix は manifest.name に基づくため
+    // is_enabled には manifest.name を渡す。
+    let enabled = resolve_enabled(&cache_path, marketplace_key, manifest.name.as_str());
 
     // InstalledPlugin を組み立てる（list_installed_plugins と同じく marketplace は Option<String> を保つ）
     let id = Some(dir_name.clone());
@@ -235,11 +237,11 @@ fn build_plugin_info(content: MarketplaceContent) -> Result<PluginInfo> {
 ///
 /// * `cache_path` - Path to the plugin's cache directory.
 /// * `marketplace` - Marketplace key (e.g. `"github"`).
-/// * `id` - identifier used to match deployed entries.
-fn resolve_enabled(cache_path: &Path, marketplace: &str, id: &str) -> bool {
+/// * `plugin_name` - `PluginManifest.name`。`flattened_name` の prefix 判定に使う。
+fn resolve_enabled(cache_path: &Path, marketplace: &str, plugin_name: &str) -> bool {
     let project_root = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
     let deployed = list_all_placed(&project_root);
-    meta::is_enabled(cache_path, marketplace, id, &deployed)
+    meta::is_enabled(cache_path, marketplace, plugin_name, &deployed)
 }
 
 #[cfg(test)]

--- a/src/application/lifecycle.rs
+++ b/src/application/lifecycle.rs
@@ -11,7 +11,8 @@
 
 use crate::component::Component;
 use crate::plugin::{
-    cleanup_plugin_directories, load_plugin, PackageCacheAccess, PluginAction, PluginIntent,
+    cleanup_legacy_hierarchy, cleanup_plugin_directories, load_plugin, PackageCacheAccess,
+    PluginAction, PluginIntent,
 };
 use crate::target::{all_targets, OperationResult};
 use std::path::Path;
@@ -68,6 +69,7 @@ pub fn disable_plugin(
         };
         for target in &targets_to_cleanup {
             cleanup_plugin_directories(target.kind(), plugin.origin(), project_root);
+            cleanup_legacy_hierarchy(target.kind(), plugin.origin(), project_root);
         }
     }
 

--- a/src/commands/sync_test.rs
+++ b/src/commands/sync_test.rs
@@ -72,19 +72,22 @@ fn test_sync_project_scope_no_components_zero_exit() {
         .stdout(predicate::str::contains("No components to sync"));
 }
 
+// Phase 2 ではフラットな placement_location と 3 階層の scanner が不整合になり
+// このシナリオのソース／宛先パスを単一 fixture で両立できないため一時的に
+// `#[ignore]` する。Phase 4（scanner フラット化）で再有効化し、
+// 同時に fixture をフラット 2 階層へ更新する。
 #[test]
+#[ignore = "Phase 4 で scanner をフラット化した後に再有効化"]
 fn test_sync_creates_component() {
     // Actually create and sync a component
     let temp = TempDir::new().unwrap();
 
-    // Create source skill directory structure
+    // Phase 4 で fixture をフラット化する。
     let skill_dir = temp
         .path()
         .join(".codex")
         .join("skills")
-        .join("github")
-        .join("test-plugin")
-        .join("my-skill");
+        .join("test-plugin_my-skill");
     fs::create_dir_all(&skill_dir).unwrap();
     fs::write(skill_dir.join("SKILL.md"), "# Test Skill").unwrap();
 
@@ -98,14 +101,12 @@ fn test_sync_creates_component() {
         .success()
         .stdout(predicate::str::contains("Synced"));
 
-    // Verify the skill was copied to copilot
+    // 配置先はフラット 2 階層: <base>/skills/<flattened_name>
     let target_skill = temp
         .path()
         .join(".github")
         .join("skills")
-        .join("github")
-        .join("test-plugin")
-        .join("my-skill");
+        .join("test-plugin_my-skill");
     assert!(target_skill.exists(), "Skill should be synced to copilot");
 }
 

--- a/src/commands/sync_test.rs
+++ b/src/commands/sync_test.rs
@@ -72,17 +72,12 @@ fn test_sync_project_scope_no_components_zero_exit() {
         .stdout(predicate::str::contains("No components to sync"));
 }
 
-// Phase 2 ではフラットな placement_location と 3 階層の scanner が不整合になり
-// このシナリオのソース／宛先パスを単一 fixture で両立できないため一時的に
-// `#[ignore]` する。Phase 4（scanner フラット化）で再有効化し、
-// 同時に fixture をフラット 2 階層へ更新する。
 #[test]
-#[ignore = "Phase 4 で scanner をフラット化した後に再有効化"]
 fn test_sync_creates_component() {
     // Actually create and sync a component
     let temp = TempDir::new().unwrap();
 
-    // Phase 4 で fixture をフラット化する。
+    // フラット 2 階層: .codex/skills/<flattened_name>/SKILL.md
     let skill_dir = temp
         .path()
         .join(".codex")

--- a/src/install.rs
+++ b/src/install.rs
@@ -168,7 +168,6 @@ pub fn place_plugin(request: &PlaceRequest) -> PlaceResult {
         PluginOrigin::from_cached_plugin(request.scanned.marketplace(), request.scanned.id());
 
     for target in request.targets {
-        let successes_before = successes.len();
         let failures_before = failures.len();
 
         for component in &request.scanned.components {
@@ -270,13 +269,14 @@ pub fn place_plugin(request: &PlaceRequest) -> PlaceResult {
         }
 
         // 旧 3 階層構造 (<base>/<plural>/<mp>/<plg>) のクリーンアップは
-        // 当該 target 内の配置がすべて成功し、かつ少なくとも 1 件配置できた
-        // 場合にのみ実行する。途中で failure があった場合に旧階層を消すと
-        // 「新旧どちらも残らない」状態を招きうるため、ロールバック相当として
-        // 旧階層を温存する。
+        // 当該 target 内で failure が発生しなかった場合に実行する。
+        // 途中で failure があった場合に旧階層を消すと「新旧どちらも残らない」
+        // 状態を招きうるため、ロールバック相当として旧階層を温存する。
+        // 一方、配置件数が 0 件（target がサポートしないコンポーネントだけ
+        // の場合など）でも failure がなければ、install 実行時の自動クリーン
+        // アップ対象とし旧階層が永続するのを避ける。
         let target_had_failure = failures.len() > failures_before;
-        let target_had_success = successes.len() > successes_before;
-        if target_had_success && !target_had_failure {
+        if !target_had_failure {
             cleanup_legacy_hierarchy(target.kind(), &origin, request.project_root);
         }
     }

--- a/src/install.rs
+++ b/src/install.rs
@@ -3,7 +3,9 @@ use std::path::{Path, PathBuf};
 use crate::component::{AgentFormat, CommandFormat, ComponentKind, Scope};
 use crate::component::{Component, ComponentDeployment, ConversionConfig, DeploymentOutput};
 use crate::component::{ComponentRef, PlacementContext, PlacementScope, ProjectContext};
-use crate::plugin::{MarketplaceContent, PackageCache, PackageCacheAccess};
+use crate::plugin::{
+    cleanup_legacy_hierarchy, MarketplaceContent, PackageCache, PackageCacheAccess,
+};
 use crate::source::parse_source;
 use crate::target::{PluginOrigin, Target, TargetKind};
 
@@ -166,6 +168,10 @@ pub fn place_plugin(request: &PlaceRequest) -> PlaceResult {
         PluginOrigin::from_cached_plugin(request.scanned.marketplace(), request.scanned.id());
 
     for target in request.targets {
+        // 旧 3 階層構造 (<base>/<plural>/<mp>/<plg>) が残っている場合に掃除する。
+        // フラット 2 階層配置への移行をサポートするため、新規配置の前に実行する。
+        cleanup_legacy_hierarchy(target.kind(), &origin, request.project_root);
+
         for component in &request.scanned.components {
             if !target.supports(component.kind) {
                 continue;

--- a/src/install.rs
+++ b/src/install.rs
@@ -168,9 +168,8 @@ pub fn place_plugin(request: &PlaceRequest) -> PlaceResult {
         PluginOrigin::from_cached_plugin(request.scanned.marketplace(), request.scanned.id());
 
     for target in request.targets {
-        // 旧 3 階層構造 (<base>/<plural>/<mp>/<plg>) が残っている場合に掃除する。
-        // フラット 2 階層配置への移行をサポートするため、新規配置の前に実行する。
-        cleanup_legacy_hierarchy(target.kind(), &origin, request.project_root);
+        let successes_before = successes.len();
+        let failures_before = failures.len();
 
         for component in &request.scanned.components {
             if !target.supports(component.kind) {
@@ -268,6 +267,17 @@ pub fn place_plugin(request: &PlaceRequest) -> PlaceResult {
                     });
                 }
             }
+        }
+
+        // 旧 3 階層構造 (<base>/<plural>/<mp>/<plg>) のクリーンアップは
+        // 当該 target 内の配置がすべて成功し、かつ少なくとも 1 件配置できた
+        // 場合にのみ実行する。途中で failure があった場合に旧階層を消すと
+        // 「新旧どちらも残らない」状態を招きうるため、ロールバック相当として
+        // 旧階層を温存する。
+        let target_had_failure = failures.len() > failures_before;
+        let target_had_success = successes.len() > successes_before;
+        if target_had_success && !target_had_failure {
+            cleanup_legacy_hierarchy(target.kind(), &origin, request.project_root);
         }
     }
 

--- a/src/install_test.rs
+++ b/src/install_test.rs
@@ -290,14 +290,16 @@ fn test_place_plugin_uses_id_for_origin() {
         project_root: project_dir.path(),
     });
 
-    // PluginOrigin の plugin フィールドが id() ("owner--repo") を使用していることを
-    // 配置先パスに "owner--repo" が含まれることで間接的に検証
+    // フラット配置: target_path 末尾は flattened_name (= "{plugin}_{original}")
     assert_eq!(result.plugin_name, "My Plugin");
     assert_eq!(result.successes.len(), 1);
+    let component_name = &result.successes[0].component_name;
     let target_path = result.successes[0].target_path.to_string_lossy();
     assert!(
-        target_path.contains("owner--repo"),
-        "target path should contain id 'owner--repo', got: {}",
+        target_path.ends_with(component_name.as_str())
+            || target_path.contains(&format!("/{}", component_name)),
+        "target path should end with flattened component name '{}', got: {}",
+        component_name,
         target_path
     );
 }

--- a/src/install_test.rs
+++ b/src/install_test.rs
@@ -294,13 +294,20 @@ fn test_place_plugin_uses_id_for_origin() {
     assert_eq!(result.plugin_name, "My Plugin");
     assert_eq!(result.successes.len(), 1);
     let component_name = &result.successes[0].component_name;
-    let target_path = result.successes[0].target_path.to_string_lossy();
+    let target_path = &result.successes[0].target_path;
+    let last_segment = target_path
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("");
+    // ディレクトリ配置 (Skill) は完全一致、ファイル配置 (Agent/Command/Hook) は
+    // `<flattened_name>.<ext>` のため接頭辞 + `.` で判定する。
+    let matches = last_segment == component_name.as_str()
+        || last_segment.starts_with(&format!("{}.", component_name));
     assert!(
-        target_path.ends_with(component_name.as_str())
-            || target_path.contains(&format!("/{}", component_name)),
-        "target path should end with flattened component name '{}', got: {}",
+        matches,
+        "target path last segment should be flattened component name '{}', got: {}",
         component_name,
-        target_path
+        target_path.display()
     );
 }
 

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -16,7 +16,7 @@ mod version;
 pub use action::PluginAction;
 pub(crate) use cache::list_installed;
 pub use cache::{CachedPackage, PackageCache, PackageCacheAccess};
-pub(crate) use cleanup::cleanup_plugin_directories;
+pub(crate) use cleanup::{cleanup_legacy_hierarchy, cleanup_plugin_directories};
 pub use installed::InstalledPlugin;
 pub use intent::PluginIntent;
 pub(crate) use loader::load_plugin;

--- a/src/plugin/cleanup.rs
+++ b/src/plugin/cleanup.rs
@@ -9,6 +9,7 @@ use crate::fs::{FileSystem, RealFs};
 use crate::target::{PluginOrigin, TargetKind};
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 /// プラグインディレクトリをクリーンアップ
@@ -277,19 +278,24 @@ fn dir_is_empty(path: &Path) -> bool {
         .unwrap_or(false)
 }
 
-/// quarantine 名に使うランダム性のあるサフィックスを生成する。
+/// quarantine 名に使うサフィックスを生成する。
 ///
-/// 暗号学的乱数は不要（rename の race を縮小する目的のみ）。`SystemTime` の
-/// ナノ秒下位ビットとプロセス ID + ポインタアドレスを混ぜてユニーク性を稼ぐ。
+/// 暗号学的乱数は不要（rename の race を縮小する目的のみ）。同一親配下での
+/// 一意性確保が目的のため、`SystemTime` のナノ秒下位ビット + プロセス ID +
+/// プロセス内単調カウンタを混ぜる。
+///
+/// **注意**: 以前はポインタアドレスも混ぜていたが、quarantine ディレクトリ名
+/// としてアドレスがディスク上に露出するのを避けるため除外した。
 fn quarantine_suffix() -> String {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_nanos())
+        .map(|d| d.as_nanos() as u64)
         .unwrap_or(0);
-    let pid = std::process::id() as u128;
-    let stack_addr = &nanos as *const _ as usize as u128;
-    let mixed = nanos ^ (pid << 32) ^ stack_addr;
-    format!("{:016x}", mixed as u64)
+    let pid = std::process::id() as u64;
+    let counter = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let mixed = nanos ^ pid.rotate_left(32) ^ counter.rotate_left(48);
+    format!("{:016x}", mixed)
 }
 
 fn remove_if_empty(fs: &dyn FileSystem, path: &Path) {

--- a/src/plugin/cleanup.rs
+++ b/src/plugin/cleanup.rs
@@ -162,6 +162,20 @@ fn is_safe_path_segment(segment: &str) -> bool {
 /// （legacy + kind_root + mp_dir）/ depth=2 / file_name 一致 / 空親昇格削除
 /// に加え、削除前に同一親配下の `<plugin>.plm-quarantine-<random>` 名へ
 /// `rename` してから `remove_dir_all` する quarantine 方式で race を縮小する。
+///
+/// # I/O 抽象化方針
+///
+/// 同モジュールの `cleanup_plugin_directories` は `&dyn FileSystem` を受け取る
+/// が、本関数（および下請けの `sweep_legacy_one` / `dir_is_empty` /
+/// `path_is_symlink`）は `std::fs` を直接呼び出している。これは以下の API が
+/// 12 ガードの安全性確保に必須だが現状 `FileSystem` trait 未提供のため:
+/// - `std::fs::symlink_metadata` (シンボリックリンク非追従の type 判定)
+/// - `Path::canonicalize` (kind_root 配下に厳密に含まれるかの判定)
+/// - `std::fs::remove_dir` (空親ディレクトリ単独の昇格削除)
+///
+/// `FileSystem` 抽象に上記 3 点を追加して再注入する余地はあるが、本関数は
+/// 旧階層からの一回限りのマイグレーション用途であり、MockFs 化の費用対効果が
+/// 限定的なため当面 `std::fs` 直接呼び出しを維持する。
 pub(crate) fn cleanup_legacy_hierarchy(
     kind: TargetKind,
     origin: &PluginOrigin,

--- a/src/plugin/cleanup.rs
+++ b/src/plugin/cleanup.rs
@@ -181,11 +181,15 @@ pub(crate) fn cleanup_legacy_hierarchy(
     origin: &PluginOrigin,
     project_root: &Path,
 ) {
+    // HOME が相対パス（例: "." / "tmp"）の場合に personal sweep が
+    // カレント配下で quarantine rename + remove_dir_all を走らせるリスクを
+    // 避けるため、絶対パスのみ採用する。
     let home = std::env::var("HOME")
         .ok()
         .map(|s| s.trim().to_string())
         .filter(|s| !s.is_empty())
-        .map(PathBuf::from);
+        .map(PathBuf::from)
+        .filter(|p| p.is_absolute());
     cleanup_legacy_hierarchy_impl(kind, home.as_deref(), origin, project_root);
 }
 

--- a/src/plugin/cleanup.rs
+++ b/src/plugin/cleanup.rs
@@ -31,15 +31,39 @@ pub(crate) fn cleanup_plugin_directories(
     project_root: &Path,
 ) {
     let fs = RealFs;
-    // HOME="" や HOME="   " を未設定相当として扱う。
-    // そのまま PathBuf::from("") を使うと personal cleanup が `./.codex` 等の
-    // CWD 配下パスで走ってしまうため、trim 後に空なら None にフォールバックする。
-    let home = std::env::var("HOME")
-        .ok()
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
-        .map(PathBuf::from);
+    let home = resolve_home_dir();
     cleanup_plugin_directories_impl(&fs, kind, home.as_deref(), origin, project_root);
+}
+
+/// `HOME` 環境変数を正規化する。
+///
+/// 以下を一箇所で扱い、`cleanup_plugin_directories` と
+/// `cleanup_legacy_hierarchy` の両者で挙動が分岐しないようにする:
+/// - 未設定 / 空文字 / 空白のみは `None`
+/// - 非 UTF-8 値も `OsString` のまま受理（`var_os`）
+/// - 相対パス（例: `.` や `tmp`）は `None`。CWD 配下で
+///   `quarantine rename + remove_dir_all` が走るリスクを避けるため
+fn resolve_home_dir() -> Option<PathBuf> {
+    let home = std::env::var_os("HOME")?;
+
+    let home = match home.to_str() {
+        Some(s) => {
+            let trimmed = s.trim();
+            if trimmed.is_empty() {
+                return None;
+            }
+            PathBuf::from(trimmed)
+        }
+        None => {
+            let path = PathBuf::from(home);
+            if path.as_os_str().is_empty() {
+                return None;
+            }
+            path
+        }
+    };
+
+    home.is_absolute().then_some(home)
 }
 
 /// 内部実装 — `home` と `fs` を注入可能にし、テストから直接呼ぶ。
@@ -181,15 +205,9 @@ pub(crate) fn cleanup_legacy_hierarchy(
     origin: &PluginOrigin,
     project_root: &Path,
 ) {
-    // HOME が相対パス（例: "." / "tmp"）の場合に personal sweep が
-    // カレント配下で quarantine rename + remove_dir_all を走らせるリスクを
-    // 避けるため、絶対パスのみ採用する。
-    let home = std::env::var("HOME")
-        .ok()
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
-        .map(PathBuf::from)
-        .filter(|p| p.is_absolute());
+    // HOME 正規化（空白/空文字・相対パス・非 UTF-8 の扱い）は
+    // `cleanup_plugin_directories` と共通 helper `resolve_home_dir` に集約。
+    let home = resolve_home_dir();
     cleanup_legacy_hierarchy_impl(kind, home.as_deref(), origin, project_root);
 }
 

--- a/src/plugin/cleanup.rs
+++ b/src/plugin/cleanup.rs
@@ -7,7 +7,9 @@
 
 use crate::fs::{FileSystem, RealFs};
 use crate::target::{PluginOrigin, TargetKind};
+use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 /// プラグインディレクトリをクリーンアップ
 ///
@@ -147,6 +149,147 @@ fn is_safe_path_segment(segment: &str) -> bool {
         return false;
     }
     true
+}
+
+/// 旧 3 階層構造 `<base>/<kind_subdir>/<marketplace>/<plugin>` を一掃する
+///
+/// install/uninstall/disable のタイミングで呼ばれ、新しいフラット 2 階層
+/// 構造へ移行済みの環境から旧階層の残骸を除去する。
+///
+/// 安全性は「**誤削除防止のベストエフォート**」を方針とし、完全な TOCTOU
+/// 耐性は目指さない。`is_safe_path_segment` / canonicalize / symlink 除外
+/// （legacy + kind_root + mp_dir）/ depth=2 / file_name 一致 / 空親昇格削除
+/// に加え、削除前に同一親配下の `<plugin>.plm-quarantine-<random>` 名へ
+/// `rename` してから `remove_dir_all` する quarantine 方式で race を縮小する。
+pub(crate) fn cleanup_legacy_hierarchy(
+    kind: TargetKind,
+    origin: &PluginOrigin,
+    project_root: &Path,
+) {
+    let home = std::env::var("HOME")
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .map(PathBuf::from);
+    cleanup_legacy_hierarchy_impl(kind, home.as_deref(), origin, project_root);
+}
+
+/// 内部実装 — `home` を注入可能にしテストから直接呼ぶ。
+pub(crate) fn cleanup_legacy_hierarchy_impl(
+    kind: TargetKind,
+    home: Option<&Path>,
+    origin: &PluginOrigin,
+    project_root: &Path,
+) {
+    for (base, kind_subdir) in cleanup_specs(kind, home, project_root) {
+        sweep_legacy_one(&base, kind_subdir, origin);
+    }
+}
+
+/// 単一 (base, kind_subdir) について、12 ガードを通過した場合のみ
+/// `<base>/<kind_subdir>/<mp>/<plg>` を quarantine rename → remove_dir_all で除去し、
+/// 空になった親 (mp_dir / kind_root) を昇格削除する。
+fn sweep_legacy_one(base: &Path, kind_subdir: &str, origin: &PluginOrigin) {
+    // ガード 1: marketplace / plugin が安全な path-segment か
+    if !is_safe_path_segment(&origin.marketplace) || !is_safe_path_segment(&origin.plugin) {
+        return;
+    }
+
+    let kind_root = base.join(kind_subdir);
+    let mp_dir = kind_root.join(&origin.marketplace);
+    let legacy = mp_dir.join(&origin.plugin);
+
+    // ガード 2: legacy が存在
+    if !legacy.exists() {
+        return;
+    }
+
+    // ガード 3 / 11 / 12: legacy / kind_root / mp_dir のいずれかが symlink なら no-op
+    if path_is_symlink(&legacy) || path_is_symlink(&kind_root) || path_is_symlink(&mp_dir) {
+        return;
+    }
+
+    // ガード 10: legacy が is_dir であること
+    if !legacy.is_dir() {
+        return;
+    }
+
+    // ガード 4-5: canonicalize 後 legacy が kind_root 配下に厳密に含まれる
+    let canonical_legacy = match legacy.canonicalize() {
+        Ok(p) => p,
+        Err(_) => return,
+    };
+    let canonical_kind_root = match kind_root.canonicalize() {
+        Ok(p) => p,
+        Err(_) => return,
+    };
+    if !canonical_legacy.starts_with(&canonical_kind_root) {
+        return;
+    }
+
+    // ガード 6: legacy.parent() == Some(&mp_dir)
+    if legacy.parent() != Some(mp_dir.as_path()) {
+        return;
+    }
+    // ガード 7: mp_dir.parent() == Some(&kind_root)
+    if mp_dir.parent() != Some(kind_root.as_path()) {
+        return;
+    }
+
+    // ガード 8-9: file_name 一致
+    if mp_dir.file_name() != Some(OsStr::new(&origin.marketplace)) {
+        return;
+    }
+    if legacy.file_name() != Some(OsStr::new(&origin.plugin)) {
+        return;
+    }
+
+    // 全ガード通過 — quarantine rename → remove_dir_all
+    let suffix = quarantine_suffix();
+    let quarantine = mp_dir.join(format!("{}.plm-quarantine-{}", origin.plugin, suffix));
+    if std::fs::rename(&legacy, &quarantine).is_err() {
+        // rename 失敗時は no-op で abort（race 中に削除されたなど誤削除を避ける）。
+        return;
+    }
+    let _ = std::fs::remove_dir_all(&quarantine);
+
+    // 空親昇格削除
+    if dir_is_empty(&mp_dir) {
+        let _ = std::fs::remove_dir(&mp_dir);
+    }
+    if dir_is_empty(&kind_root) {
+        let _ = std::fs::remove_dir(&kind_root);
+    }
+}
+
+fn path_is_symlink(path: &Path) -> bool {
+    std::fs::symlink_metadata(path)
+        .map(|m| m.file_type().is_symlink())
+        .unwrap_or(false)
+}
+
+fn dir_is_empty(path: &Path) -> bool {
+    if !path.is_dir() {
+        return false;
+    }
+    std::fs::read_dir(path)
+        .map(|mut iter| iter.next().is_none())
+        .unwrap_or(false)
+}
+
+/// quarantine 名に使うランダム性のあるサフィックスを生成する。
+///
+/// 暗号学的乱数は不要（rename の race を縮小する目的のみ）。`SystemTime` の
+/// ナノ秒下位ビットとプロセス ID + ポインタアドレスを混ぜてユニーク性を稼ぐ。
+fn quarantine_suffix() -> String {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let pid = std::process::id() as u128;
+    let stack_addr = &nanos as *const _ as usize as u128;
+    let mixed = nanos ^ (pid << 32) ^ stack_addr;
+    format!("{:016x}", mixed as u64)
 }
 
 fn remove_if_empty(fs: &dyn FileSystem, path: &Path) {

--- a/src/plugin/cleanup_test.rs
+++ b/src/plugin/cleanup_test.rs
@@ -275,6 +275,154 @@ fn cleanup_runs_project_scope_when_home_is_none() {
     );
 }
 
+// =============================================================================
+// cleanup_legacy_hierarchy: 旧 3 階層構造の削除
+// =============================================================================
+
+/// 旧 3 階層 `<base>/skills/<mp>/<plg>` 全体を削除し、空親も再帰削除される。
+#[test]
+fn legacy_sweep_removes_three_layer_dir() {
+    let tmp = TempDir::new().unwrap();
+    let project = tmp.path().join("proj");
+    let kind_root = project.join(".codex").join("skills");
+    let mp_dir = kind_root.join("mp");
+    let legacy = mp_dir.join("plg");
+    fs::create_dir_all(legacy.join("my-skill")).unwrap();
+    fs::write(legacy.join("my-skill/SKILL.md"), "# Skill").unwrap();
+
+    cleanup_legacy_hierarchy_impl(TargetKind::Codex, None, &origin(), &project);
+
+    assert!(!legacy.exists(), "legacy plugin dir should be removed");
+    assert!(!mp_dir.exists(), "empty marketplace dir should be removed");
+    assert!(!kind_root.exists(), "empty kind_root should be removed");
+}
+
+/// 兄弟プラグインのコンテンツが残るとき親 (mp_dir) は削除されない。
+#[test]
+fn legacy_sweep_keeps_parent_when_sibling_exists() {
+    let tmp = TempDir::new().unwrap();
+    let project = tmp.path().join("proj");
+    let kind_root = project.join(".codex").join("skills");
+    let mp_dir = kind_root.join("mp");
+    let legacy = mp_dir.join("plg");
+    let sibling = mp_dir.join("other-plg");
+    fs::create_dir_all(&legacy).unwrap();
+    fs::create_dir_all(&sibling).unwrap();
+
+    cleanup_legacy_hierarchy_impl(TargetKind::Codex, None, &origin(), &project);
+
+    assert!(!legacy.exists());
+    assert!(sibling.exists(), "sibling plugin dir must remain");
+    assert!(mp_dir.exists(), "marketplace dir with siblings must remain");
+}
+
+/// `..` 等の不正セグメントが入った場合、no-op になり外部ディレクトリは触らない。
+#[test]
+fn legacy_sweep_rejects_origin_with_traversal_segment() {
+    let tmp = TempDir::new().unwrap();
+    let project = tmp.path().join("proj");
+
+    let outside = tmp.path().join("outside");
+    fs::create_dir_all(&outside).unwrap();
+
+    let bad_origin = PluginOrigin::from_marketplace("..", "..");
+    cleanup_legacy_hierarchy_impl(TargetKind::Codex, None, &bad_origin, &project);
+
+    assert!(outside.exists(), "must not escape via .. segments");
+}
+
+/// `legacy` が symlink の場合は削除しない（ガード 3）。
+#[cfg(unix)]
+#[test]
+fn legacy_sweep_skips_symlink_legacy() {
+    let tmp = TempDir::new().unwrap();
+    let project = tmp.path().join("proj");
+    let kind_root = project.join(".codex").join("skills");
+    let mp_dir = kind_root.join("mp");
+    fs::create_dir_all(&mp_dir).unwrap();
+
+    // symlink を mp_dir/plg として作成（target は別ディレクトリ）
+    let target_dir = tmp.path().join("real-target");
+    fs::create_dir_all(&target_dir).unwrap();
+    std::os::unix::fs::symlink(&target_dir, mp_dir.join("plg")).unwrap();
+
+    cleanup_legacy_hierarchy_impl(TargetKind::Codex, None, &origin(), &project);
+
+    // symlink もそのターゲットも残る
+    assert!(mp_dir.join("plg").exists());
+    assert!(target_dir.exists(), "symlink target must not be removed");
+}
+
+/// `kind_root` が symlink の場合は削除しない（ガード 11）。
+#[cfg(unix)]
+#[test]
+fn legacy_sweep_skips_symlink_kind_root() {
+    let tmp = TempDir::new().unwrap();
+    let project = tmp.path().join("proj");
+    let parent = project.join(".codex");
+    fs::create_dir_all(&parent).unwrap();
+
+    let real_kind_root = tmp.path().join("real-skills");
+    let mp_dir = real_kind_root.join("mp");
+    let legacy = mp_dir.join("plg");
+    fs::create_dir_all(&legacy).unwrap();
+
+    std::os::unix::fs::symlink(&real_kind_root, parent.join("skills")).unwrap();
+
+    cleanup_legacy_hierarchy_impl(TargetKind::Codex, None, &origin(), &project);
+
+    // symlink 経由は削除しない
+    assert!(
+        legacy.exists(),
+        "real legacy must remain via symlink-skipped sweep"
+    );
+}
+
+/// `mp_dir` が symlink の場合は削除しない（ガード 12）。
+#[cfg(unix)]
+#[test]
+fn legacy_sweep_skips_symlink_mp_dir() {
+    let tmp = TempDir::new().unwrap();
+    let project = tmp.path().join("proj");
+    let kind_root = project.join(".codex").join("skills");
+    fs::create_dir_all(&kind_root).unwrap();
+
+    let real_mp_dir = tmp.path().join("real-mp");
+    let legacy = real_mp_dir.join("plg");
+    fs::create_dir_all(&legacy).unwrap();
+
+    std::os::unix::fs::symlink(&real_mp_dir, kind_root.join("mp")).unwrap();
+
+    cleanup_legacy_hierarchy_impl(TargetKind::Codex, None, &origin(), &project);
+
+    assert!(legacy.exists(), "symlinked mp_dir must not be swept");
+}
+
+/// kind_root が存在しない場合 no-op（ガード 2）。
+#[test]
+fn legacy_sweep_noop_when_legacy_missing() {
+    let tmp = TempDir::new().unwrap();
+    let project = tmp.path().join("proj");
+
+    cleanup_legacy_hierarchy_impl(TargetKind::Codex, None, &origin(), &project);
+    // panic も I/O エラーも出さない
+}
+
+/// `home` 引数があれば personal scope の旧階層も対象になる。
+#[test]
+fn legacy_sweep_handles_personal_scope() {
+    let tmp = TempDir::new().unwrap();
+    let home = tmp.path().join("home");
+    let project = tmp.path().join("proj");
+
+    let personal_legacy = home.join(".codex").join("skills").join("mp").join("plg");
+    fs::create_dir_all(&personal_legacy).unwrap();
+
+    cleanup_legacy_hierarchy_impl(TargetKind::Codex, Some(&home), &origin(), &project);
+
+    assert!(!personal_legacy.exists());
+}
+
 /// `home` が None の場合、`cleanup_specs` は personal scope 側のエントリを
 /// まるごと省略して project_root 配下のみを返すことを直接検証する。
 /// これにより literal `~` を含む誤パス（`./~/.codex` など）が絶対に

--- a/src/plugin/meta.rs
+++ b/src/plugin/meta.rs
@@ -377,18 +377,21 @@ pub fn build_deployed_plugin_set(
     deployed: &HashSet<String>,
     plugin_names: &HashSet<String>,
 ) -> HashSet<String> {
-    let mut result = HashSet::new();
-    for name in deployed {
-        for (idx, ch) in name.char_indices() {
-            if ch == '_' {
-                let candidate = &name[..idx];
-                if plugin_names.contains(candidate) {
-                    result.insert(candidate.to_string());
-                }
-            }
-        }
-    }
-    result
+    deployed
+        .iter()
+        .flat_map(|name| underscore_prefix_candidates(name))
+        .filter(|candidate| plugin_names.contains(*candidate))
+        .map(str::to_string)
+        .collect()
+}
+
+/// `name` 内の各 `_` 位置で区切った prefix 候補を列挙する。
+///
+/// 例: `"foo_bar_baz"` → `["foo", "foo_bar"]`
+fn underscore_prefix_candidates(name: &str) -> impl Iterator<Item = &str> {
+    name.char_indices()
+        .filter(|(_, ch)| *ch == '_')
+        .map(move |(idx, _)| &name[..idx])
 }
 
 #[cfg(test)]

--- a/src/plugin/meta.rs
+++ b/src/plugin/meta.rs
@@ -288,8 +288,9 @@ pub fn resolve_installed_at(
 ///
 /// 後方互換ロジックは `manifest.name` を `flattened_name` 集合の prefix として
 /// マッチさせる。フラット化後の `flattened_name` は `"{plugin_name}_{...}"`
-/// 形式のため、`plugin_name` で始まるエントリがあれば「このプラグイン由来の
-/// コンポーネントが配置済み」と判定する。
+/// 形式のため、境界付き prefix `"{plugin_name}_"` で始まるエントリが
+/// 1 件でもあれば「このプラグイン由来のコンポーネントが配置済み」と判定する
+/// （末尾 `_` を含めることで `plugin_name` と他プラグイン名の部分一致を防ぐ）。
 ///
 /// # Arguments
 ///

--- a/src/plugin/meta.rs
+++ b/src/plugin/meta.rs
@@ -319,6 +319,65 @@ pub fn is_enabled(
     deployed.iter().any(|name| name.starts_with(&prefix))
 }
 
+/// `is_enabled` の O(1) バリアント。プラグイン一覧を一括判定する経路で使う。
+///
+/// 事前に [`build_deployed_plugin_set`] で構築した
+/// 「配置済みコンポーネントを少なくとも 1 件持つ plugin_name 集合」を渡し、
+/// `deployed_plugins.contains(plugin_name)` の定数時間ルックアップに置換する。
+/// `.plm-meta.json` の `statusByTarget` を優先する判定ロジックは `is_enabled`
+/// と同一。
+///
+/// # Arguments
+///
+/// * `cache_path` - プラグインのキャッシュパス
+/// * `plugin_name` - `PluginManifest.name`
+/// * `deployed_plugins` - 配置済みコンポーネントを持つ plugin_name の集合
+pub fn is_enabled_indexed(
+    cache_path: &Path,
+    plugin_name: &str,
+    deployed_plugins: &HashSet<String>,
+) -> bool {
+    if let Some(plugin_meta) = load_meta(cache_path) {
+        if !plugin_meta.status_by_target.is_empty() {
+            return plugin_meta.any_enabled();
+        }
+    }
+    deployed_plugins.contains(plugin_name)
+}
+
+/// `deployed` の `flattened_name` 集合と既知の `plugin_names` から、
+/// 配置済みコンポーネントを少なくとも 1 件持つ plugin_name の集合を構築する。
+///
+/// `flattened_name = "{plugin}_{original}"` の `plugin` 部分を `_` 区切りで
+/// 走査し、`plugin_names` に存在する候補を収集する。`plugin_name` 自体が
+/// `_` を含む場合（例 `"my_plugin"`）も全 `_` 位置を試行するため正しく拾える。
+///
+/// 計算量: `O(sum(|name|))` の文字走査と各 `_` 位置での `HashSet::contains`。
+/// プラグイン数 N に対して `is_enabled` を呼ぶ経路では、従来の
+/// `O(N × |deployed|)` を `O(sum(|name|) + N)` に改善する。
+///
+/// # Arguments
+///
+/// * `deployed` - `list_all_placed` が返す `flattened_name` 集合
+/// * `plugin_names` - 既知の plugin_name 集合（通常はキャッシュから列挙）
+pub fn build_deployed_plugin_set(
+    deployed: &HashSet<String>,
+    plugin_names: &HashSet<String>,
+) -> HashSet<String> {
+    let mut result = HashSet::new();
+    for name in deployed {
+        for (idx, ch) in name.char_indices() {
+            if ch == '_' {
+                let candidate = &name[..idx];
+                if plugin_names.contains(candidate) {
+                    result.insert(candidate.to_string());
+                }
+            }
+        }
+    }
+    result
+}
+
 #[cfg(test)]
 #[path = "meta_test.rs"]
 mod tests;

--- a/src/plugin/meta.rs
+++ b/src/plugin/meta.rs
@@ -7,7 +7,6 @@ use super::manifest_resolve::resolve_manifest_path;
 use super::PluginManifest;
 use crate::error::Result;
 use crate::fs::{FileSystem, RealFs};
-use crate::target::PluginOrigin;
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
@@ -287,20 +286,25 @@ pub fn resolve_installed_at(
 /// 2. `.plm-meta.json` が存在しない/読み取りエラー/statusByTarget が空の場合:
 ///    実デプロイ状態から判定（後方互換）
 ///
+/// 後方互換ロジックは `manifest.name` を `flattened_name` 集合の prefix として
+/// マッチさせる。フラット化後の `flattened_name` は `"{plugin_name}_{...}"`
+/// 形式のため、`plugin_name` で始まるエントリがあれば「このプラグイン由来の
+/// コンポーネントが配置済み」と判定する。
+///
 /// # Arguments
 ///
 /// * `cache_path` - プラグインのキャッシュパス
-/// * `marketplace` - マーケットプレイス名
-/// * `plugin_name` - プラグイン名
-/// * `deployed` - デプロイ済みプラグインの集合（事前計算済み）
+/// * `_marketplace` - マーケットプレイス名（フラット化後は未使用、互換のために残す）
+/// * `plugin_name` - プラグイン名（`PluginManifest.name` 相当）
+/// * `deployed` - デプロイ済みコンポーネントの `flattened_name` 集合
 ///
 /// # Returns
 /// `true` if enabled, `false` otherwise
 pub fn is_enabled(
     cache_path: &Path,
-    marketplace: &str,
+    _marketplace: &str,
     plugin_name: &str,
-    deployed: &HashSet<(String, String)>,
+    deployed: &HashSet<String>,
 ) -> bool {
     if let Some(plugin_meta) = load_meta(cache_path) {
         if !plugin_meta.status_by_target.is_empty() {
@@ -308,16 +312,11 @@ pub fn is_enabled(
         }
     }
 
-    // 後方互換: statusByTarget が無い古いプラグインは実デプロイ状態から判定
-    let origin = PluginOrigin::from_cached_plugin(
-        if marketplace == "github" {
-            None
-        } else {
-            Some(marketplace)
-        },
-        plugin_name,
-    );
-    deployed.contains(&(origin.marketplace, origin.plugin))
+    // 後方互換: statusByTarget が無い古いプラグインは flattened_name の prefix
+    // マッチで判定する。`flattened_name = "{plugin}_{original}"` なので、
+    // `plugin_name` で始まるエントリが 1 件でもあれば enabled と判定する。
+    let prefix = format!("{}_", plugin_name);
+    deployed.iter().any(|name| name.starts_with(&prefix))
 }
 
 #[cfg(test)]

--- a/src/plugin/meta.rs
+++ b/src/plugin/meta.rs
@@ -356,6 +356,18 @@ pub fn is_enabled_indexed(
 /// プラグイン数 N に対して `is_enabled` を呼ぶ経路では、従来の
 /// `O(N × |deployed|)` を `O(sum(|name|) + N)` に改善する。
 ///
+/// # 既知の曖昧さ（プレフィックス衝突）
+///
+/// `"{plugin}_{original}"` 形式は `_` を含む plugin / original では分解が
+/// 一意にならない。例えば `plugin_names = {"foo", "foo_bar"}` で
+/// `deployed = {"foo_bar_baz"}` の場合、`"foo"` も `"foo_bar"` もマッチする
+/// ため両プラグインが enabled として返る。これは従来の
+/// `is_enabled` の `prefix.starts_with` ロジックと同一の挙動で（後方互換）、
+/// 「false positive を許容する best-effort なアッパーバウンド」として扱う。
+/// 完全な一意性が必要な場合は `flatten_name` の区切り文字再設計
+/// （非英数記号への変更や escape）または plugin_name の `_` 禁止が必要。
+/// 衝突挙動は `test_build_deployed_plugin_set_prefix_collision` で固定する。
+///
 /// # Arguments
 ///
 /// * `deployed` - `list_all_placed` が返す `flattened_name` 集合

--- a/src/plugin/meta_test.rs
+++ b/src/plugin/meta_test.rs
@@ -568,3 +568,91 @@ fn test_is_enabled_func_prefix_no_partial_match() {
 
     assert!(!is_enabled(plugin_dir, "github", "test-plugin", &deployed));
 }
+
+// =============================================================================
+// build_deployed_plugin_set / is_enabled_indexed tests
+// =============================================================================
+
+#[test]
+fn test_build_deployed_plugin_set_basic() {
+    let mut deployed: HashSet<String> = HashSet::new();
+    deployed.insert("foo_skill-a".to_string());
+    deployed.insert("bar_skill-b".to_string());
+    deployed.insert("baz_skill-c".to_string());
+
+    let mut known: HashSet<String> = HashSet::new();
+    known.insert("foo".to_string());
+    known.insert("bar".to_string());
+
+    let result = build_deployed_plugin_set(&deployed, &known);
+    assert_eq!(result.len(), 2);
+    assert!(result.contains("foo"));
+    assert!(result.contains("bar"));
+    assert!(!result.contains("baz"));
+}
+
+#[test]
+fn test_build_deployed_plugin_set_handles_underscore_in_plugin_name() {
+    // plugin_name 自体が `_` を含むケース。`flattened_name = "my_plugin_skill"`
+    // に対し全 `_` 位置を試行するため、最初の `_` で誤マッチさせない。
+    let mut deployed: HashSet<String> = HashSet::new();
+    deployed.insert("my_plugin_skill".to_string());
+
+    let mut known: HashSet<String> = HashSet::new();
+    known.insert("my_plugin".to_string());
+
+    let result = build_deployed_plugin_set(&deployed, &known);
+    assert_eq!(result.len(), 1);
+    assert!(result.contains("my_plugin"));
+}
+
+#[test]
+fn test_build_deployed_plugin_set_no_partial_match() {
+    // "test-plugin" が "test-plugin-other" の prefix と部分マッチしないこと。
+    let mut deployed: HashSet<String> = HashSet::new();
+    deployed.insert("test-plugin-other_x".to_string());
+
+    let mut known: HashSet<String> = HashSet::new();
+    known.insert("test-plugin".to_string());
+
+    let result = build_deployed_plugin_set(&deployed, &known);
+    assert!(result.is_empty());
+}
+
+#[test]
+fn test_is_enabled_indexed_uses_status_by_target_when_present() {
+    let temp_dir = TempDir::new().unwrap();
+    let plugin_dir = temp_dir.path();
+
+    let mut meta = PluginMeta::default();
+    meta.set_status("codex", "enabled");
+    write_meta(plugin_dir, &meta).unwrap();
+
+    // deployed_plugins が空でも statusByTarget で enabled なら true
+    let deployed_plugins: HashSet<String> = HashSet::new();
+    assert!(is_enabled_indexed(
+        plugin_dir,
+        "test-plugin",
+        &deployed_plugins
+    ));
+}
+
+#[test]
+fn test_is_enabled_indexed_falls_back_to_index() {
+    let temp_dir = TempDir::new().unwrap();
+    let plugin_dir = temp_dir.path();
+
+    let mut deployed_plugins: HashSet<String> = HashSet::new();
+    deployed_plugins.insert("test-plugin".to_string());
+
+    assert!(is_enabled_indexed(
+        plugin_dir,
+        "test-plugin",
+        &deployed_plugins
+    ));
+    assert!(!is_enabled_indexed(
+        plugin_dir,
+        "missing",
+        &deployed_plugins
+    ));
+}

--- a/src/plugin/meta_test.rs
+++ b/src/plugin/meta_test.rs
@@ -496,7 +496,7 @@ fn test_is_enabled_func_with_status_by_target_enabled() {
     meta.set_status("codex", "enabled");
     write_meta(plugin_dir, &meta).unwrap();
 
-    let deployed: HashSet<(String, String)> = HashSet::new();
+    let deployed: HashSet<String> = HashSet::new();
     assert!(is_enabled(plugin_dir, "github", "test-plugin", &deployed));
 }
 
@@ -510,7 +510,7 @@ fn test_is_enabled_func_with_status_by_target_disabled() {
     meta.set_status("codex", "disabled");
     write_meta(plugin_dir, &meta).unwrap();
 
-    let deployed: HashSet<(String, String)> = HashSet::new();
+    let deployed: HashSet<String> = HashSet::new();
     assert!(!is_enabled(plugin_dir, "github", "test-plugin", &deployed));
 }
 
@@ -519,12 +519,13 @@ fn test_is_enabled_func_fallback_to_deployed() {
     let temp_dir = TempDir::new().unwrap();
     let plugin_dir = temp_dir.path();
 
-    // statusByTarget が空の場合、deployed から判定
+    // statusByTarget が空の場合、deployed の flattened_name に prefix
+    // マッチするエントリがあれば enabled。
     let meta = PluginMeta::default();
     write_meta(plugin_dir, &meta).unwrap();
 
-    let mut deployed: HashSet<(String, String)> = HashSet::new();
-    deployed.insert(("github".to_string(), "test-plugin".to_string()));
+    let mut deployed: HashSet<String> = HashSet::new();
+    deployed.insert("test-plugin_my-skill".to_string());
 
     assert!(is_enabled(plugin_dir, "github", "test-plugin", &deployed));
 }
@@ -538,7 +539,7 @@ fn test_is_enabled_func_fallback_not_deployed() {
     let meta = PluginMeta::default();
     write_meta(plugin_dir, &meta).unwrap();
 
-    let deployed: HashSet<(String, String)> = HashSet::new();
+    let deployed: HashSet<String> = HashSet::new();
     assert!(!is_enabled(plugin_dir, "github", "test-plugin", &deployed));
 }
 
@@ -547,22 +548,23 @@ fn test_is_enabled_func_no_meta_file_fallback() {
     let temp_dir = TempDir::new().unwrap();
     let plugin_dir = temp_dir.path();
 
-    // .plm-meta.json が存在しない場合、deployed から判定
-    let mut deployed: HashSet<(String, String)> = HashSet::new();
-    deployed.insert(("github".to_string(), "test-plugin".to_string()));
+    // .plm-meta.json が存在しない場合、deployed の flattened_name から判定
+    let mut deployed: HashSet<String> = HashSet::new();
+    deployed.insert("test-plugin_my-skill".to_string());
 
     assert!(is_enabled(plugin_dir, "github", "test-plugin", &deployed));
 }
 
 #[test]
-fn test_is_enabled_func_marketplace_normalization() {
+fn test_is_enabled_func_prefix_no_partial_match() {
     let temp_dir = TempDir::new().unwrap();
     let plugin_dir = temp_dir.path();
 
-    // marketplace が "github" の場合、None として扱われる
-    let mut deployed: HashSet<(String, String)> = HashSet::new();
-    deployed.insert(("github".to_string(), "test-plugin".to_string()));
+    // "test-plugin" が "test-plugin-other" の prefix と部分マッチしてしまう
+    // のを防ぐため、`flattened_name = "{plugin}_{...}"` に対し
+    // `"{plugin}_"` で始まるかをチェックする。
+    let mut deployed: HashSet<String> = HashSet::new();
+    deployed.insert("test-plugin-other_x".to_string());
 
-    // "github" は PluginOrigin::from_cached_plugin(None, ...) と同じ結果
-    assert!(is_enabled(plugin_dir, "github", "test-plugin", &deployed));
+    assert!(!is_enabled(plugin_dir, "github", "test-plugin", &deployed));
 }

--- a/src/plugin/meta_test.rs
+++ b/src/plugin/meta_test.rs
@@ -620,6 +620,32 @@ fn test_build_deployed_plugin_set_no_partial_match() {
 }
 
 #[test]
+fn test_build_deployed_plugin_set_prefix_collision() {
+    // 既知の曖昧さ: `_` を含む plugin 名が包含関係になる場合、1 つの
+    // `flattened_name` から複数 plugin_name が拾われる。これは従来の
+    // `is_enabled` の prefix.starts_with と同じ挙動（後方互換）。
+    // 完全一意化には `flatten_name` の区切り文字再設計が必要。
+    let mut deployed: HashSet<String> = HashSet::new();
+    deployed.insert("foo_bar_baz".to_string());
+
+    let mut known: HashSet<String> = HashSet::new();
+    known.insert("foo".to_string());
+    known.insert("foo_bar".to_string());
+
+    let result = build_deployed_plugin_set(&deployed, &known);
+    assert_eq!(result.len(), 2);
+    assert!(result.contains("foo"));
+    assert!(result.contains("foo_bar"));
+
+    // 互換確認: 同じ deployed と plugin_name 個別に対する `is_enabled` も
+    // 両方 true を返す（false positive の挙動が build_deployed_plugin_set と
+    // 等価であること）。
+    let temp_dir = TempDir::new().unwrap();
+    assert!(is_enabled(temp_dir.path(), "github", "foo", &deployed));
+    assert!(is_enabled(temp_dir.path(), "github", "foo_bar", &deployed));
+}
+
+#[test]
 fn test_is_enabled_indexed_uses_status_by_target_when_present() {
     let temp_dir = TempDir::new().unwrap();
     let plugin_dir = temp_dir.path();

--- a/src/plugin/plugin_content.rs
+++ b/src/plugin/plugin_content.rs
@@ -153,6 +153,10 @@ impl Plugin {
                 ComponentKind::Command,
                 list_command_names(&manifest.commands_dir(path)),
             ),
+            (
+                ComponentKind::Hook,
+                list_hook_names(&manifest.hooks_dir(path)),
+            ),
         ] {
             let flattened = flatten_components(kind, plugin_name, items)?;
             detect_name_collisions(&flattened)?;
@@ -160,14 +164,6 @@ impl Plugin {
         }
 
         Self::build_instructions(path, manifest, &mut components);
-
-        for (name, p) in list_hook_names(&manifest.hooks_dir(path)) {
-            components.push(Component {
-                kind: ComponentKind::Hook,
-                path: p,
-                name,
-            });
-        }
 
         Ok(components)
     }

--- a/src/plugin/plugin_content_test.rs
+++ b/src/plugin/plugin_content_test.rs
@@ -265,7 +265,8 @@ fn test_plugin_new_with_hooks() {
     let components = plugin.components();
     assert_eq!(components.len(), 1);
     assert_eq!(components[0].kind, ComponentKind::Hook);
-    assert_eq!(components[0].name, "on-apply-patch");
+    // flatten_name 適用後: "{plugin}_{original}" = "test_on-apply-patch"
+    assert_eq!(components[0].name, "test_on-apply-patch");
     assert_eq!(
         components[0].path,
         path.join("hooks").join("on-apply-patch.sh")
@@ -325,25 +326,22 @@ fn test_plugin_new_with_hooks_same_stem_different_ext() {
     write_file(&path.join("hooks/pre-commit.sh"), "#!/bin/sh\n");
     write_file(&path.join("hooks/pre-commit.py"), "#!/usr/bin/env python\n");
 
-    let plugin = Plugin::new(
+    let result = Plugin::new(
         make_manifest("test"),
-        path.clone(),
+        path,
         PluginOrigin::from_marketplace("test", "test"),
-    )
-    .unwrap();
+    );
 
-    let hooks: Vec<&Component> = plugin
-        .components()
-        .iter()
-        .filter(|c| c.kind == ComponentKind::Hook)
-        .collect();
-    // Hooks with the same stem but different extensions should be kept as
-    // separate components, each preserving its own file path.
-    assert_eq!(hooks.len(), 2);
-    assert!(hooks.iter().all(|h| h.name == "pre-commit"));
-    assert!(hooks.iter().all(|h| {
-        h.path == path.join("hooks/pre-commit.sh") || h.path == path.join("hooks/pre-commit.py")
-    }));
+    // 同一プラグイン内の同 stem・別拡張子 Hook は detect_name_collisions が
+    // Validation エラーで報告する（Skill / Agent / Command と挙動を揃える）。
+    let err = result.unwrap_err();
+    let msg = match err {
+        PlmError::Validation(s) => s,
+        other => panic!("expected Validation error, got: {:?}", other),
+    };
+    assert!(msg.contains("test_pre-commit"), "msg: {msg}");
+    assert!(msg.contains("Hook"), "msg: {msg}");
+    assert!(msg.contains("conflicts with"), "msg: {msg}");
 }
 
 #[test]
@@ -546,6 +544,78 @@ fn test_plugin_new_rejects_empty_plugin_name() {
         PluginOrigin::from_marketplace("test", "test"),
     );
     assert!(matches!(result, Err(PlmError::Validation(_))));
+}
+
+#[test]
+fn test_plugin_new_hook_uses_flat_name() {
+    let temp = TempDir::new().unwrap();
+    let path = temp.path().to_path_buf();
+    write_file(&path.join("hooks/pre-commit.json"), "{}");
+
+    let plugin = Plugin::new(
+        make_manifest("myplugin"),
+        path.clone(),
+        PluginOrigin::from_marketplace("test", "test"),
+    )
+    .unwrap();
+
+    let components = plugin.components();
+    assert_eq!(components.len(), 1);
+    assert_eq!(components[0].kind, ComponentKind::Hook);
+    assert_eq!(components[0].name, "myplugin_pre-commit");
+    assert_eq!(
+        components[0].path,
+        path.join("hooks").join("pre-commit.json")
+    );
+}
+
+#[test]
+fn test_plugin_new_hook_collision_returns_validation_error() {
+    let temp = TempDir::new().unwrap();
+    let path = temp.path().to_path_buf();
+    // 同 stem の Hook を 2 つ配置する: detect_name_collisions が拾うはず
+    write_file(&path.join("hooks/pre-commit.sh"), "#!/bin/sh\n");
+    write_file(&path.join("hooks/pre-commit.json"), "{}");
+
+    let result = Plugin::new(
+        make_manifest("myplugin"),
+        path,
+        PluginOrigin::from_marketplace("test", "test"),
+    );
+
+    let err = result.unwrap_err();
+    let msg = match err {
+        PlmError::Validation(s) => s,
+        other => panic!("expected Validation error, got: {:?}", other),
+    };
+    assert!(msg.contains("myplugin_pre-commit"), "msg: {msg}");
+    assert!(msg.contains("Hook"), "msg: {msg}");
+}
+
+#[test]
+fn test_plugin_new_rejects_hook_name_with_path_separator() {
+    let temp = TempDir::new().unwrap();
+    let path = temp.path().to_path_buf();
+    // ディレクトリ階層に置かれた Hook（再帰スキャンで `..` 等が混入した想定）
+    write_file(&path.join("hooks/sub/inner.json"), "{}");
+
+    // Hook は再帰スキャンしないので通常パスでは混入しないが、
+    // 念のため list_hook_names が単一セグメントを返すことを保証する目的で
+    // 通常の sub-dir 内ファイルは無視されることを確認する。
+    let plugin = Plugin::new(
+        make_manifest("myplugin"),
+        path,
+        PluginOrigin::from_marketplace("test", "test"),
+    )
+    .unwrap();
+
+    // hooks サブディレクトリは無視されて Hook 0 件
+    let hooks: Vec<&Component> = plugin
+        .components()
+        .iter()
+        .filter(|c| c.kind == ComponentKind::Hook)
+        .collect();
+    assert!(hooks.is_empty());
 }
 
 #[test]

--- a/src/plugin/plugin_content_test.rs
+++ b/src/plugin/plugin_content_test.rs
@@ -593,7 +593,7 @@ fn test_plugin_new_hook_collision_returns_validation_error() {
 }
 
 #[test]
-fn test_plugin_new_rejects_hook_name_with_path_separator() {
+fn test_plugin_new_ignores_hooks_in_subdirectories() {
     let temp = TempDir::new().unwrap();
     let path = temp.path().to_path_buf();
     // ディレクトリ階層に置かれた Hook（再帰スキャンで `..` 等が混入した想定）

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -24,4 +24,4 @@ pub use constants::{
     DEFAULT_AGENTS_DIR, DEFAULT_COMMANDS_DIR, DEFAULT_HOOKS_DIR, DEFAULT_INSTRUCTIONS_DIR,
     DEFAULT_INSTRUCTIONS_FILE, DEFAULT_SKILLS_DIR,
 };
-pub use placement::list_placed_components;
+pub use placement::{is_instruction_file, list_placed_components};

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -24,4 +24,4 @@ pub use constants::{
     DEFAULT_AGENTS_DIR, DEFAULT_COMMANDS_DIR, DEFAULT_HOOKS_DIR, DEFAULT_INSTRUCTIONS_DIR,
     DEFAULT_INSTRUCTIONS_FILE, DEFAULT_SKILLS_DIR,
 };
-pub use placement::list_placed_plugins;
+pub use placement::list_placed_components;

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -5,8 +5,8 @@
 //!
 //! ## 配置スキャン
 //!
-//! - `list_placed_plugins`: 配置済みアイテムからプラグインを抽出
-//! - `parse_placement`: 配置済みアイテム文字列をパース
+//! - [`list_placed_components`]: `target.list_placed()` の戻り値から
+//!   Instruction ファイルを除外した `flattened_name` 集合（`HashSet<String>`）を返す
 //!
 //! ## 低レベル関数
 //!

--- a/src/scan/components.rs
+++ b/src/scan/components.rs
@@ -206,6 +206,12 @@ pub fn list_hook_names(hooks_dir: &Path) -> Vec<(String, PathBuf)> {
                 .rsplit_once('.')
                 .map(|(n, _)| n.to_string())
                 .unwrap_or_else(|| file_name.to_string());
+            // ドットファイル (`.env` / `.gitignore` など) は stem が空になるため
+            // Hook として扱わずスキップする。空名は flatten_name 後も `<plugin>_`
+            // という不完全な名前になり、後段の validate_path_segment で失敗する。
+            if hook_name.is_empty() {
+                return None;
+            }
             Some((hook_name, path))
         })
         .collect()

--- a/src/scan/components.rs
+++ b/src/scan/components.rs
@@ -207,8 +207,9 @@ pub fn list_hook_names(hooks_dir: &Path) -> Vec<(String, PathBuf)> {
                 .map(|(n, _)| n.to_string())
                 .unwrap_or_else(|| file_name.to_string());
             // ドットファイル (`.env` / `.gitignore` など) は stem が空になるため
-            // Hook として扱わずスキップする。空名は flatten_name 後も `<plugin>_`
-            // という不完全な名前になり、後段の validate_path_segment で失敗する。
+            // Hook として扱わずスキップする。空名は flatten_name 適用前の
+            // `validate_path_segment("component name", &original_name)` で
+            // `Validation` エラーになるため、ここで前段で除外しておく。
             if hook_name.is_empty() {
                 return None;
             }

--- a/src/scan/components/tests.rs
+++ b/src/scan/components/tests.rs
@@ -449,7 +449,8 @@ fn test_list_hook_names_dot_file() {
 
     fs::write(hooks_dir.join(".env"), "KEY=VALUE").unwrap();
 
-    assert_eq!(names(list_hook_names(hooks_dir)), vec![""]);
+    // ドットファイルは stem が空文字になるため Hook 候補から除外する。
+    assert!(list_hook_names(hooks_dir).is_empty());
 }
 
 #[test]
@@ -469,7 +470,8 @@ fn test_list_hook_names_only_extension() {
 
     fs::write(hooks_dir.join(".gitignore"), "*.log").unwrap();
 
-    assert_eq!(names(list_hook_names(hooks_dir)), vec![""]);
+    // 拡張子のみのドットファイルも stem が空のため除外する。
+    assert!(list_hook_names(hooks_dir).is_empty());
 }
 
 #[test]

--- a/src/scan/components/tests.rs
+++ b/src/scan/components/tests.rs
@@ -214,6 +214,21 @@ fn test_list_hook_names_returns_empty_for_nonexistent() {
     assert!(list_hook_names(&nonexistent).is_empty());
 }
 
+#[test]
+fn test_list_hook_names_skips_dotfiles_with_empty_stem() {
+    let temp_dir = TempDir::new().unwrap();
+    let hooks_dir = temp_dir.path();
+
+    // ドットファイルは rsplit_once('.') が ("", ext) を返すため stem が空文字
+    // になる。flatten_name 後も `<plugin>_` という不完全な名前になり
+    // validate_path_segment で失敗するため、ここで除外する。
+    fs::write(hooks_dir.join(".gitignore"), "*.tmp").unwrap();
+    fs::write(hooks_dir.join(".env"), "FOO=bar").unwrap();
+    fs::write(hooks_dir.join("pre-commit.sh"), "#!/bin/sh").unwrap();
+
+    assert_eq!(names(list_hook_names(hooks_dir)), vec!["pre-commit"]);
+}
+
 // =========================================================================
 // list_markdown_names tests
 // =========================================================================

--- a/src/scan/placement.rs
+++ b/src/scan/placement.rs
@@ -1,66 +1,40 @@
 //! 配置スキャンロジック
 //!
-//! ターゲットから取得した配置済みアイテム文字列をパースする。
+//! ターゲットから取得した配置済みアイテム文字列を集約する。
 //! ドメイン非依存: 文字列のみに依存。
 //!
 //! ## 入力形式
 //!
 //! `target.list_placed()` は以下の形式の文字列を返す:
-//! - `"marketplace/plugin/component"` (Skills, Agents)
-//! - `"AGENTS.md"` (Instructions)
+//! - `<flattened_name>` (フラット 2 階層: Skills, Agents, Commands, Hooks)
+//! - `AGENTS.md` / `GEMINI.md` / `copilot-instructions.md` (Instructions)
 //!
-//! この文字列は常に `/` 区切り（OS のパス区切りではない）。
+//! このモジュールは `flattened_name` 集合を返し、Instruction ファイル名は除外する。
 
 use std::collections::HashSet;
 
-/// 配置済みアイテム文字列のリストから (marketplace, plugin_name) ペアを抽出
+/// Instruction として扱う既知のファイル名集合。
+const INSTRUCTION_FILE_NAMES: &[&str] = &["AGENTS.md", "copilot-instructions.md", "GEMINI.md"];
+
+/// 配置済みアイテム文字列の中に Instruction ファイル名が含まれているか。
+pub fn is_instruction_file(item: &str) -> bool {
+    INSTRUCTION_FILE_NAMES.contains(&item)
+}
+
+/// 配置済みアイテム文字列のリストから `flattened_name` 集合を抽出する。
 ///
-/// `target.list_placed()` の戻り値をパースし、プラグイン単位で集約する。
+/// `target.list_placed()` の戻り値をパースし、Instruction ファイルを除外して
+/// プラグイン配置の `flattened_name` の重複なし集合を返す。
 ///
 /// # Arguments
 ///
 /// * `placed_items` - `target.list_placed()` の戻り値リスト
-///
-/// # Returns
-/// (marketplace, plugin_name) ペアの集合
-pub fn list_placed_plugins(placed_items: &[String]) -> HashSet<(String, String)> {
+pub fn list_placed_components(placed_items: &[String]) -> HashSet<String> {
     placed_items
         .iter()
-        .filter_map(|item| parse_placement(item))
+        .filter(|item| !item.is_empty() && !is_instruction_file(item))
+        .cloned()
         .collect()
-}
-
-/// "marketplace/plugin/..." 形式をパース
-///
-/// # Arguments
-///
-/// * `item` - パース対象の文字列
-///
-/// # Returns
-/// * `Some((marketplace, plugin_name))` - 2セグメント以上かつ両方非空の場合
-/// * `None` - 以下のいずれかの場合:
-///   - 1セグメント以下（スラッシュなし）
-///   - marketplace または plugin_name が空文字
-///
-/// # Edge Cases
-/// * `""` → `None`
-/// * `"plugin"` → `None`
-/// * `"marketplace/plugin"` → `Some(("marketplace", "plugin"))`
-/// * `"marketplace/plugin/skill"` → `Some(("marketplace", "plugin"))`
-/// * `"/plugin"` → `None`
-/// * `"marketplace/"` → `None`
-pub fn parse_placement(item: &str) -> Option<(String, String)> {
-    let parts: Vec<&str> = item.split('/').collect();
-    if parts.len() >= 2 {
-        let marketplace = parts[0];
-        let plugin = parts[1];
-        if marketplace.is_empty() || plugin.is_empty() {
-            return None;
-        }
-        Some((marketplace.to_string(), plugin.to_string()))
-    } else {
-        None
-    }
 }
 
 #[cfg(test)]

--- a/src/scan/placement_test.rs
+++ b/src/scan/placement_test.rs
@@ -3,82 +3,67 @@
 use super::*;
 
 #[test]
-fn test_parse_placement_empty() {
-    assert_eq!(parse_placement(""), None);
+fn test_is_instruction_file_known() {
+    assert!(is_instruction_file("AGENTS.md"));
+    assert!(is_instruction_file("GEMINI.md"));
+    assert!(is_instruction_file("copilot-instructions.md"));
 }
 
 #[test]
-fn test_parse_placement_no_slash() {
-    assert_eq!(parse_placement("plugin"), None);
+fn test_is_instruction_file_unknown() {
+    assert!(!is_instruction_file("plugin_my-skill"));
+    assert!(!is_instruction_file(""));
+    assert!(!is_instruction_file("AGENTS.txt"));
 }
 
 #[test]
-fn test_parse_placement_two_segments() {
-    assert_eq!(
-        parse_placement("marketplace/plugin"),
-        Some(("marketplace".to_string(), "plugin".to_string()))
-    );
-}
-
-#[test]
-fn test_parse_placement_three_segments() {
-    assert_eq!(
-        parse_placement("marketplace/plugin/skill"),
-        Some(("marketplace".to_string(), "plugin".to_string()))
-    );
-}
-
-#[test]
-fn test_parse_placement_leading_slash() {
-    assert_eq!(parse_placement("/plugin"), None);
-}
-
-#[test]
-fn test_parse_placement_trailing_slash() {
-    assert_eq!(parse_placement("marketplace/"), None);
-}
-
-#[test]
-fn test_parse_placement_only_slash() {
-    assert_eq!(parse_placement("/"), None);
-}
-
-#[test]
-fn test_list_placed_plugins_empty() {
+fn test_list_placed_components_empty() {
     let items: Vec<String> = vec![];
-    let result = list_placed_plugins(&items);
+    let result = list_placed_components(&items);
     assert!(result.is_empty());
 }
 
 #[test]
-fn test_list_placed_plugins_single() {
-    let items = vec!["github/my-plugin/my-skill".to_string()];
-    let result = list_placed_plugins(&items);
+fn test_list_placed_components_single_flat_name() {
+    let items = vec!["plg_my-skill".to_string()];
+    let result = list_placed_components(&items);
     assert_eq!(result.len(), 1);
-    assert!(result.contains(&("github".to_string(), "my-plugin".to_string())));
+    assert!(result.contains("plg_my-skill"));
 }
 
 #[test]
-fn test_list_placed_plugins_dedup() {
+fn test_list_placed_components_dedup() {
     let items = vec![
-        "github/my-plugin/skill1".to_string(),
-        "github/my-plugin/skill2".to_string(),
-        "github/other-plugin/agent".to_string(),
+        "plg_skill1".to_string(),
+        "plg_skill1".to_string(),
+        "plg_skill2".to_string(),
     ];
-    let result = list_placed_plugins(&items);
+    let result = list_placed_components(&items);
     assert_eq!(result.len(), 2);
-    assert!(result.contains(&("github".to_string(), "my-plugin".to_string())));
-    assert!(result.contains(&("github".to_string(), "other-plugin".to_string())));
+    assert!(result.contains("plg_skill1"));
+    assert!(result.contains("plg_skill2"));
 }
 
 #[test]
-fn test_list_placed_plugins_ignores_invalid() {
+fn test_list_placed_components_excludes_instruction_files() {
     let items = vec![
-        "github/my-plugin/skill".to_string(),
-        "AGENTS.md".to_string(), // No slash, should be ignored
-        "/invalid".to_string(),  // Leading slash, should be ignored
+        "plg_skill".to_string(),
+        "AGENTS.md".to_string(),
+        "GEMINI.md".to_string(),
+        "copilot-instructions.md".to_string(),
     ];
-    let result = list_placed_plugins(&items);
+    let result = list_placed_components(&items);
     assert_eq!(result.len(), 1);
-    assert!(result.contains(&("github".to_string(), "my-plugin".to_string())));
+    assert!(result.contains("plg_skill"));
+    assert!(!result.contains("AGENTS.md"));
+    assert!(!result.contains("GEMINI.md"));
+    assert!(!result.contains("copilot-instructions.md"));
+}
+
+#[test]
+fn test_list_placed_components_excludes_empty_string() {
+    let items = vec!["".to_string(), "valid_name".to_string()];
+    let result = list_placed_components(&items);
+    assert_eq!(result.len(), 1);
+    assert!(result.contains("valid_name"));
 }

--- a/src/sync/source.rs
+++ b/src/sync/source.rs
@@ -171,7 +171,10 @@ impl SyncSource {
 ///
 /// フラット化後の識別子は `flattened_name` 単一セグメントのみ。Instruction
 /// (AGENTS.md / copilot-instructions.md / GEMINI.md) はそのままファイル名で
-/// 受け取る特例とする。`/` を含むレガシー識別子は `InvalidArgument` で拒否する。
+/// 受け取る特例とする。空文字・パス区切り (`/` `\`) ・null バイト・`.` / `..` ・
+/// 複合パスを含むレガシー識別子は `InvalidArgument` で拒否する
+/// (`placement_location` が `base.join(name)` を直接行うためベースディレクトリ
+/// 外への書き込みを防ぐ)。
 ///
 /// # Arguments
 ///
@@ -182,15 +185,40 @@ pub fn parse_component_name(name: &str) -> Result<(PluginOrigin, &str)> {
         return Ok((PluginOrigin::from_marketplace("", ""), name));
     }
 
-    if name.contains('/') {
-        return Err(PlmError::InvalidArgument(format!(
-            "Invalid component name format: '{}'. Expected a single flattened segment",
-            name
-        )));
-    }
+    validate_flattened_name(name)?;
 
     // フラット配置では origin を復元できないためプレースホルダを埋める。
     Ok((PluginOrigin::from_marketplace("_", "_"), name))
+}
+
+/// `flattened_name` が単一の安全なパスセグメントであることを検証する。
+fn validate_flattened_name(name: &str) -> Result<()> {
+    if name.is_empty() {
+        return Err(PlmError::InvalidArgument(
+            "Component name must not be empty".to_string(),
+        ));
+    }
+    if name.contains('/') || name.contains('\\') || name.contains('\0') {
+        return Err(PlmError::InvalidArgument(format!(
+            "Invalid component name '{}': must not contain path separators or null bytes",
+            name
+        )));
+    }
+    if name == "." || name == ".." {
+        return Err(PlmError::InvalidArgument(format!(
+            "Invalid component name '{}': must not be a parent/current directory reference",
+            name
+        )));
+    }
+    let mut components = Path::new(name).components();
+    let first = components.next();
+    if components.next().is_some() || !matches!(first, Some(std::path::Component::Normal(_))) {
+        return Err(PlmError::InvalidArgument(format!(
+            "Invalid component name '{}': must be a single flattened segment",
+            name
+        )));
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/sync/source.rs
+++ b/src/sync/source.rs
@@ -188,7 +188,7 @@ pub fn parse_component_name(name: &str) -> Result<(PluginOrigin, &str)> {
     validate_flattened_name(name)?;
 
     // フラット配置では origin を復元できないためプレースホルダを埋める。
-    Ok((PluginOrigin::from_marketplace("_", "_"), name))
+    Ok((PluginOrigin::placeholder(), name))
 }
 
 /// `flattened_name` が単一の安全なパスセグメントであることを検証する。

--- a/src/sync/source.rs
+++ b/src/sync/source.rs
@@ -166,27 +166,30 @@ impl SyncSource {
     }
 }
 
-/// コンポーネント名をパース (marketplace/plugin/component)
+/// コンポーネント名をパース。
+///
+/// フラット化後の識別子は `flattened_name` 単一セグメントのみ。Instruction
+/// (AGENTS.md / copilot-instructions.md / GEMINI.md) はそのままファイル名で
+/// 受け取る特例とする。`/` を含むレガシー識別子は `InvalidArgument` で拒否する。
 ///
 /// # Arguments
 ///
-/// * `name` - Component name in `marketplace/plugin/component` form, or a bare instruction file name.
+/// * `name` - フラット化された Component 名、または Instruction のファイル名。
 pub fn parse_component_name(name: &str) -> Result<(PluginOrigin, &str)> {
     // Instruction の特別扱い
     if name == "AGENTS.md" || name == "copilot-instructions.md" || name == "GEMINI.md" {
         return Ok((PluginOrigin::from_marketplace("", ""), name));
     }
 
-    let parts: Vec<&str> = name.split('/').collect();
-    if parts.len() != 3 {
+    if name.contains('/') {
         return Err(PlmError::InvalidArgument(format!(
-            "Invalid component name format: '{}'. Expected 'marketplace/plugin/component'",
+            "Invalid component name format: '{}'. Expected a single flattened segment",
             name
         )));
     }
 
-    let origin = PluginOrigin::from_marketplace(parts[0], parts[1]);
-    Ok((origin, parts[2]))
+    // フラット配置では origin を復元できないためプレースホルダを埋める。
+    Ok((PluginOrigin::from_marketplace("_", "_"), name))
 }
 
 #[cfg(test)]

--- a/src/sync/source.rs
+++ b/src/sync/source.rs
@@ -7,6 +7,7 @@ use crate::component::{
     Scope,
 };
 use crate::error::{PlmError, Result};
+use crate::scan::is_instruction_file;
 use crate::target::{parse_target, PluginOrigin, Target, TargetKind};
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
@@ -177,7 +178,7 @@ impl SyncSource {
 /// * `name` - フラット化された Component 名、または Instruction のファイル名。
 pub fn parse_component_name(name: &str) -> Result<(PluginOrigin, &str)> {
     // Instruction の特別扱い
-    if name == "AGENTS.md" || name == "copilot-instructions.md" || name == "GEMINI.md" {
+    if is_instruction_file(name) {
         return Ok((PluginOrigin::from_marketplace("", ""), name));
     }
 

--- a/src/sync/source_test.rs
+++ b/src/sync/source_test.rs
@@ -1,15 +1,16 @@
 use super::*;
 
 #[test]
-fn test_parse_component_name_valid() {
-    let (origin, name) = parse_component_name("github/my-plugin/my-skill").unwrap();
-    assert_eq!(origin.marketplace, "github");
-    assert_eq!(origin.plugin, "my-plugin");
-    assert_eq!(name, "my-skill");
+fn test_parse_component_name_single_segment() {
+    let (origin, name) = parse_component_name("test-plugin_my-skill").unwrap();
+    // フラット化後は origin は復元できないためプレースホルダ
+    assert_eq!(origin.marketplace, "_");
+    assert_eq!(origin.plugin, "_");
+    assert_eq!(name, "test-plugin_my-skill");
 }
 
 #[test]
-fn test_parse_component_name_instruction() {
+fn test_parse_component_name_instruction_agents() {
     let (origin, name) = parse_component_name("AGENTS.md").unwrap();
     assert_eq!(origin.marketplace, "");
     assert_eq!(origin.plugin, "");
@@ -17,7 +18,7 @@ fn test_parse_component_name_instruction() {
 }
 
 #[test]
-fn test_parse_component_name_gemini_instruction() {
+fn test_parse_component_name_instruction_gemini() {
     let (origin, name) = parse_component_name("GEMINI.md").unwrap();
     assert_eq!(origin.marketplace, "");
     assert_eq!(origin.plugin, "");
@@ -25,10 +26,22 @@ fn test_parse_component_name_gemini_instruction() {
 }
 
 #[test]
-fn test_parse_component_name_error() {
-    let result = parse_component_name("invalid");
+fn test_parse_component_name_instruction_copilot() {
+    let (origin, name) = parse_component_name("copilot-instructions.md").unwrap();
+    assert_eq!(origin.marketplace, "");
+    assert_eq!(origin.plugin, "");
+    assert_eq!(name, "copilot-instructions.md");
+}
+
+#[test]
+fn test_parse_component_name_rejects_slashes() {
+    // 旧 3 セグメント形式は破壊的変更で拒否される
+    let result = parse_component_name("github/my-plugin/my-skill");
     assert!(result.is_err());
 
     let result = parse_component_name("only/two");
+    assert!(result.is_err());
+
+    let result = parse_component_name("/leading-slash");
     assert!(result.is_err());
 }

--- a/src/sync/source_test.rs
+++ b/src/sync/source_test.rs
@@ -45,3 +45,21 @@ fn test_parse_component_name_rejects_slashes() {
     let result = parse_component_name("/leading-slash");
     assert!(result.is_err());
 }
+
+#[test]
+fn test_parse_component_name_rejects_empty() {
+    let result = parse_component_name("");
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_parse_component_name_rejects_dot_segments() {
+    assert!(parse_component_name(".").is_err());
+    assert!(parse_component_name("..").is_err());
+}
+
+#[test]
+fn test_parse_component_name_rejects_backslashes_and_nul() {
+    assert!(parse_component_name("a\\b").is_err());
+    assert!(parse_component_name("a\0b").is_err());
+}

--- a/src/target.rs
+++ b/src/target.rs
@@ -110,6 +110,20 @@ impl PluginOrigin {
         }
     }
 
+    /// origin が復元できない場面で埋めるプレースホルダ。
+    ///
+    /// フラット 2 階層構造 `<base>/<plural>/<flattened_name>` では配置物から
+    /// `marketplace` / `plugin` を復元できない。スキャン層 (`scan_components`)
+    /// と sync ソース (`parse_component_name`) はいずれも `flattened_name`
+    /// 単独でキー化する想定でこのプレースホルダを埋める。利用側はこの
+    /// フィールドを参照してはならない。
+    pub fn placeholder() -> Self {
+        Self {
+            marketplace: "_".to_string(),
+            plugin: "_".to_string(),
+        }
+    }
+
     /// 配置物の識別キー（フラット化された `name` 単独）を返す。
     ///
     /// `<base>/<plural>/<flattened_name>` 構造ではマーケットプレイス/プラグイン

--- a/src/target.rs
+++ b/src/target.rs
@@ -119,7 +119,6 @@ impl PluginOrigin {
     pub fn qualify(&self, name: &str) -> String {
         // marketplace/plugin はもはや配置物識別に使われないため、引数 self は
         // 互換のためだけに残す。将来の API クリーンアップで削除候補。
-        let _ = (&self.marketplace, &self.plugin);
         name.to_string()
     }
 }

--- a/src/target.rs
+++ b/src/target.rs
@@ -110,12 +110,17 @@ impl PluginOrigin {
         }
     }
 
-    /// `{marketplace}/{plugin}/{name}` 形式の完全修飾名を返す。
+    /// 配置物の識別キー（フラット化された `name` 単独）を返す。
     ///
-    /// target の `filter_component` や list_placed で配置物の識別キーを
-    /// 組み立てる際に使用する。
+    /// `<base>/<plural>/<flattened_name>` 構造ではマーケットプレイス/プラグイン
+    /// 段が存在しないため、配置物からは `flattened_name` のみ復元できる。
+    /// 過去は `{marketplace}/{plugin}/{name}` の 3 セグメントを返していたが、
+    /// フラット化後は識別子としても `name` を返す。
     pub fn qualify(&self, name: &str) -> String {
-        format!("{}/{}/{}", self.marketplace, self.plugin, name)
+        // marketplace/plugin はもはや配置物識別に使われないため、引数 self は
+        // 互換のためだけに残す。将来の API クリーンアップで削除候補。
+        let _ = (&self.marketplace, &self.plugin);
+        name.to_string()
     }
 }
 

--- a/src/target/antigravity.rs
+++ b/src/target/antigravity.rs
@@ -96,7 +96,6 @@ impl Target for AntigravityTarget {
         let scope = context.scope();
         let project_root = context.project_root();
         let base = Self::base_dir(scope, project_root);
-        let _ = context.origin;
         let name = context.name();
 
         Some(match kind {

--- a/src/target/antigravity.rs
+++ b/src/target/antigravity.rs
@@ -96,17 +96,12 @@ impl Target for AntigravityTarget {
         let scope = context.scope();
         let project_root = context.project_root();
         let base = Self::base_dir(scope, project_root);
-        let origin = context.origin;
+        let _ = context.origin;
         let name = context.name();
 
         Some(match kind {
-            // 階層構造: skills/<marketplace>/<plugin>/<skill> (ディレクトリ)
-            ComponentKind::Skill => PlacementLocation::dir(
-                base.join("skills")
-                    .join(&origin.marketplace)
-                    .join(&origin.plugin)
-                    .join(name),
-            ),
+            // フラット構造: skills/<flattened_name> (ディレクトリ)
+            ComponentKind::Skill => PlacementLocation::dir(base.join("skills").join(name)),
             _ => return None,
         })
     }

--- a/src/target/antigravity_test.rs
+++ b/src/target/antigravity_test.rs
@@ -136,12 +136,15 @@ fn test_antigravity_placement_location_agent_returns_none() {
 
 #[test]
 fn test_antigravity_placement_with_hierarchy() {
+    // インストール経路では `Component.name` が `flatten_name(plugin, original)
+    // = "{plugin}_{original}"` に平坦化されるため、origin が GitHub でも
+    // テストはその形を使う。
     let target = AntigravityTarget::new();
     let project_root = Path::new("/project");
     let origin = PluginOrigin::from_github("owner", "repo");
 
     let ctx = PlacementContext {
-        component: ComponentRef::new(ComponentKind::Skill, "my-skill"),
+        component: ComponentRef::new(ComponentKind::Skill, "my-plugin_my-skill"),
         origin: &origin,
         scope: PlacementScope::new(Scope::Project),
         project: ProjectContext::new(project_root),
@@ -151,7 +154,7 @@ fn test_antigravity_placement_with_hierarchy() {
     assert!(location.is_dir());
     assert_eq!(
         location.as_path(),
-        Path::new("/project/.agent/skills/my-skill")
+        Path::new("/project/.agent/skills/my-plugin_my-skill")
     );
 }
 

--- a/src/target/antigravity_test.rs
+++ b/src/target/antigravity_test.rs
@@ -197,9 +197,8 @@ fn test_antigravity_list_placed_with_skills() {
         .list_placed(ComponentKind::Skill, Scope::Project, project_root)
         .unwrap();
     assert_eq!(result.len(), 1);
-    // qualify は Phase 5 で name 単独になる。現状はプレースホルダ origin で
-    // "_/_/<flattened_name>" 形式を返す。
-    assert_eq!(result[0], "_/_/plugin_skill-1");
+    // qualify は name 単独 (= flattened_name) を返す。
+    assert_eq!(result[0], "plugin_skill-1");
 }
 
 #[test]

--- a/src/target/antigravity_test.rs
+++ b/src/target/antigravity_test.rs
@@ -70,12 +70,14 @@ fn test_antigravity_supports_scope_skill_project() {
 
 #[test]
 fn test_antigravity_placement_location_skill_personal() {
+    // インストール経路では `Component.name` が `flatten_name(plugin, original)
+    // = "{plugin}_{original}"` に平坦化されるため、テストもその形を使う。
     let target = AntigravityTarget::new();
     let project_root = Path::new("/project");
     let origin = PluginOrigin::from_marketplace("official", "my-plugin");
 
     let ctx = PlacementContext {
-        component: ComponentRef::new(ComponentKind::Skill, "my-skill"),
+        component: ComponentRef::new(ComponentKind::Skill, "my-plugin_my-skill"),
         origin: &origin,
         scope: PlacementScope::new(Scope::Personal),
         project: ProjectContext::new(project_root),
@@ -89,7 +91,7 @@ fn test_antigravity_placement_location_skill_personal() {
         .join(".gemini")
         .join("antigravity")
         .join("skills")
-        .join("my-skill");
+        .join("my-plugin_my-skill");
     assert_eq!(location.as_path(), expected.as_path());
 }
 

--- a/src/target/antigravity_test.rs
+++ b/src/target/antigravity_test.rs
@@ -97,12 +97,14 @@ fn test_antigravity_placement_location_skill_personal() {
 
 #[test]
 fn test_antigravity_placement_location_skill_project() {
+    // インストール経路では `Component.name` が `flatten_name(plugin, original)
+    // = "{plugin}_{original}"` に平坦化されるため、テストもその形を使う。
     let target = AntigravityTarget::new();
     let project_root = Path::new("/project");
     let origin = PluginOrigin::from_marketplace("official", "my-plugin");
 
     let ctx = PlacementContext {
-        component: ComponentRef::new(ComponentKind::Skill, "my-skill"),
+        component: ComponentRef::new(ComponentKind::Skill, "my-plugin_my-skill"),
         origin: &origin,
         scope: PlacementScope::new(Scope::Project),
         project: ProjectContext::new(project_root),
@@ -113,7 +115,7 @@ fn test_antigravity_placement_location_skill_project() {
     // Project scope uses .agent/skills/
     assert_eq!(
         location.as_path(),
-        Path::new("/project/.agent/skills/my-skill")
+        Path::new("/project/.agent/skills/my-plugin_my-skill")
     );
 }
 

--- a/src/target/antigravity_test.rs
+++ b/src/target/antigravity_test.rs
@@ -185,13 +185,11 @@ fn test_antigravity_list_placed_with_skills() {
     let temp_dir = TempDir::new().unwrap();
     let project_root = temp_dir.path();
 
-    // Create skill directory structure with SKILL.md
+    // フラット 2 階層: .agent/skills/<flattened_name>/SKILL.md
     let skill_path = project_root
         .join(".agent")
         .join("skills")
-        .join("marketplace")
-        .join("plugin")
-        .join("skill-1");
+        .join("plugin_skill-1");
     std::fs::create_dir_all(&skill_path).unwrap();
     std::fs::write(skill_path.join("SKILL.md"), "# Skill 1").unwrap();
 
@@ -199,7 +197,9 @@ fn test_antigravity_list_placed_with_skills() {
         .list_placed(ComponentKind::Skill, Scope::Project, project_root)
         .unwrap();
     assert_eq!(result.len(), 1);
-    assert_eq!(result[0], "marketplace/plugin/skill-1");
+    // qualify は Phase 5 で name 単独になる。現状はプレースホルダ origin で
+    // "_/_/<flattened_name>" 形式を返す。
+    assert_eq!(result[0], "_/_/plugin_skill-1");
 }
 
 #[test]
@@ -208,13 +208,11 @@ fn test_antigravity_list_placed_no_skill_md() {
     let temp_dir = TempDir::new().unwrap();
     let project_root = temp_dir.path();
 
-    // Create skill directory without SKILL.md (should be ignored)
+    // SKILL.md 不在のディレクトリは無視される（フラット構造）
     let skill_path = project_root
         .join(".agent")
         .join("skills")
-        .join("marketplace")
-        .join("plugin")
-        .join("empty-skill");
+        .join("plugin_empty-skill");
     std::fs::create_dir_all(&skill_path).unwrap();
 
     let result = target

--- a/src/target/antigravity_test.rs
+++ b/src/target/antigravity_test.rs
@@ -85,10 +85,7 @@ fn test_antigravity_placement_location_skill_personal() {
     assert!(location.is_dir());
     // Personal scope uses ~/.gemini/antigravity/skills/
     let home = std::env::var("HOME").unwrap();
-    let expected = format!(
-        "{}/.gemini/antigravity/skills/official/my-plugin/my-skill",
-        home
-    );
+    let expected = format!("{}/.gemini/antigravity/skills/my-skill", home);
     assert_eq!(location.as_path(), Path::new(&expected));
 }
 
@@ -110,7 +107,7 @@ fn test_antigravity_placement_location_skill_project() {
     // Project scope uses .agent/skills/
     assert_eq!(
         location.as_path(),
-        Path::new("/project/.agent/skills/official/my-plugin/my-skill")
+        Path::new("/project/.agent/skills/my-skill")
     );
 }
 
@@ -146,7 +143,7 @@ fn test_antigravity_placement_with_hierarchy() {
     assert!(location.is_dir());
     assert_eq!(
         location.as_path(),
-        Path::new("/project/.agent/skills/github/owner--repo/my-skill")
+        Path::new("/project/.agent/skills/my-skill")
     );
 }
 
@@ -165,7 +162,7 @@ fn test_antigravity_placement_location_skill_with_prefixed_name() {
     let location = target.placement_location(&ctx).unwrap();
     assert_eq!(
         location.as_path(),
-        Path::new("/project/.agent/skills/official/my-plugin/myplugin_foo")
+        Path::new("/project/.agent/skills/myplugin_foo")
     );
 }
 

--- a/src/target/antigravity_test.rs
+++ b/src/target/antigravity_test.rs
@@ -85,8 +85,12 @@ fn test_antigravity_placement_location_skill_personal() {
     assert!(location.is_dir());
     // Personal scope uses ~/.gemini/antigravity/skills/
     let home = std::env::var("HOME").unwrap();
-    let expected = format!("{}/.gemini/antigravity/skills/my-skill", home);
-    assert_eq!(location.as_path(), Path::new(&expected));
+    let expected = std::path::PathBuf::from(home)
+        .join(".gemini")
+        .join("antigravity")
+        .join("skills")
+        .join("my-skill");
+    assert_eq!(location.as_path(), expected.as_path());
 }
 
 #[test]

--- a/src/target/codex.rs
+++ b/src/target/codex.rs
@@ -46,7 +46,12 @@ impl CodexTarget {
     fn filter_component(c: &ScannedComponent, kind: ComponentKind) -> Option<String> {
         let make_qualified = |name: &str| c.origin.qualify(name);
         match kind {
-            ComponentKind::Skill if c.is_dir => Some(make_qualified(&c.name)),
+            // Skill: 直下に SKILL.md が存在するディレクトリのみ採用する。
+            // 旧 3 階層 `<plural>/<mp>/<plg>/<skill>/SKILL.md` の中間段
+            // (`<mp>` ディレクトリ等) を Skill と誤認しないための二重防御。
+            ComponentKind::Skill if c.is_dir && c.path.join("SKILL.md").is_file() => {
+                Some(make_qualified(&c.name))
+            }
             ComponentKind::Agent if !c.is_dir && c.name.ends_with(".agent.md") => {
                 let name = c.name.trim_end_matches(".agent.md");
                 Some(make_qualified(name))

--- a/src/target/codex.rs
+++ b/src/target/codex.rs
@@ -95,21 +95,14 @@ impl Target for CodexTarget {
         let origin = context.origin;
         let name = context.name();
 
+        let _ = origin;
         Some(match kind {
-            // 階層構造: skills/<marketplace>/<plugin>/<skill> (ディレクトリ)
-            ComponentKind::Skill => PlacementLocation::dir(
-                base.join("skills")
-                    .join(&origin.marketplace)
-                    .join(&origin.plugin)
-                    .join(name),
-            ),
-            // 階層構造: agents/<marketplace>/<plugin>/<name>.agent.md (ファイル)
-            ComponentKind::Agent => PlacementLocation::file(
-                base.join("agents")
-                    .join(&origin.marketplace)
-                    .join(&origin.plugin)
-                    .join(format!("{}.agent.md", name)),
-            ),
+            // フラット構造: skills/<flattened_name> (ディレクトリ)
+            ComponentKind::Skill => PlacementLocation::dir(base.join("skills").join(name)),
+            // フラット構造: agents/<flattened_name>.agent.md (ファイル)
+            ComponentKind::Agent => {
+                PlacementLocation::file(base.join("agents").join(format!("{}.agent.md", name)))
+            }
             ComponentKind::Instruction => match scope {
                 // Project scope: AGENTS.md is at project root, not in .codex
                 Scope::Project => PlacementLocation::file(project_root.join("AGENTS.md")),

--- a/src/target/codex.rs
+++ b/src/target/codex.rs
@@ -97,10 +97,8 @@ impl Target for CodexTarget {
         let scope = context.scope();
         let project_root = context.project_root();
         let base = Self::base_dir(scope, project_root);
-        let origin = context.origin;
         let name = context.name();
 
-        let _ = origin;
         Some(match kind {
             // フラット構造: skills/<flattened_name> (ディレクトリ)
             ComponentKind::Skill => PlacementLocation::dir(base.join("skills").join(name)),

--- a/src/target/codex_test.rs
+++ b/src/target/codex_test.rs
@@ -36,7 +36,7 @@ fn test_codex_placement_location_skill_with_hierarchy() {
     assert!(location.is_dir());
     assert_eq!(
         location.as_path(),
-        Path::new("/project/.codex/skills/official/my-plugin/my-skill")
+        Path::new("/project/.codex/skills/my-skill")
     );
 }
 
@@ -57,7 +57,7 @@ fn test_codex_placement_location_skill_github_direct() {
     assert!(location.is_dir());
     assert_eq!(
         location.as_path(),
-        Path::new("/project/.codex/skills/github/owner--repo/my-skill")
+        Path::new("/project/.codex/skills/my-skill")
     );
 }
 
@@ -78,7 +78,7 @@ fn test_codex_placement_location_agent() {
     assert!(location.is_file());
     assert_eq!(
         location.as_path(),
-        Path::new("/project/.codex/agents/official/my-plugin/my-agent.agent.md")
+        Path::new("/project/.codex/agents/my-agent.agent.md")
     );
 }
 
@@ -116,7 +116,7 @@ fn test_codex_placement_location_skill_with_prefixed_name() {
     let location = target.placement_location(&ctx).unwrap();
     assert_eq!(
         location.as_path(),
-        Path::new("/project/.codex/skills/official/my-plugin/myplugin_foo")
+        Path::new("/project/.codex/skills/myplugin_foo")
     );
 }
 
@@ -135,7 +135,7 @@ fn test_codex_placement_location_agent_with_prefixed_name() {
     let location = target.placement_location(&ctx).unwrap();
     assert_eq!(
         location.as_path(),
-        Path::new("/project/.codex/agents/official/my-plugin/myplugin_foo.agent.md")
+        Path::new("/project/.codex/agents/myplugin_foo.agent.md")
     );
 }
 

--- a/src/target/codex_test.rs
+++ b/src/target/codex_test.rs
@@ -21,12 +21,14 @@ fn test_codex_supported_components() {
 
 #[test]
 fn test_codex_placement_location_skill_with_hierarchy() {
+    // インストール経路では `Component.name` が `flatten_name(plugin, original)
+    // = "{plugin}_{original}"` に平坦化されるため、テストもその形を使う。
     let target = CodexTarget::new();
     let project_root = Path::new("/project");
     let origin = PluginOrigin::from_marketplace("official", "my-plugin");
 
     let ctx = PlacementContext {
-        component: ComponentRef::new(ComponentKind::Skill, "my-skill"),
+        component: ComponentRef::new(ComponentKind::Skill, "my-plugin_my-skill"),
         origin: &origin,
         scope: PlacementScope::new(Scope::Project),
         project: ProjectContext::new(project_root),
@@ -36,7 +38,7 @@ fn test_codex_placement_location_skill_with_hierarchy() {
     assert!(location.is_dir());
     assert_eq!(
         location.as_path(),
-        Path::new("/project/.codex/skills/my-skill")
+        Path::new("/project/.codex/skills/my-plugin_my-skill")
     );
 }
 

--- a/src/target/codex_test.rs
+++ b/src/target/codex_test.rs
@@ -68,12 +68,14 @@ fn test_codex_placement_location_skill_github_direct() {
 
 #[test]
 fn test_codex_placement_location_agent() {
+    // インストール経路では `Component.name` が `flatten_name(plugin, original)
+    // = "{plugin}_{original}"` に平坦化されるため、テストもその形を使う。
     let target = CodexTarget::new();
     let project_root = Path::new("/project");
     let origin = PluginOrigin::from_marketplace("official", "my-plugin");
 
     let ctx = PlacementContext {
-        component: ComponentRef::new(ComponentKind::Agent, "my-agent"),
+        component: ComponentRef::new(ComponentKind::Agent, "my-plugin_my-agent"),
         origin: &origin,
         scope: PlacementScope::new(Scope::Project),
         project: ProjectContext::new(project_root),
@@ -83,7 +85,7 @@ fn test_codex_placement_location_agent() {
     assert!(location.is_file());
     assert_eq!(
         location.as_path(),
-        Path::new("/project/.codex/agents/my-agent.agent.md")
+        Path::new("/project/.codex/agents/my-plugin_my-agent.agent.md")
     );
 }
 

--- a/src/target/codex_test.rs
+++ b/src/target/codex_test.rs
@@ -44,12 +44,15 @@ fn test_codex_placement_location_skill_with_hierarchy() {
 
 #[test]
 fn test_codex_placement_location_skill_github_direct() {
+    // インストール経路では `Component.name` が `flatten_name(plugin, original)
+    // = "{plugin}_{original}"` に平坦化されるため、origin の種別 (github) に
+    // 関わらずテストもその形を使う。
     let target = CodexTarget::new();
     let project_root = Path::new("/project");
     let origin = PluginOrigin::from_github("owner", "repo");
 
     let ctx = PlacementContext {
-        component: ComponentRef::new(ComponentKind::Skill, "my-skill"),
+        component: ComponentRef::new(ComponentKind::Skill, "my-plugin_my-skill"),
         origin: &origin,
         scope: PlacementScope::new(Scope::Project),
         project: ProjectContext::new(project_root),
@@ -59,7 +62,7 @@ fn test_codex_placement_location_skill_github_direct() {
     assert!(location.is_dir());
     assert_eq!(
         location.as_path(),
-        Path::new("/project/.codex/skills/my-skill")
+        Path::new("/project/.codex/skills/my-plugin_my-skill")
     );
 }
 

--- a/src/target/copilot.rs
+++ b/src/target/copilot.rs
@@ -56,7 +56,10 @@ impl CopilotTarget {
     fn filter_component(c: &ScannedComponent, kind: ComponentKind) -> Option<String> {
         let make_qualified = |name: &str| c.origin.qualify(name);
         match kind {
-            ComponentKind::Skill if c.is_dir => Some(make_qualified(&c.name)),
+            // Skill: SKILL.md が直下にあるディレクトリのみ採用（二重防御）。
+            ComponentKind::Skill if c.is_dir && c.path.join("SKILL.md").is_file() => {
+                Some(make_qualified(&c.name))
+            }
             ComponentKind::Agent if !c.is_dir && c.name.ends_with(".agent.md") => {
                 Some(make_qualified(c.name.trim_end_matches(".agent.md")))
             }

--- a/src/target/copilot.rs
+++ b/src/target/copilot.rs
@@ -112,10 +112,8 @@ impl Target for CopilotTarget {
 
         let project_root = context.project_root();
         let base = Self::base_dir(scope, project_root);
-        let origin = context.origin;
         let name = context.name();
 
-        let _ = origin;
         Some(match kind {
             // フラット構造: skills/<flattened_name> (ディレクトリ)
             ComponentKind::Skill => PlacementLocation::dir(base.join("skills").join(name)),

--- a/src/target/copilot.rs
+++ b/src/target/copilot.rs
@@ -112,37 +112,25 @@ impl Target for CopilotTarget {
         let origin = context.origin;
         let name = context.name();
 
+        let _ = origin;
         Some(match kind {
-            // 階層構造: skills/<marketplace>/<plugin>/<skill> (ディレクトリ)
-            ComponentKind::Skill => PlacementLocation::dir(
-                base.join("skills")
-                    .join(&origin.marketplace)
-                    .join(&origin.plugin)
-                    .join(name),
-            ),
-            // 階層構造: agents/<marketplace>/<plugin>/<name>.agent.md (ファイル)
-            ComponentKind::Agent => PlacementLocation::file(
-                base.join("agents")
-                    .join(&origin.marketplace)
-                    .join(&origin.plugin)
-                    .join(format!("{}.agent.md", name)),
-            ),
-            // 階層構造: prompts/<marketplace>/<plugin>/<name>.prompt.md (ファイル)
-            ComponentKind::Command => PlacementLocation::file(
-                base.join("prompts")
-                    .join(&origin.marketplace)
-                    .join(&origin.plugin)
-                    .join(format!("{}.prompt.md", name)),
-            ),
+            // フラット構造: skills/<flattened_name> (ディレクトリ)
+            ComponentKind::Skill => PlacementLocation::dir(base.join("skills").join(name)),
+            // フラット構造: agents/<flattened_name>.agent.md (ファイル)
+            ComponentKind::Agent => {
+                PlacementLocation::file(base.join("agents").join(format!("{}.agent.md", name)))
+            }
+            // フラット構造: prompts/<flattened_name>.prompt.md (ファイル)
+            ComponentKind::Command => {
+                PlacementLocation::file(base.join("prompts").join(format!("{}.prompt.md", name)))
+            }
             ComponentKind::Instruction => {
                 PlacementLocation::file(base.join("copilot-instructions.md"))
             }
-            ComponentKind::Hook => PlacementLocation::file(
-                base.join("hooks")
-                    .join(&origin.marketplace)
-                    .join(&origin.plugin)
-                    .join(format!("{}.json", name)),
-            ),
+            // フラット構造: hooks/<flattened_name>.json (ファイル)
+            ComponentKind::Hook => {
+                PlacementLocation::file(base.join("hooks").join(format!("{}.json", name)))
+            }
         })
     }
 

--- a/src/target/copilot_test.rs
+++ b/src/target/copilot_test.rs
@@ -52,7 +52,7 @@ fn test_copilot_placement_location_skill_project() {
     assert!(location.is_dir());
     assert_eq!(
         location.as_path(),
-        Path::new("/project/.github/skills/official/my-plugin/my-skill")
+        Path::new("/project/.github/skills/my-skill")
     );
 }
 
@@ -74,7 +74,7 @@ fn test_copilot_placement_location_agent() {
     assert!(location_personal
         .as_path()
         .to_string_lossy()
-        .contains(".copilot/agents/official/my-plugin/test.agent.md"));
+        .contains(".copilot/agents/test.agent.md"));
 
     // Project scope
     let ctx_project = PlacementContext {
@@ -87,7 +87,7 @@ fn test_copilot_placement_location_agent() {
     assert!(location_project.is_file());
     assert_eq!(
         location_project.as_path(),
-        Path::new("/project/.github/agents/official/my-plugin/test.agent.md")
+        Path::new("/project/.github/agents/test.agent.md")
     );
 }
 
@@ -117,7 +117,7 @@ fn test_copilot_placement_location_command() {
     assert!(location.is_file());
     assert_eq!(
         location.as_path(),
-        Path::new("/project/.github/prompts/official/my-plugin/my-command.prompt.md")
+        Path::new("/project/.github/prompts/my-command.prompt.md")
     );
 }
 
@@ -156,7 +156,7 @@ fn test_copilot_placement_location_with_prefixed_name() {
     };
     assert_eq!(
         target.placement_location(&skill_ctx).unwrap().as_path(),
-        Path::new("/project/.github/skills/official/my-plugin/myplugin_foo")
+        Path::new("/project/.github/skills/myplugin_foo")
     );
 
     let cmd_ctx = PlacementContext {
@@ -167,7 +167,7 @@ fn test_copilot_placement_location_with_prefixed_name() {
     };
     assert_eq!(
         target.placement_location(&cmd_ctx).unwrap().as_path(),
-        Path::new("/project/.github/prompts/official/my-plugin/myplugin_foo.prompt.md")
+        Path::new("/project/.github/prompts/myplugin_foo.prompt.md")
     );
 }
 
@@ -250,7 +250,7 @@ fn test_copilot_placement_location_hook_project() {
     assert!(location.is_file());
     assert_eq!(
         location.as_path(),
-        Path::new("/project/.github/hooks/official/my-plugin/pre-commit.json")
+        Path::new("/project/.github/hooks/pre-commit.json")
     );
 }
 
@@ -272,7 +272,28 @@ fn test_copilot_placement_location_hook_personal() {
     assert!(location
         .as_path()
         .to_string_lossy()
-        .contains(".copilot/hooks/official/my-plugin/pre-commit.json"));
+        .contains(".copilot/hooks/pre-commit.json"));
+}
+
+#[test]
+fn test_copilot_placement_location_hook_with_prefixed_name() {
+    let target = CopilotTarget::new();
+    let project_root = Path::new("/project");
+    let origin = PluginOrigin::from_marketplace("official", "my-plugin");
+
+    let ctx = PlacementContext {
+        component: ComponentRef::new(ComponentKind::Hook, "my-plugin_pre-commit"),
+        origin: &origin,
+        scope: PlacementScope::new(Scope::Project),
+        project: ProjectContext::new(project_root),
+    };
+    let location = target.placement_location(&ctx).unwrap();
+
+    assert!(location.is_file());
+    assert_eq!(
+        location.as_path(),
+        Path::new("/project/.github/hooks/my-plugin_pre-commit.json")
+    );
 }
 
 #[test]

--- a/src/target/copilot_test.rs
+++ b/src/target/copilot_test.rs
@@ -235,12 +235,14 @@ fn test_copilot_agent_single_file_edge_case() {
 
 #[test]
 fn test_copilot_placement_location_hook_project() {
+    // フラット化後は Hook も `flatten_name(plugin, original) = "{plugin}_{stem}"`
+    // で配置されるため、テストもプリフィックス済みの名前を使う。
     let target = CopilotTarget::new();
     let project_root = Path::new("/project");
     let origin = PluginOrigin::from_marketplace("official", "my-plugin");
 
     let ctx = PlacementContext {
-        component: ComponentRef::new(ComponentKind::Hook, "pre-commit"),
+        component: ComponentRef::new(ComponentKind::Hook, "my-plugin_pre-commit"),
         origin: &origin,
         scope: PlacementScope::new(Scope::Project),
         project: ProjectContext::new(project_root),
@@ -250,7 +252,7 @@ fn test_copilot_placement_location_hook_project() {
     assert!(location.is_file());
     assert_eq!(
         location.as_path(),
-        Path::new("/project/.github/hooks/pre-commit.json")
+        Path::new("/project/.github/hooks/my-plugin_pre-commit.json")
     );
 }
 
@@ -273,27 +275,6 @@ fn test_copilot_placement_location_hook_personal() {
         .as_path()
         .to_string_lossy()
         .contains(".copilot/hooks/pre-commit.json"));
-}
-
-#[test]
-fn test_copilot_placement_location_hook_with_prefixed_name() {
-    let target = CopilotTarget::new();
-    let project_root = Path::new("/project");
-    let origin = PluginOrigin::from_marketplace("official", "my-plugin");
-
-    let ctx = PlacementContext {
-        component: ComponentRef::new(ComponentKind::Hook, "my-plugin_pre-commit"),
-        origin: &origin,
-        scope: PlacementScope::new(Scope::Project),
-        project: ProjectContext::new(project_root),
-    };
-    let location = target.placement_location(&ctx).unwrap();
-
-    assert!(location.is_file());
-    assert_eq!(
-        location.as_path(),
-        Path::new("/project/.github/hooks/my-plugin_pre-commit.json")
-    );
 }
 
 #[test]

--- a/src/target/copilot_test.rs
+++ b/src/target/copilot_test.rs
@@ -272,10 +272,11 @@ fn test_copilot_placement_location_hook_personal() {
     let location = target.placement_location(&ctx).unwrap();
 
     assert!(location.is_file());
-    assert!(location
-        .as_path()
-        .to_string_lossy()
-        .contains(".copilot/hooks/my-plugin_pre-commit.json"));
+    assert!(location.as_path().ends_with(
+        Path::new(".copilot")
+            .join("hooks")
+            .join("my-plugin_pre-commit.json")
+    ));
 }
 
 #[test]

--- a/src/target/copilot_test.rs
+++ b/src/target/copilot_test.rs
@@ -258,12 +258,14 @@ fn test_copilot_placement_location_hook_project() {
 
 #[test]
 fn test_copilot_placement_location_hook_personal() {
+    // フラット化後は Hook も `flatten_name(plugin, original) = "{plugin}_{stem}"`
+    // で配置されるため、テストもプリフィックス済みの名前を使う。
     let target = CopilotTarget::new();
     let project_root = Path::new("/project");
     let origin = PluginOrigin::from_marketplace("official", "my-plugin");
 
     let ctx = PlacementContext {
-        component: ComponentRef::new(ComponentKind::Hook, "pre-commit"),
+        component: ComponentRef::new(ComponentKind::Hook, "my-plugin_pre-commit"),
         origin: &origin,
         scope: PlacementScope::new(Scope::Personal),
         project: ProjectContext::new(project_root),
@@ -274,7 +276,7 @@ fn test_copilot_placement_location_hook_personal() {
     assert!(location
         .as_path()
         .to_string_lossy()
-        .contains(".copilot/hooks/pre-commit.json"));
+        .contains(".copilot/hooks/my-plugin_pre-commit.json"));
 }
 
 #[test]

--- a/src/target/copilot_test.rs
+++ b/src/target/copilot_test.rs
@@ -317,7 +317,7 @@ fn test_copilot_list_placed_hooks() {
     assert_eq!(result.len(), 1);
     // origin は scanner プレースホルダ ("_") のため qualify は "_/_/<name>"
     // を返す。Phase 5 で qualify を name 単独へ変更するまでこの形式を期待する。
-    assert_eq!(result[0], "_/_/my-plugin_pre-commit");
+    assert_eq!(result[0], "my-plugin_pre-commit");
 }
 
 #[test]
@@ -353,5 +353,5 @@ fn test_copilot_filter_component_skill_requires_skill_md() {
         .list_placed(ComponentKind::Skill, Scope::Project, project_root)
         .unwrap();
     assert_eq!(result.len(), 1);
-    assert_eq!(result[0], "_/_/plugin_my-skill");
+    assert_eq!(result[0], "plugin_my-skill");
 }

--- a/src/target/copilot_test.rs
+++ b/src/target/copilot_test.rs
@@ -304,14 +304,10 @@ fn test_copilot_list_placed_hooks() {
     let temp = TempDir::new().unwrap();
     let project_root = temp.path();
 
-    // hooks ディレクトリ構造を作成: .github/hooks/mkt/plugin/hook.json
-    let hooks_dir = project_root
-        .join(".github")
-        .join("hooks")
-        .join("official")
-        .join("my-plugin");
+    // フラット 2 階層構造: .github/hooks/<flattened_name>.json
+    let hooks_dir = project_root.join(".github").join("hooks");
     fs::create_dir_all(&hooks_dir).unwrap();
-    fs::write(hooks_dir.join("pre-commit.json"), "{}").unwrap();
+    fs::write(hooks_dir.join("my-plugin_pre-commit.json"), "{}").unwrap();
 
     let target = CopilotTarget::new();
     let result = target
@@ -319,5 +315,43 @@ fn test_copilot_list_placed_hooks() {
         .unwrap();
 
     assert_eq!(result.len(), 1);
-    assert_eq!(result[0], "official/my-plugin/pre-commit");
+    // origin は scanner プレースホルダ ("_") のため qualify は "_/_/<name>"
+    // を返す。Phase 5 で qualify を name 単独へ変更するまでこの形式を期待する。
+    assert_eq!(result[0], "_/_/my-plugin_pre-commit");
+}
+
+#[test]
+fn test_copilot_filter_component_skill_requires_skill_md() {
+    use std::fs;
+    use tempfile::TempDir;
+
+    let temp = TempDir::new().unwrap();
+    let project_root = temp.path();
+
+    // SKILL.md なしの Skill ディレクトリ -> Skill 扱いされない
+    let skill_dir = project_root
+        .join(".github")
+        .join("skills")
+        .join("plugin_no-skill-md");
+    fs::create_dir_all(&skill_dir).unwrap();
+
+    let target = CopilotTarget::new();
+    let result = target
+        .list_placed(ComponentKind::Skill, Scope::Project, project_root)
+        .unwrap();
+    assert!(result.is_empty(), "Skill without SKILL.md must be ignored");
+
+    // SKILL.md ありの Skill ディレクトリ -> Skill として認識
+    let valid_skill = project_root
+        .join(".github")
+        .join("skills")
+        .join("plugin_my-skill");
+    fs::create_dir_all(&valid_skill).unwrap();
+    fs::write(valid_skill.join("SKILL.md"), "# Skill").unwrap();
+
+    let result = target
+        .list_placed(ComponentKind::Skill, Scope::Project, project_root)
+        .unwrap();
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0], "_/_/plugin_my-skill");
 }

--- a/src/target/copilot_test.rs
+++ b/src/target/copilot_test.rs
@@ -60,26 +60,30 @@ fn test_copilot_placement_location_skill_project() {
 
 #[test]
 fn test_copilot_placement_location_agent() {
+    // インストール経路では Agent も `flatten_name(plugin, original)
+    // = "{plugin}_{original}"` に平坦化されるため、テストもその形を使う。
     let target = CopilotTarget::new();
     let project_root = Path::new("/project");
     let origin = PluginOrigin::from_marketplace("official", "my-plugin");
 
     // Personal scope
     let ctx_personal = PlacementContext {
-        component: ComponentRef::new(ComponentKind::Agent, "test"),
+        component: ComponentRef::new(ComponentKind::Agent, "my-plugin_test"),
         origin: &origin,
         scope: PlacementScope::new(Scope::Personal),
         project: ProjectContext::new(project_root),
     };
     let location_personal = target.placement_location(&ctx_personal).unwrap();
     assert!(location_personal.is_file());
-    assert!(location_personal
-        .as_path()
-        .ends_with(Path::new(".copilot").join("agents").join("test.agent.md")));
+    assert!(location_personal.as_path().ends_with(
+        Path::new(".copilot")
+            .join("agents")
+            .join("my-plugin_test.agent.md")
+    ));
 
     // Project scope
     let ctx_project = PlacementContext {
-        component: ComponentRef::new(ComponentKind::Agent, "test"),
+        component: ComponentRef::new(ComponentKind::Agent, "my-plugin_test"),
         origin: &origin,
         scope: PlacementScope::new(Scope::Project),
         project: ProjectContext::new(project_root),
@@ -88,7 +92,7 @@ fn test_copilot_placement_location_agent() {
     assert!(location_project.is_file());
     assert_eq!(
         location_project.as_path(),
-        Path::new("/project/.github/agents/test.agent.md")
+        Path::new("/project/.github/agents/my-plugin_test.agent.md")
     );
 }
 

--- a/src/target/copilot_test.rs
+++ b/src/target/copilot_test.rs
@@ -98,13 +98,15 @@ fn test_copilot_placement_location_agent() {
 
 #[test]
 fn test_copilot_placement_location_command() {
+    // インストール経路では Command も `flatten_name(plugin, original)
+    // = "{plugin}_{original}"` に平坦化されるため、テストもその形を使う。
     let target = CopilotTarget::new();
     let project_root = Path::new("/project");
     let origin = PluginOrigin::from_marketplace("official", "my-plugin");
 
     // Personal scope for commands is not supported
     let ctx_personal = PlacementContext {
-        component: ComponentRef::new(ComponentKind::Command, "my-command"),
+        component: ComponentRef::new(ComponentKind::Command, "my-plugin_my-command"),
         origin: &origin,
         scope: PlacementScope::new(Scope::Personal),
         project: ProjectContext::new(project_root),
@@ -113,7 +115,7 @@ fn test_copilot_placement_location_command() {
 
     // Project scope
     let ctx_project = PlacementContext {
-        component: ComponentRef::new(ComponentKind::Command, "my-command"),
+        component: ComponentRef::new(ComponentKind::Command, "my-plugin_my-command"),
         origin: &origin,
         scope: PlacementScope::new(Scope::Project),
         project: ProjectContext::new(project_root),
@@ -122,7 +124,7 @@ fn test_copilot_placement_location_command() {
     assert!(location.is_file());
     assert_eq!(
         location.as_path(),
-        Path::new("/project/.github/prompts/my-command.prompt.md")
+        Path::new("/project/.github/prompts/my-plugin_my-command.prompt.md")
     );
 }
 

--- a/src/target/copilot_test.rs
+++ b/src/target/copilot_test.rs
@@ -73,8 +73,7 @@ fn test_copilot_placement_location_agent() {
     assert!(location_personal.is_file());
     assert!(location_personal
         .as_path()
-        .to_string_lossy()
-        .contains(".copilot/agents/test.agent.md"));
+        .ends_with(Path::new(".copilot").join("agents").join("test.agent.md")));
 
     // Project scope
     let ctx_project = PlacementContext {

--- a/src/target/copilot_test.rs
+++ b/src/target/copilot_test.rs
@@ -37,12 +37,14 @@ fn test_copilot_skill_personal_not_supported() {
 
 #[test]
 fn test_copilot_placement_location_skill_project() {
+    // インストール経路では `Component.name` が `flatten_name(plugin, original)
+    // = "{plugin}_{original}"` に平坦化されるため、テストもその形を使う。
     let target = CopilotTarget::new();
     let project_root = Path::new("/project");
     let origin = PluginOrigin::from_marketplace("official", "my-plugin");
 
     let ctx = PlacementContext {
-        component: ComponentRef::new(ComponentKind::Skill, "my-skill"),
+        component: ComponentRef::new(ComponentKind::Skill, "my-plugin_my-skill"),
         origin: &origin,
         scope: PlacementScope::new(Scope::Project),
         project: ProjectContext::new(project_root),
@@ -52,7 +54,7 @@ fn test_copilot_placement_location_skill_project() {
     assert!(location.is_dir());
     assert_eq!(
         location.as_path(),
-        Path::new("/project/.github/skills/my-skill")
+        Path::new("/project/.github/skills/my-plugin_my-skill")
     );
 }
 

--- a/src/target/copilot_test.rs
+++ b/src/target/copilot_test.rs
@@ -315,8 +315,8 @@ fn test_copilot_list_placed_hooks() {
         .unwrap();
 
     assert_eq!(result.len(), 1);
-    // origin は scanner プレースホルダ ("_") のため qualify は "_/_/<name>"
-    // を返す。Phase 5 で qualify を name 単独へ変更するまでこの形式を期待する。
+    // origin は scanner プレースホルダ ("_") だが、`PluginOrigin::qualify` は
+    // フラット化以降 `name` 単独を返すため、そのまま flattened_name を期待する。
     assert_eq!(result[0], "my-plugin_pre-commit");
 }
 

--- a/src/target/gemini_cli.rs
+++ b/src/target/gemini_cli.rs
@@ -90,16 +90,11 @@ impl Target for GeminiCliTarget {
         let scope = context.scope();
         let project_root = context.project_root();
         let base = Self::base_dir(scope, project_root);
-        let origin = context.origin;
+        let _ = context.origin;
         let name = context.name();
 
         Some(match kind {
-            ComponentKind::Skill => PlacementLocation::dir(
-                base.join("skills")
-                    .join(&origin.marketplace)
-                    .join(&origin.plugin)
-                    .join(name),
-            ),
+            ComponentKind::Skill => PlacementLocation::dir(base.join("skills").join(name)),
             ComponentKind::Instruction => match scope {
                 Scope::Project => PlacementLocation::file(project_root.join("GEMINI.md")),
                 Scope::Personal => PlacementLocation::file(base.join("GEMINI.md")),

--- a/src/target/gemini_cli.rs
+++ b/src/target/gemini_cli.rs
@@ -90,7 +90,6 @@ impl Target for GeminiCliTarget {
         let scope = context.scope();
         let project_root = context.project_root();
         let base = Self::base_dir(scope, project_root);
-        let _ = context.origin;
         let name = context.name();
 
         Some(match kind {

--- a/src/target/gemini_cli_test.rs
+++ b/src/target/gemini_cli_test.rs
@@ -233,12 +233,14 @@ fn test_gemini_cli_placement_location_hook_returns_none() {
 
 #[test]
 fn test_gemini_cli_placement_with_github_origin() {
+    // インストール経路では `Component.name` が `flatten_name(plugin, original)
+    // = "{plugin}_{original}"` に平坦化される（origin 種別 github でも同じ）。
     let target = GeminiCliTarget::new();
     let project_root = Path::new("/project");
     let origin = PluginOrigin::from_github("owner", "repo");
 
     let ctx = PlacementContext {
-        component: ComponentRef::new(ComponentKind::Skill, "my-skill"),
+        component: ComponentRef::new(ComponentKind::Skill, "my-plugin_my-skill"),
         origin: &origin,
         scope: PlacementScope::new(Scope::Project),
         project: ProjectContext::new(project_root),
@@ -248,7 +250,7 @@ fn test_gemini_cli_placement_with_github_origin() {
     assert!(location.is_dir());
     assert_eq!(
         location.as_path(),
-        Path::new("/project/.gemini/skills/my-skill")
+        Path::new("/project/.gemini/skills/my-plugin_my-skill")
     );
 }
 

--- a/src/target/gemini_cli_test.rs
+++ b/src/target/gemini_cli_test.rs
@@ -97,7 +97,7 @@ fn test_gemini_cli_placement_location_skill_personal() {
 
     assert!(location.is_dir());
     let home = std::env::var("HOME").unwrap();
-    let expected = format!("{}/.gemini/skills/official/my-plugin/my-skill", home);
+    let expected = format!("{}/.gemini/skills/my-skill", home);
     assert_eq!(location.as_path(), Path::new(&expected));
 }
 
@@ -118,7 +118,7 @@ fn test_gemini_cli_placement_location_skill_project() {
     assert!(location.is_dir());
     assert_eq!(
         location.as_path(),
-        Path::new("/project/.gemini/skills/official/my-plugin/my-skill")
+        Path::new("/project/.gemini/skills/my-skill")
     );
 }
 
@@ -137,7 +137,7 @@ fn test_gemini_cli_placement_location_skill_with_prefixed_name() {
     let location = target.placement_location(&ctx).unwrap();
     assert_eq!(
         location.as_path(),
-        Path::new("/project/.gemini/skills/official/my-plugin/myplugin_foo")
+        Path::new("/project/.gemini/skills/myplugin_foo")
     );
 }
 
@@ -241,7 +241,7 @@ fn test_gemini_cli_placement_with_github_origin() {
     assert!(location.is_dir());
     assert_eq!(
         location.as_path(),
-        Path::new("/project/.gemini/skills/github/owner--repo/my-skill")
+        Path::new("/project/.gemini/skills/my-skill")
     );
 }
 

--- a/src/target/gemini_cli_test.rs
+++ b/src/target/gemini_cli_test.rs
@@ -83,12 +83,14 @@ fn test_gemini_cli_supports_scope_instruction_project() {
 
 #[test]
 fn test_gemini_cli_placement_location_skill_personal() {
+    // インストール経路では `Component.name` が `flatten_name(plugin, original)
+    // = "{plugin}_{original}"` に平坦化されるため、テストもその形を使う。
     let target = GeminiCliTarget::new();
     let project_root = Path::new("/project");
     let origin = PluginOrigin::from_marketplace("official", "my-plugin");
 
     let ctx = PlacementContext {
-        component: ComponentRef::new(ComponentKind::Skill, "my-skill"),
+        component: ComponentRef::new(ComponentKind::Skill, "my-plugin_my-skill"),
         origin: &origin,
         scope: PlacementScope::new(Scope::Personal),
         project: ProjectContext::new(project_root),
@@ -100,7 +102,7 @@ fn test_gemini_cli_placement_location_skill_personal() {
     let expected = std::path::PathBuf::from(home)
         .join(".gemini")
         .join("skills")
-        .join("my-skill");
+        .join("my-plugin_my-skill");
     assert_eq!(location.as_path(), expected.as_path());
 }
 

--- a/src/target/gemini_cli_test.rs
+++ b/src/target/gemini_cli_test.rs
@@ -263,12 +263,11 @@ fn test_gemini_cli_list_placed_with_skills() {
     let temp_dir = TempDir::new().unwrap();
     let project_root = temp_dir.path();
 
+    // フラット 2 階層: .gemini/skills/<flattened_name>/SKILL.md
     let skill_path = project_root
         .join(".gemini")
         .join("skills")
-        .join("marketplace")
-        .join("plugin")
-        .join("skill-1");
+        .join("plugin_skill-1");
     std::fs::create_dir_all(&skill_path).unwrap();
     std::fs::write(skill_path.join("SKILL.md"), "# Skill 1").unwrap();
 
@@ -276,7 +275,7 @@ fn test_gemini_cli_list_placed_with_skills() {
         .list_placed(ComponentKind::Skill, Scope::Project, project_root)
         .unwrap();
     assert_eq!(result.len(), 1);
-    assert_eq!(result[0], "marketplace/plugin/skill-1");
+    assert_eq!(result[0], "_/_/plugin_skill-1");
 }
 
 #[test]
@@ -288,9 +287,7 @@ fn test_gemini_cli_list_placed_no_skill_md() {
     let skill_path = project_root
         .join(".gemini")
         .join("skills")
-        .join("marketplace")
-        .join("plugin")
-        .join("empty-skill");
+        .join("plugin_empty-skill");
     std::fs::create_dir_all(&skill_path).unwrap();
 
     let result = target

--- a/src/target/gemini_cli_test.rs
+++ b/src/target/gemini_cli_test.rs
@@ -275,7 +275,7 @@ fn test_gemini_cli_list_placed_with_skills() {
         .list_placed(ComponentKind::Skill, Scope::Project, project_root)
         .unwrap();
     assert_eq!(result.len(), 1);
-    assert_eq!(result[0], "_/_/plugin_skill-1");
+    assert_eq!(result[0], "plugin_skill-1");
 }
 
 #[test]

--- a/src/target/gemini_cli_test.rs
+++ b/src/target/gemini_cli_test.rs
@@ -97,8 +97,11 @@ fn test_gemini_cli_placement_location_skill_personal() {
 
     assert!(location.is_dir());
     let home = std::env::var("HOME").unwrap();
-    let expected = format!("{}/.gemini/skills/my-skill", home);
-    assert_eq!(location.as_path(), Path::new(&expected));
+    let expected = std::path::PathBuf::from(home)
+        .join(".gemini")
+        .join("skills")
+        .join("my-skill");
+    assert_eq!(location.as_path(), expected.as_path());
 }
 
 #[test]

--- a/src/target/gemini_cli_test.rs
+++ b/src/target/gemini_cli_test.rs
@@ -108,12 +108,14 @@ fn test_gemini_cli_placement_location_skill_personal() {
 
 #[test]
 fn test_gemini_cli_placement_location_skill_project() {
+    // インストール経路では `Component.name` が `flatten_name(plugin, original)
+    // = "{plugin}_{original}"` に平坦化されるため、テストもその形を使う。
     let target = GeminiCliTarget::new();
     let project_root = Path::new("/project");
     let origin = PluginOrigin::from_marketplace("official", "my-plugin");
 
     let ctx = PlacementContext {
-        component: ComponentRef::new(ComponentKind::Skill, "my-skill"),
+        component: ComponentRef::new(ComponentKind::Skill, "my-plugin_my-skill"),
         origin: &origin,
         scope: PlacementScope::new(Scope::Project),
         project: ProjectContext::new(project_root),
@@ -123,7 +125,7 @@ fn test_gemini_cli_placement_location_skill_project() {
     assert!(location.is_dir());
     assert_eq!(
         location.as_path(),
-        Path::new("/project/.gemini/skills/my-skill")
+        Path::new("/project/.gemini/skills/my-plugin_my-skill")
     );
 }
 

--- a/src/target/placed.rs
+++ b/src/target/placed.rs
@@ -5,19 +5,21 @@
 
 use super::all_targets;
 use crate::component::{ComponentKind, Scope};
-use crate::scan::list_placed_plugins;
+use crate::scan::list_placed_components;
 use std::collections::HashSet;
 use std::path::Path;
 
-/// 全ターゲットから配置済みプラグインを収集
+/// 全ターゲットから配置済みコンポーネントの `flattened_name` 集合を収集する。
 ///
 /// 全ターゲット・全コンポーネント種別のデプロイ済みコンポーネントを走査し、
-/// プラグインの (marketplace, plugin_name) の集合を返す。
+/// Instruction ファイル名を除いた `flattened_name` の重複なし集合を返す。
+/// フラット 2 階層構造へ移行後は `(marketplace, plugin)` ペアでは識別できない
+/// ため、戻り値の型を `HashSet<String>` に変更している。
 ///
 /// # Arguments
 ///
 /// * `project_root` - Project root directory used for project-scope lookups.
-pub(crate) fn list_all_placed(project_root: &Path) -> HashSet<(String, String)> {
+pub(crate) fn list_all_placed(project_root: &Path) -> HashSet<String> {
     let targets = all_targets();
     let mut all_items = Vec::new();
 
@@ -33,5 +35,5 @@ pub(crate) fn list_all_placed(project_root: &Path) -> HashSet<(String, String)> 
         }
     }
 
-    list_placed_plugins(&all_items)
+    list_placed_components(&all_items)
 }

--- a/src/target/placed.rs
+++ b/src/target/placed.rs
@@ -30,6 +30,11 @@ pub(crate) fn list_all_placed(project_root: &Path) -> HashSet<String> {
             if !target.supports(*kind) {
                 continue;
             }
+            // Instruction の戻り値は後段の `list_placed_components` で
+            // 除外されるため、ファイルシステム探査自体をスキップする。
+            if matches!(kind, ComponentKind::Instruction) {
+                continue;
+            }
             // エラー時は黙殺（保守的に deployed とみなさない）
             if let Ok(placed) = target.list_placed(*kind, Scope::Project, project_root) {
                 all_items.extend(placed);

--- a/src/target/placed.rs
+++ b/src/target/placed.rs
@@ -11,10 +11,12 @@ use std::path::Path;
 
 /// 全ターゲットから配置済みコンポーネントの `flattened_name` 集合を収集する。
 ///
-/// 全ターゲット・全コンポーネント種別のデプロイ済みコンポーネントを走査し、
+/// 全ターゲット・全コンポーネント種別の **Project scope のみ** を走査し、
 /// Instruction ファイル名を除いた `flattened_name` の重複なし集合を返す。
-/// フラット 2 階層構造へ移行後は `(marketplace, plugin)` ペアでは識別できない
-/// ため、戻り値の型を `HashSet<String>` に変更している。
+/// Personal scope（`~/.codex/`, `~/.copilot/` 等）は走査せず、Personal の
+/// 配置検知は `.plm-meta.json` の `statusByTarget` 経由（`is_enabled` の優先
+/// パス）に委ねる。フラット 2 階層構造へ移行後は `(marketplace, plugin)`
+/// ペアでは識別できないため、戻り値の型を `HashSet<String>` に変更している。
 ///
 /// # Arguments
 ///

--- a/src/target/scanner.rs
+++ b/src/target/scanner.rs
@@ -11,13 +11,6 @@ use std::path::{Path, PathBuf};
 use crate::error::{PlmError, Result};
 use crate::target::PluginOrigin;
 
-/// フラット配置で復元できない origin を埋めるプレースホルダ。
-///
-/// 旧 3 階層構造では `<marketplace>/<plugin>` が判別可能だったが、フラット化後
-/// は配置物 (`<base>/<plural>/<flattened_name>`) からは復元不能。利用側は
-/// `flattened_name` 単独でキー化する想定で、このフィールドは参照しない。
-const ORIGIN_PLACEHOLDER: &str = "_";
-
 /// スキャンで発見したコンポーネント
 #[derive(Debug, Clone)]
 pub struct ScannedComponent {
@@ -54,7 +47,7 @@ pub fn scan_components(base_dir: &Path) -> Result<Vec<ScannedComponent>> {
         // 既存挙動維持: path.is_dir() はメタデータエラーを握りつぶす
         let is_dir = path.is_dir();
         results.push(ScannedComponent {
-            origin: PluginOrigin::from_marketplace(ORIGIN_PLACEHOLDER, ORIGIN_PLACEHOLDER),
+            origin: PluginOrigin::placeholder(),
             name: entry_name_lossy(&entry),
             path,
             is_dir,

--- a/src/target/scanner.rs
+++ b/src/target/scanner.rs
@@ -1,6 +1,9 @@
-//! 3層ディレクトリ構造のスキャン
+//! フラット 1 階層ディレクトリ構造のスキャン
 //!
-//! `<kind>/<marketplace>/<plugin>/<component>` 階層を再帰的に走査する。
+//! `<kind>/<flattened_name>` 構造を 1 階層走査する。`Component.name` は
+//! `flatten_name(plugin_name, original_name)` で平坦化済みのため、中間
+//! ディレクトリは存在しない。`origin` は復元できないためプレースホルダ
+//! (`PluginOrigin { marketplace: "_", plugin: "_" }`) を埋めて返す。
 
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -8,10 +11,12 @@ use std::path::{Path, PathBuf};
 use crate::error::{PlmError, Result};
 use crate::target::PluginOrigin;
 
-/// 3層構造の階層定数（マジックナンバー回避）
-const LEVEL_MARKETPLACE: usize = 0;
-const LEVEL_PLUGIN: usize = 1;
-const LEVEL_COMPONENT: usize = 2;
+/// フラット配置で復元できない origin を埋めるプレースホルダ。
+///
+/// 旧 3 階層構造では `<marketplace>/<plugin>` が判別可能だったが、フラット化後
+/// は配置物 (`<base>/<plural>/<flattened_name>`) からは復元不能。利用側は
+/// `flattened_name` 単独でキー化する想定で、このフィールドは参照しない。
+const ORIGIN_PLACEHOLDER: &str = "_";
 
 /// スキャンで発見したコンポーネント
 #[derive(Debug, Clone)]
@@ -22,7 +27,7 @@ pub struct ScannedComponent {
     pub is_dir: bool,
 }
 
-/// 3層ディレクトリ構造をスキャンしてコンポーネント一覧を取得
+/// フラット 1 階層ディレクトリ構造をスキャンしてコンポーネント一覧を取得
 ///
 /// # 引数
 ///
@@ -43,55 +48,19 @@ pub fn scan_components(base_dir: &Path) -> Result<Vec<ScannedComponent>> {
     }
 
     let mut results = Vec::new();
-    collect_recursively(base_dir, &[], &mut results)?;
-    Ok(results)
-}
-
-/// 再帰的にディレクトリを走査してコンポーネントを収集
-///
-/// # Arguments
-///
-/// * `dir` - Directory currently being traversed.
-/// * `path_parts` - Accumulated path segments from the scan root down to `dir`.
-/// * `results` - Output buffer that receives discovered components.
-fn collect_recursively(
-    dir: &Path,
-    path_parts: &[String],
-    results: &mut Vec<ScannedComponent>,
-) -> Result<()> {
-    let current_level = path_parts.len();
-
-    fs::read_dir(dir)?.try_for_each(|result| -> Result<()> {
-        let entry = result?;
+    for entry in fs::read_dir(base_dir)? {
+        let entry = entry?;
         let path = entry.path();
-        // 既存挙動維持: path.is_dir()はメタデータエラーを握りつぶす
+        // 既存挙動維持: path.is_dir() はメタデータエラーを握りつぶす
         let is_dir = path.is_dir();
-
-        match current_level {
-            LEVEL_COMPONENT => {
-                // 最下層: コンポーネントとして収集
-                results.push(ScannedComponent {
-                    origin: PluginOrigin::from_marketplace(
-                        &path_parts[LEVEL_MARKETPLACE],
-                        &path_parts[LEVEL_PLUGIN],
-                    ),
-                    name: entry_name_lossy(&entry),
-                    path,
-                    is_dir,
-                });
-            }
-            _ if is_dir => {
-                // 中間層: ディレクトリのみ再帰
-                let mut next_parts = path_parts.to_vec();
-                next_parts.push(entry_name_lossy(&entry));
-                collect_recursively(&path, &next_parts, results)?;
-            }
-            _ => {
-                // 中間層のファイル: スキップ
-            }
-        }
-        Ok(())
-    })
+        results.push(ScannedComponent {
+            origin: PluginOrigin::from_marketplace(ORIGIN_PLACEHOLDER, ORIGIN_PLACEHOLDER),
+            name: entry_name_lossy(&entry),
+            path,
+            is_dir,
+        });
+    }
+    Ok(results)
 }
 
 /// ファイル名を取得（lossy変換、エラーにしない）

--- a/src/target/scanner_test.rs
+++ b/src/target/scanner_test.rs
@@ -1,26 +1,26 @@
 //! scanner モジュールのテスト
 
-use super::{scan_components, ScannedComponent};
+use super::scan_components;
 use std::fs;
 use tempfile::TempDir;
 
-/// 3層構造を正常にスキャンできる
+/// フラット 1 階層構造を正常にスキャンできる
 #[test]
-fn test_scan_components_three_level_structure() {
+fn test_scan_components_flat_dir() {
     let temp = TempDir::new().unwrap();
     let base = temp.path();
 
-    // 3層構造を作成: marketplace/plugin/component
-    let component_dir = base.join("official").join("my-plugin").join("my-skill");
+    // フラット構造: `<flattened_name>` を直下に配置
+    let component_dir = base.join("plugin_my-skill");
     fs::create_dir_all(&component_dir).unwrap();
 
     let results = scan_components(base).unwrap();
 
     assert_eq!(results.len(), 1);
     let component = &results[0];
-    assert_eq!(component.origin.marketplace, "official");
-    assert_eq!(component.origin.plugin, "my-plugin");
-    assert_eq!(component.name, "my-skill");
+    assert_eq!(component.origin.marketplace, "_");
+    assert_eq!(component.origin.plugin, "_");
+    assert_eq!(component.name, "plugin_my-skill");
     assert!(component.is_dir);
     assert_eq!(component.path, component_dir);
 }
@@ -36,55 +36,38 @@ fn test_scan_components_nonexistent_dir() {
     assert!(results.is_empty());
 }
 
-/// 中間層のファイルはスキップされる
+/// 直下のファイルもエントリとして拾われる（ディレクトリかどうかは is_dir で区別）
 #[test]
-fn test_scan_components_skips_files_at_intermediate_levels() {
+fn test_scan_components_includes_files_at_top_level() {
     let temp = TempDir::new().unwrap();
     let base = temp.path();
 
-    // 正常な3層構造
-    let component_dir = base.join("mp").join("plugin").join("skill");
-    fs::create_dir_all(&component_dir).unwrap();
-
-    // 中間層にファイルを置く (これはスキップされるべき)
-    fs::write(base.join("mp").join("stray-file.txt"), "ignored").unwrap();
-    fs::write(base.join("top-level-file.txt"), "ignored").unwrap();
+    fs::write(base.join("plugin_foo.agent.md"), "content").unwrap();
+    fs::create_dir_all(base.join("plugin_bar")).unwrap();
 
     let results = scan_components(base).unwrap();
 
-    // 3層構造のコンポーネントのみが取得される
-    assert_eq!(results.len(), 1);
-    assert_eq!(results[0].name, "skill");
+    assert_eq!(results.len(), 2);
+    let dirs: Vec<_> = results.iter().filter(|c| c.is_dir).collect();
+    let files: Vec<_> = results.iter().filter(|c| !c.is_dir).collect();
+    assert_eq!(dirs.len(), 1);
+    assert_eq!(files.len(), 1);
 }
 
-/// 複数のコンポーネントをスキャンできる
+/// 複数のフラットエントリをスキャンできる
 #[test]
 fn test_scan_components_multiple() {
     let temp = TempDir::new().unwrap();
     let base = temp.path();
 
-    // 複数のコンポーネント
-    fs::create_dir_all(base.join("mp1").join("plugin-a").join("skill-1")).unwrap();
-    fs::create_dir_all(base.join("mp1").join("plugin-a").join("skill-2")).unwrap();
-    fs::create_dir_all(base.join("mp2").join("plugin-b").join("agent")).unwrap();
-
-    // ファイルコンポーネントも含む
-    fs::create_dir_all(base.join("mp1").join("plugin-c")).unwrap();
-    fs::write(
-        base.join("mp1").join("plugin-c").join("test.agent.md"),
-        "content",
-    )
-    .unwrap();
+    fs::create_dir_all(base.join("plg-a_skill-1")).unwrap();
+    fs::create_dir_all(base.join("plg-a_skill-2")).unwrap();
+    fs::create_dir_all(base.join("plg-b_skill-3")).unwrap();
+    fs::write(base.join("plg-c_test.agent.md"), "content").unwrap();
 
     let results = scan_components(base).unwrap();
 
     assert_eq!(results.len(), 4);
-
-    // ディレクトリとファイルが両方含まれる
-    let dirs: Vec<_> = results.iter().filter(|c| c.is_dir).collect();
-    let files: Vec<_> = results.iter().filter(|c| !c.is_dir).collect();
-    assert_eq!(dirs.len(), 3);
-    assert_eq!(files.len(), 1);
 }
 
 /// 空のディレクトリは空Vecを返す

--- a/src/target_test.rs
+++ b/src/target_test.rs
@@ -39,3 +39,12 @@ fn test_parse_target_gemini() {
     let target = parse_target("gemini").unwrap();
     assert_eq!(target.name(), "gemini");
 }
+
+#[test]
+fn test_plugin_origin_qualify_returns_name_only() {
+    // フラット化後は marketplace/plugin の段が配置物識別に使われないため、
+    // qualify は引数 name をそのまま返す。
+    let origin = PluginOrigin::from_marketplace("any-mp", "any-plg");
+    assert_eq!(origin.qualify("foo"), "foo");
+    assert_eq!(origin.qualify("plugin_my-skill"), "plugin_my-skill");
+}


### PR DESCRIPTION
## 概要

`<base>/<plural_kind>/<marketplace>/<plugin>/<flattened_name>` の 3 階層 install 配置を `<base>/<plural_kind>/<flattened_name>` の 2 階層へフラット化する。`Component.name` は既に `flatten_name(plugin_name, original_name) = "{plugin}_{original}"` で平坦化済みのため、中間 2 段（marketplace / plugin）を撤廃してもユニーク性は保たれる。

合わせて、これまで生名のままだった Hook も `flatten_name` 対象に統合し、別プラグイン由来の同名 Hook が衝突しないようにする。フラット化以前にインストールした旧 3 階層も install/uninstall/disable 時に自動除去する。

## 変更内容

### 🎯 変更の種類

- [x] ✨ 新機能 (cleanup_legacy_hierarchy)
- [x] ♻️ リファクタリング (scanner / qualify / enabled キー統一)
- [x] 🔧 設定変更 (placement_location 構造変更)
- [x] 破壊的変更 (install パス / Hook 同 stem 衝突方針 / qualify 識別子形式)

### 📝 詳細な変更内容

#### Phase 2 — install パスのフラット化と Hook flatten 統合 (35a18b6)

- 4 ターゲット (copilot / codex / antigravity / gemini_cli) の `placement_location` から `<marketplace>/<plugin>` 中間段を撤廃し `<base>/<plural>/<flattened_name>` 形式に統一
- `Hook` を `plugin_content::build_components` の flatten ループに統合し、Hook 名にも `flatten_name(\"{plugin}_{original}\")` を適用
- 同一プラグイン内の同 stem・別拡張子 Hook (`pre-commit.sh` と `pre-commit.py` 等) は `detect_name_collisions` が `Validation` エラーを返すよう挙動を変更
- 関連テスト更新 + Copilot Hook `*_with_prefixed_name` 回帰テストを新規追加

#### Phase 3 — 旧 3 階層の自動掃除 (d8fd51a)

- `cleanup_legacy_hierarchy` を新設し、`install.rs::place_plugin` と `lifecycle::disable_plugin` から呼び出して旧 `<base>/<plural>/<mp>/<plg>` 階層を除去
- 安全性は誤削除防止のベストエフォート方針。12 ガード（`is_safe_path_segment` / `exists` / symlink × 3 / `canonicalize` starts_with / parent depth × 2 / file_name × 2 / `is_dir`）を通過した場合のみ、quarantine rename + `remove_dir_all` で削除

#### Phase 4 — scanner 1 階層化 + SKILL.md ガード (437a128)

- `src/target/scanner.rs` を 1 階層 `read_dir` に書き換え、復元不能な `origin` はプレースホルダ `(\"_\", \"_\")` を埋める
- codex / copilot の `filter_component` に SKILL.md 存在ガードを追加（`<marketplace>` ディレクトリ自体を Skill と誤認しない二重防御）

#### Phase 5 — qualify / parse / enabled キーの単一セグメント化 (dd8629d)

- `PluginOrigin::qualify` を `name.to_string()` に変更（marketplace / plugin はもはや配置物識別に使われない）
- `sync::source::parse_component_name` を単一セグメント (`flattened_name`) 受理に。`/` を含むと `InvalidArgument`
- `scan/placement` を `list_placed_components -> HashSet<String>` に書き換え、Instruction ファイルを除外
- `plugin/meta::is_enabled` の `deployed` を `HashSet<String>` + `manifest.name` prefix (`\"{plugin}_\"`) マッチへ
- `application/catalog.rs` / `info.rs` の `is_enabled` 呼び出しに `manifest.name` を渡す（cache id は flatten 接頭辞と必ずしも一致しないため）

## 📊 システム図

### install パス（修正前後）

\`\`\`mermaid
flowchart TD
    Start([place_plugin]) --> Sweep[cleanup_legacy_hierarchy:::new]
    Sweep --> Place
    Place[placement_location] --> NewPath[\"&lt;base&gt;/&lt;plural&gt;/&lt;flattened_name&gt;<br/>例: .github/skills/skill-creator_skill-authoring-guide\"]:::new
    Place -. legacy 配置 .-> OldPath[\"&lt;base&gt;/&lt;plural&gt;/&lt;mp&gt;/&lt;plg&gt;/&lt;name&gt;\"]:::removed
    Sweep -. 旧階層を quarantine rename → remove_dir_all .-> OldPath

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
    classDef removed fill:#fecaca,stroke:#b91c1c,stroke-width:2px,stroke-dasharray:5 5
\`\`\`

### Hook 名のフラット化フロー

\`\`\`mermaid
flowchart LR
    A[hooks/pre-commit.json] --> B[list_hook_names]
    B --> C[\"flatten_components<br/>(NEW: Hook 追加)\"]:::new
    C --> D[validate_path_segment]
    D --> E[detect_name_collisions]
    E -->|衝突あり| F[Err Validation:::new]
    E -->|衝突なし| G[\"Component { name: '{plugin}_pre-commit' }\"]

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
\`\`\`

### enabled 判定のキー変更

\`\`\`mermaid
flowchart TD
    Cat[catalog::list_installed_plugins] --> Deployed[\"list_all_placed → HashSet&lt;String&gt;:::new<br/>(旧: HashSet&lt;(String, String)&gt;)\"]
    Cat --> IsE[meta::is_enabled]
    Info[info::resolve_enabled] --> Deployed
    Info --> IsE
    IsE -->|prefix match| Match[\"manifest.name + '_' で始まる<br/>flattened_name があれば enabled\"]:::new

    classDef new fill:#ffe4b5,stroke:#d97706,stroke-width:2px
\`\`\`

## 📋 関連 Issue

なし（implementation-plan.md 冒頭に「TUI install ネスト不具合として観測されたが実体は CLI/TUI 共通の設計上の階層構造」と記載）。

## 🧪 テスト

### テスト実行方法

\`\`\`bash
cargo fmt
cargo check
cargo test
\`\`\`

### テスト項目

- [x] 単体テスト: 1402 件 GREEN（Phase 5 末時点）
- [x] 統合テスト: `commands::sync::tests::test_sync_creates_component`（フラット fixture）含む
- [ ] 手動テスト: 4 ターゲットで `plm install` し `tree` で 2 階層配置を確認（要レビュアー検証）

### テスト結果

\`\`\`
test result: ok. 1402 passed; 0 failed; 0 ignored
\`\`\`

## 🔍 レビューポイント

1. **`cleanup_legacy_hierarchy` の 12 ガード（src/plugin/cleanup.rs:192 周辺）** — 誤削除防止のベストエフォート方針で、symlink × 3 / canonicalize / parent depth / file_name 一致 + quarantine rename を採用。完全な TOCTOU 耐性は目指していない点を確認してほしい。
2. **`meta::is_enabled` の prefix マッチ（src/plugin/meta.rs:303）** — `\"{plugin_name}_\"` で始まる flattened_name があれば enabled と判定。`test-plugin` が `test-plugin-other_x` を誤って拾わないことを `test_is_enabled_func_prefix_no_partial_match` で担保。
3. **同名 manifest プラグインの取り扱い（既知のトレードオフ）** — Codex review でも指摘された通り、別 marketplace から `manifest.name` が同じプラグインを導入するとフラットパスが衝突する。implementation-plan の設計判断 3 で明示的に受け入れたトレードオフ（永続化メタデータ導入はスコープ外）。今後の改修で「install 時の同名ガード」または「`<base>/.plm-origin.json`」を検討する余地あり。
4. **Phase 単位コミット** — 4 コミット（💥 → ✨ → ♻️ → ♻️）で論理分割し、Phase 2 末尾以降は各コミットで `cargo test` 全件 GREEN。

## ⚠️ 破壊的変更

- [x] この変更は既存の install レイアウトに破壊的変更を含む

### 破壊的変更の詳細

1. **install パスが 3 階層から 2 階層に変化**: 既存ユーザーが install していた配置先パスが変わる。次回 install/uninstall/disable 時に `cleanup_legacy_hierarchy` が旧階層を自動除去する。
2. **Hook 同 stem・別拡張子の重複は今後エラー**: 同一プラグイン内に `pre-commit.sh` と `pre-commit.py` の両方が含まれていた場合、これまでは 2 件として登録されていたが、Skill / Agent / Command と挙動を揃え `Validation` エラーで失敗するように変更。
3. **`PluginOrigin::qualify` の戻り値形式変更**: `\"{marketplace}/{plugin}/{name}\"` から `\"{name}\"` 単独に。`sync::source::parse_component_name` も単一セグメントのみ受理し `/` を含むと `InvalidArgument`。識別子は永続化されておらず TUI/CLI 内部の間接呼び出しのみのため互換問題はないと判定。

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される（1402 件 GREEN）
- [x] コミットメッセージが適切な形式で書かれている（絵文字 + タイプ）
- [ ] 関連する Issue が PR の「Development」に Linked されている（該当 Issue なし）
- [x] セルフレビューを実施した（Codex review 1 回実施 — 重大 1 件は計画書の設計判断で受け入れ済み）
- [x] 破壊的変更を明記