### PR TITLE
♻️ [Refactoring]: 非推奨コードと後方互換シムを段階的に削除

### DIFF
--- a/src/application/info.rs
+++ b/src/application/info.rs
@@ -214,7 +214,7 @@ fn build_plugin_info(content: MarketplaceContent) -> Result<PluginInfo> {
 
     // flatten_name の prefix は manifest.name に基づくため
     // is_enabled には manifest.name を渡す。
-    let enabled = resolve_enabled(&cache_path, marketplace_key, manifest.name.as_str());
+    let enabled = resolve_enabled(&cache_path, manifest.name.as_str());
 
     // InstalledPlugin を組み立てる（list_installed_plugins と同じく marketplace は Option<String> を保つ）
     let id = Some(dir_name.clone());
@@ -236,12 +236,11 @@ fn build_plugin_info(content: MarketplaceContent) -> Result<PluginInfo> {
 /// # Arguments
 ///
 /// * `cache_path` - Path to the plugin's cache directory.
-/// * `marketplace` - Marketplace key (e.g. `"github"`).
 /// * `plugin_name` - `PluginManifest.name`。`flattened_name` の prefix 判定に使う。
-fn resolve_enabled(cache_path: &Path, marketplace: &str, plugin_name: &str) -> bool {
+fn resolve_enabled(cache_path: &Path, plugin_name: &str) -> bool {
     let project_root = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
     let deployed = list_all_placed(&project_root);
-    meta::is_enabled(cache_path, marketplace, plugin_name, &deployed)
+    meta::is_enabled(cache_path, plugin_name, &deployed)
 }
 
 #[cfg(test)]

--- a/src/application/info.rs
+++ b/src/application/info.rs
@@ -210,7 +210,7 @@ fn build_plugin_info(content: MarketplaceContent) -> Result<PluginInfo> {
 
     let source = determine_source(marketplace_key, &dir_name);
 
-    let installed_at = meta::resolve_installed_at(&cache_path, Some(&manifest));
+    let installed_at = meta::resolve_installed_at(&cache_path);
 
     // flatten_name の prefix は manifest.name に基づくため
     // is_enabled には manifest.name を渡す。

--- a/src/application/info_test.rs
+++ b/src/application/info_test.rs
@@ -218,7 +218,6 @@ fn create_marketplace_content(marketplace: &str, name: &str) -> MarketplaceConte
         hooks: None,
         mcp_servers: None,
         lsp_servers: None,
-        installed_at: None,
     };
     let cached = CachedPackage {
         name: name.to_string(),

--- a/src/commands/info/info_test.rs
+++ b/src/commands/info/info_test.rs
@@ -38,7 +38,6 @@ fn create_test_info() -> PluginInfo {
         hooks: None,
         mcp_servers: None,
         lsp_servers: None,
-        installed_at: None,
     };
     let installed = InstalledPlugin::new_for_test_full(
         manifest,
@@ -120,7 +119,6 @@ fn test_json_serialization_no_author() {
         hooks: None,
         mcp_servers: None,
         lsp_servers: None,
-        installed_at: None,
     };
     info.installed = InstalledPlugin::new_for_test_full(
         manifest,
@@ -186,7 +184,6 @@ fn table_output_contains_status() {
         hooks: None,
         mcp_servers: None,
         lsp_servers: None,
-        installed_at: None,
     };
     let disabled_info = PluginInfo {
         installed: InstalledPlugin::new_for_test_full(
@@ -224,7 +221,6 @@ fn table_output_omits_author_section_when_none() {
         hooks: None,
         mcp_servers: None,
         lsp_servers: None,
-        installed_at: None,
     };
     let info = PluginInfo {
         installed: InstalledPlugin::new_for_test_full(

--- a/src/component.rs
+++ b/src/component.rs
@@ -10,8 +10,6 @@ mod placement;
 mod scoped_path;
 
 pub use convert::{AgentFormat, CommandFormat};
-#[allow(unused_imports)]
-pub use deployment::ComponentDeploymentBuilder;
 pub use deployment::{ComponentDeployment, ConversionConfig, DeploymentOutput};
 pub use file_operation::FileOperation;
 pub use kind::{Component, ComponentKind, Scope};

--- a/src/http.rs
+++ b/src/http.rs
@@ -21,24 +21,6 @@ pub async fn download_with_progress(
     download_with_progress_impl(client, url, auth_header, "unknown").await
 }
 
-/// ホスト名付きプログレスバーダウンロード
-///
-/// # Arguments
-///
-/// * `client` - HTTP client used to issue the download request.
-/// * `url` - URL of the resource to download.
-/// * `auth_header` - Optional `(name, value)` pair appended as an HTTP header.
-/// * `_host` - Host label for future telemetry; currently unused.
-#[allow(dead_code)]
-pub async fn download_with_progress_and_host(
-    client: &Client,
-    url: &str,
-    auth_header: Option<(&str, String)>,
-    _host: &str,
-) -> Result<Vec<u8>> {
-    download_with_progress_impl(client, url, auth_header, _host).await
-}
-
 /// プログレスバー付きダウンロード実装
 ///
 /// # Arguments

--- a/src/marketplace/download_test.rs
+++ b/src/marketplace/download_test.rs
@@ -40,7 +40,6 @@ async fn test_download_with_registry_plugin_not_found() {
             source: "github:test/repo".to_string(),
             owner: None,
             plugins: vec![],
-            original_manifest: None,
         })
         .unwrap();
 

--- a/src/marketplace/registry.rs
+++ b/src/marketplace/registry.rs
@@ -62,9 +62,6 @@ pub struct MarketplaceCache {
     #[serde(default)]
     pub owner: Option<MarketplaceOwner>,
     pub plugins: Vec<MarketplacePlugin>,
-    /// 元の marketplace.json マニフェスト（旧キャッシュ互換のため読込のみ許可）
-    #[serde(default, skip_serializing)]
-    pub original_manifest: Option<MarketplaceManifest>,
 }
 
 impl MarketplaceCache {
@@ -72,7 +69,6 @@ impl MarketplaceCache {
     ///
     /// - `source` は `"github:{repo_owner}/{repo_name}"` 形式で構築（`repo` 引数の owner / name を使用）
     /// - `fetched_at` は現在時刻（`Utc::now()`）
-    /// - `original_manifest` は `None`（呼び出し元で必要なら後から付ける）
     ///
     /// # Arguments
     ///
@@ -86,7 +82,6 @@ impl MarketplaceCache {
             source: format!("github:{}/{}", repo.owner(), repo.name()),
             owner: manifest.owner,
             plugins: manifest.plugins,
-            original_manifest: None,
         }
     }
 }

--- a/src/marketplace/registry_test.rs
+++ b/src/marketplace/registry_test.rs
@@ -166,12 +166,6 @@ fn from_manifest_sets_fetched_at_near_now() {
 }
 
 #[test]
-fn from_manifest_sets_original_manifest_none() {
-    let cache = MarketplaceCache::from_manifest(sample_manifest(), "catalog", &sample_repo());
-    assert!(cache.original_manifest.is_none());
-}
-
-#[test]
 fn from_manifest_sets_name_from_argument() {
     let cache =
         MarketplaceCache::from_manifest(sample_manifest(), "my-custom-name", &sample_repo());
@@ -322,4 +316,21 @@ async fn fetch_cache_with_trailing_slash_preserves_legacy_path() {
         client.last_path().as_deref(),
         Some("subdir//.claude-plugin/marketplace.json")
     );
+}
+
+#[test]
+fn parse_legacy_cache_with_original_manifest_ignores_unknown_field() {
+    // 旧キャッシュの "original_manifest" キーは unknown field として無視される
+    let json = r#"{
+        "name": "legacy",
+        "fetched_at": "2025-01-15T10:30:00Z",
+        "source": "github:o/n",
+        "owner": null,
+        "plugins": [],
+        "original_manifest": { "name": "x", "owner": null, "plugins": [] }
+    }"#;
+    let cache: MarketplaceCache = serde_json::from_str(json).expect("parse must not fail");
+    assert_eq!(cache.name, "legacy");
+    assert_eq!(cache.source, "github:o/n");
+    assert!(cache.plugins.is_empty());
 }

--- a/src/parser/convert.rs
+++ b/src/parser/convert.rs
@@ -29,9 +29,6 @@ pub use crate::format::Format;
 struct ToolRow {
     claude_code: &'static str,
     copilot: Option<&'static str>,
-    /// 将来拡張用（Codex Tool 名マッピングが仕様化されたら Some(...) を埋める）
-    #[allow(dead_code)]
-    codex: Option<&'static str>,
     /// Marks the canonical row to use when an N:1 reverse lookup hits multiple
     /// candidates (e.g. `codebase` -> `Read` rather than `Write`/`Edit`).
     reverse_canonical: bool,
@@ -48,60 +45,47 @@ fn tool_col_claude_code(row: &ToolRow) -> Option<&'static str> {
 fn tool_col_copilot(row: &ToolRow) -> Option<&'static str> {
     row.copilot
 }
-/// Column accessor for the Codex name (reserved for future use).
-#[allow(dead_code)]
-fn tool_col_codex(row: &ToolRow) -> Option<&'static str> {
-    row.codex
-}
 
 /// Tool name conversion table (rows = logical tools, columns = formats).
 const TOOL_TABLE: &[ToolRow] = &[
     ToolRow {
         claude_code: "Read",
         copilot: Some("codebase"),
-        codex: None,
         reverse_canonical: true,
     },
     ToolRow {
         claude_code: "Write",
         copilot: Some("codebase"),
-        codex: None,
         reverse_canonical: false,
     },
     ToolRow {
         claude_code: "Edit",
         copilot: Some("codebase"),
-        codex: None,
         reverse_canonical: false,
     },
     ToolRow {
         claude_code: "Grep",
         copilot: Some("search/codebase"),
-        codex: None,
         reverse_canonical: true,
     },
     ToolRow {
         claude_code: "Glob",
         copilot: Some("search/codebase"),
-        codex: None,
         reverse_canonical: false,
     },
     ToolRow {
         claude_code: "Bash",
         copilot: Some("terminal"),
-        codex: None,
         reverse_canonical: true,
     },
     ToolRow {
         claude_code: "WebFetch",
         copilot: Some("fetch"),
-        codex: None,
         reverse_canonical: true,
     },
     ToolRow {
         claude_code: "WebSearch",
         copilot: Some("websearch"),
-        codex: None,
         reverse_canonical: true,
     },
 ];

--- a/src/plugin/cached_package_test.rs
+++ b/src/plugin/cached_package_test.rs
@@ -18,7 +18,6 @@ fn make_manifest(name: &str) -> PluginManifest {
         hooks: None,
         mcp_servers: None,
         lsp_servers: None,
-        installed_at: None,
     }
 }
 

--- a/src/plugin/installed.rs
+++ b/src/plugin/installed.rs
@@ -150,7 +150,6 @@ impl InstalledPlugin {
             hooks: None,
             mcp_servers: None,
             lsp_servers: None,
-            installed_at: None,
         };
         let plugin = Plugin::new_for_test(manifest, PathBuf::from("/test"), components);
         Self {

--- a/src/plugin/installed_test.rs
+++ b/src/plugin/installed_test.rs
@@ -216,7 +216,6 @@ fn installed_plugin_with_author(author: Option<Author>) -> InstalledPlugin {
         hooks: None,
         mcp_servers: None,
         lsp_servers: None,
-        installed_at: None,
     };
     InstalledPlugin::new_for_test_full(
         manifest,

--- a/src/plugin/manifest.rs
+++ b/src/plugin/manifest.rs
@@ -78,26 +78,6 @@ impl PluginManifest {
         Self::parse(&content)
     }
 
-    /// スキルが含まれているか
-    pub fn has_skills(&self) -> bool {
-        self.skills.is_some()
-    }
-
-    /// エージェントが含まれているか
-    pub fn has_agents(&self) -> bool {
-        self.agents.is_some()
-    }
-
-    /// コマンドが含まれているか
-    pub fn has_commands(&self) -> bool {
-        self.commands.is_some()
-    }
-
-    /// インストラクションが含まれているか
-    pub fn has_instructions(&self) -> bool {
-        self.instructions.is_some()
-    }
-
     /// スキルディレクトリのパスを解決
     ///
     /// # Arguments

--- a/src/plugin/manifest.rs
+++ b/src/plugin/manifest.rs
@@ -50,11 +50,6 @@ pub struct PluginManifest {
     pub mcp_servers: Option<String>,
     #[serde(default, rename = "lspServers")]
     pub lsp_servers: Option<String>,
-
-    /// インストール日時（RFC3339形式、例: "2025-01-15T10:30:00Z"）
-    /// 後方互換のため読み込みのみ対応。新規インストールでは .plm-meta.json に記録される。
-    #[serde(default, rename = "installedAt", skip_serializing)]
-    pub installed_at: Option<String>,
 }
 
 impl PluginManifest {

--- a/src/plugin/manifest_test.rs
+++ b/src/plugin/manifest_test.rs
@@ -10,28 +10,6 @@ fn test_parse_minimal() {
 }
 
 #[test]
-fn test_parse_full() {
-    let json = r#"{
-        "name": "full-plugin",
-        "version": "2.0.0",
-        "description": "A full plugin",
-        "author": {
-            "name": "Test Author",
-            "email": "test@example.com"
-        },
-        "skills": "./skills/",
-        "agents": "./agents/"
-    }"#;
-    let manifest = PluginManifest::parse(json).unwrap();
-    assert_eq!(manifest.name, "full-plugin");
-    assert_eq!(manifest.version, "2.0.0");
-    assert_eq!(manifest.description, Some("A full plugin".to_string()));
-    assert!(manifest.author.is_some());
-    assert!(manifest.has_skills());
-    assert!(manifest.has_agents());
-}
-
-#[test]
 fn test_parse_invalid() {
     let json = r#"{"name": "test"}"#; // missing version
     assert!(PluginManifest::parse(json).is_err());
@@ -84,23 +62,6 @@ fn test_parse_empty_version() {
 }
 
 // === 境界値テスト: 空文字パス ===
-
-#[test]
-fn test_parse_empty_skills_path() {
-    // skills: "" の場合
-    let json = r#"{"name": "test", "version": "1.0.0", "skills": ""}"#;
-    let manifest = PluginManifest::parse(json).unwrap();
-    assert!(manifest.has_skills());
-    assert_eq!(manifest.skills, Some("".to_string()));
-}
-
-#[test]
-fn test_parse_empty_agents_path() {
-    // agents: "" の場合
-    let json = r#"{"name": "test", "version": "1.0.0", "agents": ""}"#;
-    let manifest = PluginManifest::parse(json).unwrap();
-    assert!(manifest.has_agents());
-}
 
 // === 境界値テスト: パス解決 ===
 
@@ -218,14 +179,6 @@ fn test_parse_empty_string() {
     // 空文字
     let json = "";
     assert!(PluginManifest::parse(json).is_err());
-}
-
-#[test]
-fn test_parse_null_fields() {
-    // null 値
-    let json = r#"{"name": "test", "version": "1.0.0", "skills": null}"#;
-    let manifest = PluginManifest::parse(json).unwrap();
-    assert!(!manifest.has_skills());
 }
 
 // === installed_at フィールドのテスト ===

--- a/src/plugin/manifest_test.rs
+++ b/src/plugin/manifest_test.rs
@@ -181,32 +181,15 @@ fn test_parse_empty_string() {
     assert!(PluginManifest::parse(json).is_err());
 }
 
-// === installed_at フィールドのテスト ===
-
 #[test]
-fn test_parse_with_installed_at() {
+fn parse_legacy_manifest_with_installed_at_ignores_unknown_field() {
+    // 旧 plugin.json に残る "installedAt" は unknown field として無視される
     let json = r#"{
-        "name": "test",
+        "name": "legacy-plugin",
         "version": "1.0.0",
-        "installedAt": "2025-01-15T10:30:00Z"
+        "installedAt": "2024-01-01T00:00:00Z"
     }"#;
-    let manifest = PluginManifest::parse(json).unwrap();
-    assert_eq!(
-        manifest.installed_at,
-        Some("2025-01-15T10:30:00Z".to_string())
-    );
-}
-
-#[test]
-fn test_parse_without_installed_at() {
-    let json = r#"{"name": "test", "version": "1.0.0"}"#;
-    let manifest = PluginManifest::parse(json).unwrap();
-    assert!(manifest.installed_at.is_none());
-}
-
-#[test]
-fn test_parse_installed_at_null() {
-    let json = r#"{"name": "test", "version": "1.0.0", "installedAt": null}"#;
-    let manifest = PluginManifest::parse(json).unwrap();
-    assert!(manifest.installed_at.is_none());
+    let manifest: PluginManifest = serde_json::from_str(json).expect("parse must not fail");
+    assert_eq!(manifest.name, "legacy-plugin");
+    assert_eq!(manifest.version, "1.0.0");
 }

--- a/src/plugin/manifest_test.rs
+++ b/src/plugin/manifest_test.rs
@@ -189,7 +189,7 @@ fn parse_legacy_manifest_with_installed_at_ignores_unknown_field() {
         "version": "1.0.0",
         "installedAt": "2024-01-01T00:00:00Z"
     }"#;
-    let manifest: PluginManifest = serde_json::from_str(json).expect("parse must not fail");
+    let manifest = PluginManifest::parse(json).expect("parse must not fail");
     assert_eq!(manifest.name, "legacy-plugin");
     assert_eq!(manifest.version, "1.0.0");
 }

--- a/src/plugin/marketplace_content_test.rs
+++ b/src/plugin/marketplace_content_test.rs
@@ -22,7 +22,6 @@ fn make_manifest(name: &str) -> PluginManifest {
         hooks: None,
         mcp_servers: None,
         lsp_servers: None,
-        installed_at: None,
     }
 }
 

--- a/src/plugin/meta.rs
+++ b/src/plugin/meta.rs
@@ -3,8 +3,6 @@
 //! プラグインのインストール日時などPLM固有のメタデータを `.plm-meta.json` で管理する。
 //! `plugin.json` は上流成果物として改変しない設計。
 
-use super::manifest_resolve::resolve_manifest_path;
-use super::PluginManifest;
 use crate::error::Result;
 use crate::fs::{FileSystem, RealFs};
 use chrono::Utc;
@@ -223,7 +221,7 @@ pub fn load_meta(plugin_dir: &Path) -> Option<PluginMeta> {
             Ok(meta) => Some(meta),
             Err(e) => {
                 eprintln!(
-                    "Warning: {} is corrupted ({}), falling back to plugin.json. \
+                    "Warning: {} is corrupted ({}); installedAt will be unavailable. \
                      It will be regenerated on next install.",
                     META_FILE, e
                 );
@@ -232,7 +230,7 @@ pub fn load_meta(plugin_dir: &Path) -> Option<PluginMeta> {
         },
         Err(e) => {
             eprintln!(
-                "Warning: Failed to read {} ({}), falling back to plugin.json.",
+                "Warning: Failed to read {} ({}); installedAt will be unavailable.",
                 META_FILE, e
             );
             None
@@ -240,42 +238,16 @@ pub fn load_meta(plugin_dir: &Path) -> Option<PluginMeta> {
     }
 }
 
-/// installedAt を取得（.plm-meta.json → plugin.json のフォールバック付き）
+/// installedAt を `.plm-meta.json` から取得する
 ///
-/// 優先順位:
-/// 1. `.plm-meta.json` の `installedAt` を優先
-/// 2. `.plm-meta.json` が無いか `installedAt` が欠損 → `plugin.json` の `installedAt` にフォールバック
-/// 3. 両方無い → `None`
-///
-/// manifest が None の場合は plugin.json を読み込んでフォールバック
+/// `.plm-meta.json` が存在し `installedAt` が空でない場合のみ値を返す。
+/// 旧 `plugin.json` の `installedAt` フィールドは廃止済みのため参照しない。
 ///
 /// # Arguments
 ///
 /// * `plugin_dir` - Plugin root directory where the metadata file lives.
-/// * `manifest` - Pre-loaded `PluginManifest`, or `None` to load it on demand.
-pub fn resolve_installed_at(
-    plugin_dir: &Path,
-    manifest: Option<&PluginManifest>,
-) -> Option<String> {
-    if let Some(meta) = load_meta(plugin_dir) {
-        if let Some(installed_at) = normalize_installed_at(meta.installed_at.as_deref()) {
-            return Some(installed_at);
-        }
-    }
-
-    if let Some(m) = manifest {
-        return normalize_installed_at(m.installed_at.as_deref());
-    }
-
-    // manifest が渡されていない場合は plugin.json から直接読み込む
-    let loaded_manifest =
-        resolve_manifest_path(plugin_dir).and_then(|path| PluginManifest::load(&path).ok());
-
-    if let Some(m) = loaded_manifest {
-        return normalize_installed_at(m.installed_at.as_deref());
-    }
-
-    None
+pub fn resolve_installed_at(plugin_dir: &Path) -> Option<String> {
+    load_meta(plugin_dir).and_then(|meta| normalize_installed_at(meta.installed_at.as_deref()))
 }
 
 /// プラグインが有効かどうかを判定

--- a/src/plugin/meta.rs
+++ b/src/plugin/meta.rs
@@ -295,18 +295,12 @@ pub fn resolve_installed_at(
 /// # Arguments
 ///
 /// * `cache_path` - プラグインのキャッシュパス
-/// * `_marketplace` - マーケットプレイス名（フラット化後は未使用、互換のために残す）
 /// * `plugin_name` - プラグイン名（`PluginManifest.name` 相当）
 /// * `deployed` - デプロイ済みコンポーネントの `flattened_name` 集合
 ///
 /// # Returns
 /// `true` if enabled, `false` otherwise
-pub fn is_enabled(
-    cache_path: &Path,
-    _marketplace: &str,
-    plugin_name: &str,
-    deployed: &HashSet<String>,
-) -> bool {
+pub fn is_enabled(cache_path: &Path, plugin_name: &str, deployed: &HashSet<String>) -> bool {
     if let Some(plugin_meta) = load_meta(cache_path) {
         if !plugin_meta.status_by_target.is_empty() {
             return plugin_meta.any_enabled();

--- a/src/plugin/meta.rs
+++ b/src/plugin/meta.rs
@@ -221,7 +221,7 @@ pub fn load_meta(plugin_dir: &Path) -> Option<PluginMeta> {
             Ok(meta) => Some(meta),
             Err(e) => {
                 eprintln!(
-                    "Warning: {} is corrupted ({}); installedAt will be unavailable. \
+                    "Warning: {} is corrupted ({}); plugin metadata will be unavailable. \
                      It will be regenerated on next install.",
                     META_FILE, e
                 );

--- a/src/plugin/meta.rs
+++ b/src/plugin/meta.rs
@@ -230,7 +230,7 @@ pub fn load_meta(plugin_dir: &Path) -> Option<PluginMeta> {
         },
         Err(e) => {
             eprintln!(
-                "Warning: Failed to read {} ({}); installedAt will be unavailable.",
+                "Warning: Failed to read {} ({}); plugin metadata will be unavailable.",
                 META_FILE, e
             );
             None

--- a/src/plugin/meta_test.rs
+++ b/src/plugin/meta_test.rs
@@ -231,66 +231,22 @@ fn test_resolve_installed_at_from_meta() {
     };
     write_meta(plugin_dir, &meta).unwrap();
 
-    let result = resolve_installed_at(plugin_dir, None);
+    let result = resolve_installed_at(plugin_dir);
     assert_eq!(result, Some("2025-01-15T10:30:00Z".to_string()));
 }
 
 #[test]
-fn test_resolve_installed_at_fallback_to_manifest() {
+fn test_resolve_installed_at_ignores_legacy_plugin_json() {
     let temp_dir = TempDir::new().unwrap();
     let plugin_dir = temp_dir.path();
 
-    // plugin.json を作成（.plm-meta.json なし）
+    // plugin.json に installedAt があっても無視される (.plm-meta.json なし)
     let manifest_content =
         r#"{"name":"test","version":"1.0.0","installedAt":"2025-01-10T00:00:00Z"}"#;
     fs::write(plugin_dir.join("plugin.json"), manifest_content).unwrap();
 
-    let manifest = PluginManifest::parse(manifest_content).unwrap();
-    let result = resolve_installed_at(plugin_dir, Some(&manifest));
-    assert_eq!(result, Some("2025-01-10T00:00:00Z".to_string()));
-}
-
-#[test]
-fn test_resolve_installed_at_meta_priority() {
-    let temp_dir = TempDir::new().unwrap();
-    let plugin_dir = temp_dir.path();
-
-    // 両方に値がある場合、.plm-meta.json が優先
-    let meta = PluginMeta {
-        installed_at: Some("2025-01-15T10:30:00Z".to_string()),
-        ..Default::default()
-    };
-    write_meta(plugin_dir, &meta).unwrap();
-
-    let manifest_content =
-        r#"{"name":"test","version":"1.0.0","installedAt":"2025-01-10T00:00:00Z"}"#;
-    fs::write(plugin_dir.join("plugin.json"), manifest_content).unwrap();
-
-    let manifest = PluginManifest::parse(manifest_content).unwrap();
-    let result = resolve_installed_at(plugin_dir, Some(&manifest));
-    assert_eq!(result, Some("2025-01-15T10:30:00Z".to_string()));
-}
-
-#[test]
-fn test_resolve_installed_at_empty_meta_fallback() {
-    let temp_dir = TempDir::new().unwrap();
-    let plugin_dir = temp_dir.path();
-
-    // .plm-meta.json は空の installedAt
-    let meta = PluginMeta {
-        installed_at: Some("".to_string()),
-        ..Default::default()
-    };
-    write_meta(plugin_dir, &meta).unwrap();
-
-    // plugin.json に値あり
-    let manifest_content =
-        r#"{"name":"test","version":"1.0.0","installedAt":"2025-01-10T00:00:00Z"}"#;
-    fs::write(plugin_dir.join("plugin.json"), manifest_content).unwrap();
-
-    let manifest = PluginManifest::parse(manifest_content).unwrap();
-    let result = resolve_installed_at(plugin_dir, Some(&manifest));
-    assert_eq!(result, Some("2025-01-10T00:00:00Z".to_string()));
+    let result = resolve_installed_at(plugin_dir);
+    assert!(result.is_none());
 }
 
 #[test]
@@ -298,12 +254,8 @@ fn test_resolve_installed_at_both_none() {
     let temp_dir = TempDir::new().unwrap();
     let plugin_dir = temp_dir.path();
 
-    // plugin.json に installedAt なし
-    let manifest_content = r#"{"name":"test","version":"1.0.0"}"#;
-    fs::write(plugin_dir.join("plugin.json"), manifest_content).unwrap();
-
-    let manifest = PluginManifest::parse(manifest_content).unwrap();
-    let result = resolve_installed_at(plugin_dir, Some(&manifest));
+    // .plm-meta.json も plugin.json も無い
+    let result = resolve_installed_at(plugin_dir);
     assert!(result.is_none());
 }
 

--- a/src/plugin/meta_test.rs
+++ b/src/plugin/meta_test.rs
@@ -497,7 +497,7 @@ fn test_is_enabled_func_with_status_by_target_enabled() {
     write_meta(plugin_dir, &meta).unwrap();
 
     let deployed: HashSet<String> = HashSet::new();
-    assert!(is_enabled(plugin_dir, "github", "test-plugin", &deployed));
+    assert!(is_enabled(plugin_dir, "test-plugin", &deployed));
 }
 
 #[test]
@@ -511,7 +511,7 @@ fn test_is_enabled_func_with_status_by_target_disabled() {
     write_meta(plugin_dir, &meta).unwrap();
 
     let deployed: HashSet<String> = HashSet::new();
-    assert!(!is_enabled(plugin_dir, "github", "test-plugin", &deployed));
+    assert!(!is_enabled(plugin_dir, "test-plugin", &deployed));
 }
 
 #[test]
@@ -527,7 +527,7 @@ fn test_is_enabled_func_fallback_to_deployed() {
     let mut deployed: HashSet<String> = HashSet::new();
     deployed.insert("test-plugin_my-skill".to_string());
 
-    assert!(is_enabled(plugin_dir, "github", "test-plugin", &deployed));
+    assert!(is_enabled(plugin_dir, "test-plugin", &deployed));
 }
 
 #[test]
@@ -540,7 +540,7 @@ fn test_is_enabled_func_fallback_not_deployed() {
     write_meta(plugin_dir, &meta).unwrap();
 
     let deployed: HashSet<String> = HashSet::new();
-    assert!(!is_enabled(plugin_dir, "github", "test-plugin", &deployed));
+    assert!(!is_enabled(plugin_dir, "test-plugin", &deployed));
 }
 
 #[test]
@@ -552,7 +552,7 @@ fn test_is_enabled_func_no_meta_file_fallback() {
     let mut deployed: HashSet<String> = HashSet::new();
     deployed.insert("test-plugin_my-skill".to_string());
 
-    assert!(is_enabled(plugin_dir, "github", "test-plugin", &deployed));
+    assert!(is_enabled(plugin_dir, "test-plugin", &deployed));
 }
 
 #[test]
@@ -566,7 +566,7 @@ fn test_is_enabled_func_prefix_no_partial_match() {
     let mut deployed: HashSet<String> = HashSet::new();
     deployed.insert("test-plugin-other_x".to_string());
 
-    assert!(!is_enabled(plugin_dir, "github", "test-plugin", &deployed));
+    assert!(!is_enabled(plugin_dir, "test-plugin", &deployed));
 }
 
 // =============================================================================
@@ -641,8 +641,8 @@ fn test_build_deployed_plugin_set_prefix_collision() {
     // 両方 true を返す（false positive の挙動が build_deployed_plugin_set と
     // 等価であること）。
     let temp_dir = TempDir::new().unwrap();
-    assert!(is_enabled(temp_dir.path(), "github", "foo", &deployed));
-    assert!(is_enabled(temp_dir.path(), "github", "foo_bar", &deployed));
+    assert!(is_enabled(temp_dir.path(), "foo", &deployed));
+    assert!(is_enabled(temp_dir.path(), "foo_bar", &deployed));
 }
 
 #[test]

--- a/src/plugin/plugin_content_test.rs
+++ b/src/plugin/plugin_content_test.rs
@@ -26,7 +26,6 @@ fn make_manifest(name: &str) -> PluginManifest {
         hooks: None,
         mcp_servers: None,
         lsp_servers: None,
-        installed_at: None,
     }
 }
 

--- a/src/source/marketplace_source.rs
+++ b/src/source/marketplace_source.rs
@@ -51,13 +51,11 @@ impl PackageSource for MarketplaceSource {
                 .find(|p| p.name == self.plugin)
                 .ok_or_else(|| PlmError::PluginNotFound(self.plugin.clone()))?;
 
-            let marketplace_manifest = Some(mp_cache.original_manifest.clone().unwrap_or_else(
-                || MarketplaceManifest {
-                    name: mp_cache.name.clone(),
-                    owner: mp_cache.owner.clone(),
-                    plugins: mp_cache.plugins.clone(),
-                },
-            ));
+            let marketplace_manifest = Some(MarketplaceManifest {
+                name: mp_cache.name.clone(),
+                owner: mp_cache.owner.clone(),
+                plugins: mp_cache.plugins.clone(),
+            });
 
             let mut cached = match &plugin_entry.source {
                 MpPluginSource::Local(path) => {

--- a/src/target.rs
+++ b/src/target.rs
@@ -123,18 +123,6 @@ impl PluginOrigin {
             plugin: "_".to_string(),
         }
     }
-
-    /// 配置物の識別キー（フラット化された `name` 単独）を返す。
-    ///
-    /// `<base>/<plural>/<flattened_name>` 構造ではマーケットプレイス/プラグイン
-    /// 段が存在しないため、配置物からは `flattened_name` のみ復元できる。
-    /// 過去は `{marketplace}/{plugin}/{name}` の 3 セグメントを返していたが、
-    /// フラット化後は識別子としても `name` を返す。
-    pub fn qualify(&self, name: &str) -> String {
-        // marketplace/plugin はもはや配置物識別に使われないため、引数 self は
-        // 互換のためだけに残す。将来の API クリーンアップで削除候補。
-        name.to_string()
-    }
 }
 
 /// ターゲット種別（CLIオプション用）

--- a/src/target/antigravity.rs
+++ b/src/target/antigravity.rs
@@ -54,7 +54,7 @@ impl AntigravityTarget {
             ComponentKind::Skill if c.is_dir => {
                 let skill_md = c.path.join("SKILL.md");
                 if skill_md.exists() {
-                    Some(c.origin.qualify(&c.name))
+                    Some(c.name.clone())
                 } else {
                     None
                 }

--- a/src/target/antigravity_test.rs
+++ b/src/target/antigravity_test.rs
@@ -208,7 +208,7 @@ fn test_antigravity_list_placed_with_skills() {
         .list_placed(ComponentKind::Skill, Scope::Project, project_root)
         .unwrap();
     assert_eq!(result.len(), 1);
-    // qualify は name 単独 (= flattened_name) を返す。
+    // フラット化された name (= flattened_name) を返す。
     assert_eq!(result[0], "plugin_skill-1");
 }
 

--- a/src/target/codex.rs
+++ b/src/target/codex.rs
@@ -44,17 +44,15 @@ impl CodexTarget {
     /// * `c` - Scanned component entry.
     /// * `kind` - Component kind expected for the entry.
     fn filter_component(c: &ScannedComponent, kind: ComponentKind) -> Option<String> {
-        let make_qualified = |name: &str| c.origin.qualify(name);
         match kind {
             // Skill: 直下に SKILL.md が存在するディレクトリのみ採用する。
             // 旧 3 階層 `<plural>/<mp>/<plg>/<skill>/SKILL.md` の中間段
             // (`<mp>` ディレクトリ等) を Skill と誤認しないための二重防御。
             ComponentKind::Skill if c.is_dir && c.path.join("SKILL.md").is_file() => {
-                Some(make_qualified(&c.name))
+                Some(c.name.clone())
             }
             ComponentKind::Agent if !c.is_dir && c.name.ends_with(".agent.md") => {
-                let name = c.name.trim_end_matches(".agent.md");
-                Some(make_qualified(name))
+                Some(c.name.trim_end_matches(".agent.md").to_string())
             }
             _ => None,
         }

--- a/src/target/copilot.rs
+++ b/src/target/copilot.rs
@@ -54,20 +54,19 @@ impl CopilotTarget {
     /// * `c` - Scanned component entry.
     /// * `kind` - Component kind expected for the entry.
     fn filter_component(c: &ScannedComponent, kind: ComponentKind) -> Option<String> {
-        let make_qualified = |name: &str| c.origin.qualify(name);
         match kind {
             // Skill: SKILL.md が直下にあるディレクトリのみ採用（二重防御）。
             ComponentKind::Skill if c.is_dir && c.path.join("SKILL.md").is_file() => {
-                Some(make_qualified(&c.name))
+                Some(c.name.clone())
             }
             ComponentKind::Agent if !c.is_dir && c.name.ends_with(".agent.md") => {
-                Some(make_qualified(c.name.trim_end_matches(".agent.md")))
+                Some(c.name.trim_end_matches(".agent.md").to_string())
             }
             ComponentKind::Command if !c.is_dir && c.name.ends_with(".prompt.md") => {
-                Some(make_qualified(c.name.trim_end_matches(".prompt.md")))
+                Some(c.name.trim_end_matches(".prompt.md").to_string())
             }
             ComponentKind::Hook if !c.is_dir && c.name.ends_with(".json") => {
-                Some(make_qualified(c.name.trim_end_matches(".json")))
+                Some(c.name.trim_end_matches(".json").to_string())
             }
             _ => None,
         }

--- a/src/target/copilot_test.rs
+++ b/src/target/copilot_test.rs
@@ -306,8 +306,7 @@ fn test_copilot_list_placed_hooks() {
         .unwrap();
 
     assert_eq!(result.len(), 1);
-    // origin は scanner プレースホルダ ("_") だが、`PluginOrigin::qualify` は
-    // フラット化以降 `name` 単独を返すため、そのまま flattened_name を期待する。
+    // フラット化以降は `name` 単独 (= flattened_name) を識別子とする。
     assert_eq!(result[0], "my-plugin_pre-commit");
 }
 

--- a/src/target/gemini_cli.rs
+++ b/src/target/gemini_cli.rs
@@ -48,7 +48,7 @@ impl GeminiCliTarget {
             ComponentKind::Skill if c.is_dir => {
                 let skill_md = c.path.join("SKILL.md");
                 if skill_md.exists() {
-                    Some(c.origin.qualify(&c.name))
+                    Some(c.name.clone())
                 } else {
                     None
                 }

--- a/src/target_test.rs
+++ b/src/target_test.rs
@@ -39,12 +39,3 @@ fn test_parse_target_gemini() {
     let target = parse_target("gemini").unwrap();
     assert_eq!(target.name(), "gemini");
 }
-
-#[test]
-fn test_plugin_origin_qualify_returns_name_only() {
-    // フラット化後は marketplace/plugin の段が配置物識別に使われないため、
-    // qualify は引数 name をそのまま返す。
-    let origin = PluginOrigin::from_marketplace("any-mp", "any-plg");
-    assert_eq!(origin.qualify("foo"), "foo");
-    assert_eq!(origin.qualify("plugin_my-skill"), "plugin_my-skill");
-}

--- a/src/tui/manager/screens/marketplaces/actions_test.rs
+++ b/src/tui/manager/screens/marketplaces/actions_test.rs
@@ -42,7 +42,6 @@ fn make_cache(name: &str, plugins: Vec<MarketplacePlugin>) -> MarketplaceCache {
         source: "owner/repo".to_string(),
         owner: None,
         plugins,
-        original_manifest: None,
     }
 }
 


### PR DESCRIPTION
## 概要

後方互換のために残っていたコード、デッドコード（`#[allow(dead_code)]` 付き未使用コード）、不要な互換シムを 4 フェーズに分けて段階的に削除しました。新規実装は行わず削除のみで、各タスク単位でコミット境界を切り、`cargo check` + `cargo test` がフェーズ末で常に green な状態を維持しています。

## 変更の種類

- ♻️ **Refactoring**（コード削除のみ、振る舞いの変更なし）
- 🔥 **Remove**（不要 API・フィールドの完全除去）

## 詳細な変更内容

### Phase 2: デッドコード除去

- **`src/http.rs`**: `download_with_progress_and_host` を関数ごと削除（呼び出し元 0 件）
- **`src/parser/convert.rs`**: `ToolRow.codex` フィールド・`tool_col_codex` 関数・`TOOL_TABLE` 全行の `codex: None` を削除（`ModelRow.codex` / `MODEL_TABLE` は現役使用のため touch せず）
- **`src/plugin/manifest.rs`**: `has_skills` / `has_agents` / `has_commands` / `has_instructions` 4 メソッドを削除し、`manifest_test.rs` の関連テスト 4 件もテストごと除去
- **`src/component.rs`**: `pub use deployment::ComponentDeploymentBuilder` 再エクスポートと `#[allow(unused_imports)]` を削除（型本体と `deployment.rs` 内の re-export は残置）

### Phase 3: 後方互換シム除去

- **`src/target.rs`** の `PluginOrigin::qualify` を削除し、`antigravity` / `codex` / `copilot` / `gemini_cli` 各ターゲットで `name.clone()` / `name.to_string()` にインライン化（`PluginOrigin::placeholder()` は scanner / sync_source 依拠のため残置）
- **`src/plugin/meta.rs`** の `is_enabled` から未使用の `_marketplace` 引数を除去し、`application/info.rs::resolve_enabled` および `meta_test.rs` の 8 箇所も追従
- **`src/plugin/manifest.rs::installed_at`** フィールドを削除し、`resolve_installed_at` のシグネチャを `(plugin_dir)` 単独に簡素化（`.plm-meta.json` のみで解決、`plugin.json` フォールバックは廃止）
  - 構造体リテラル 11 箇所と関連テスト 3 件を整理
  - 旧 `plugin.json` の `installedAt` キーは serde の unknown field として無視される仕様を保証するリグレッションテスト `parse_legacy_manifest_with_installed_at_ignores_unknown_field` を追加
  - `PluginInfo.installed_at` / `wire::PluginInfo.installed_at` / `PluginMeta.installed_at` は表示・正規メタデータとして残置
- **`src/marketplace/registry.rs::MarketplaceCache::original_manifest`** フィールドを削除し、`source/marketplace_source.rs` のフォールバックロジックを直接構築化
  - 同様に `parse_legacy_cache_with_original_manifest_ignores_unknown_field` を新規追加して旧キャッシュとの互換を明示

## システム図

```mermaid
flowchart LR
    subgraph Phase2["Phase 2: デッドコード除去"]
        A1["http::download_with_progress_and_host"] --> A1x[("削除")]
        A2["ToolRow.codex / tool_col_codex"] --> A2x[("削除")]
        A3["PluginManifest::has_*"] --> A3x[("削除")]
        A4["ComponentDeploymentBuilder re-export"] --> A4x[("削除")]
    end
    subgraph Phase3["Phase 3: 後方互換シム除去"]
        B1["PluginOrigin::qualify"] --> B1x[("削除 + 4 ターゲットでインライン化")]
        B2["is_enabled(_marketplace)"] --> B2x[("引数削除 + 呼び出し元追従")]
        B3["PluginManifest.installed_at"] --> B3x[("フィールド削除 + .plm-meta.json 単独解決")]
        B4["MarketplaceCache.original_manifest"] --> B4x[("フィールド削除 + フォールバック直接構築")]
    end
    Phase2 --> Phase3
    style A1x fill:#fee
    style A2x fill:#fee
    style A3x fill:#fee
    style A4x fill:#fee
    style B1x fill:#fee
    style B2x fill:#fee
    style B3x fill:#fee
    style B4x fill:#fee
```

## 関連Issue

なし（仕様: \`.plugin-workspace/.specs/006-remove-deprecated-code/\`）

## テスト

- [x] \`cargo fmt\` 適用済み（Task tool 経由）
- [x] \`cargo check\` エラー・警告なし（本体）
- [x] \`cargo test\` 全件 pass: **1402 passed / 0 failed**
- [x] DoD Section 4-2 の grep 確認すべて期待通り
  - \`rg -n 'rename = \"installedAt\"' src/\` → 1 件（\`PluginMeta\` のみ）
  - \`rg -n '\"original_manifest\"\\s*:' src/\` → 1 件（新規追加テスト内 JSON のみ）
  - その他削除対象 grep はすべて 0 件
- [x] 新規追加: 旧 JSON の unknown field 許容を保証する 2 件のリグレッションテスト
- [x] Codex CLI による一括レビュー: **問題なし**

## レビューポイント

1. **シリアライゼーション互換**: \`PluginManifest.installed_at\` / \`MarketplaceCache.original_manifest\` のフィールド削除に伴い、旧 JSON の該当キーは serde の unknown field として無視される（\`#[serde(deny_unknown_fields)]\` 未付与であることを git diff で再確認可）。新規追加した 2 件のテストが今後のリグレッション検出器となります
2. **\`resolve_installed_at\` の挙動変更**: 旧 \`plugin.json\` の \`installedAt\` フィールドが読まれなくなり、\`.plm-meta.json\` 経由のみで解決されます。古いプラグインでは \"installed_at\" が一時的に未取得 (\`None\`) となりますが、再 install / 再 sync で \`.plm-meta.json\` が再生成されます（hearing-notes Q1 でユーザー合意済み）
3. **\`MarketplaceCache.original_manifest\` 削除**: 旧キャッシュは default 値で読み込まれ、\`marketplace_source\` 側で \`mp_cache.{name,owner,plugins}\` から直接 \`MarketplaceManifest\` を再構築します。ユーザー影響は無し（hearing-notes Q2）
4. **\`PluginOrigin::qualify\` のインライン化**: フラット 2 階層構造移行後は \`name\` を素通しするだけだったため、各ターゲットで \`c.name.clone()\` ないし \`name.to_string()\` に置き換えました。挙動差分なし
5. **コミット境界**: 8 コミット = 8 タスクの 1:1 対応。各コミット時点で単独 build/test green