### PR TITLE
🎨 [UI/UX]: TUI 管理画面をフル幅レイアウト化

### DIFF
--- a/src/tui/manager/core.rs
+++ b/src/tui/manager/core.rs
@@ -19,6 +19,10 @@ mod data_test;
 mod filter_test;
 
 pub use app::{update, view, Model, Tab};
-pub use common::{dialog_rect, render_filter_bar};
+#[allow(unused_imports)]
+pub use common::{
+    content_rect, render_filter_bar, truncate_to_width, BLOCK_BORDER_WIDTH, HORIZONTAL_PADDING,
+    LIST_DECORATION_WIDTH, LIST_HIGHLIGHT_WIDTH, MIN_CONTENT_WIDTH,
+};
 pub use data::{DataStore, MarketplaceItem, PluginId};
 pub use filter::filter_plugins;

--- a/src/tui/manager/core.rs
+++ b/src/tui/manager/core.rs
@@ -19,10 +19,14 @@ mod data_test;
 mod filter_test;
 
 pub use app::{update, view, Model, Tab};
+// `LIST_HIGHLIGHT_WIDTH` は現状内部利用がないが、`LIST_DECORATION_WIDTH` の内訳として
+// 公開 API を維持する（将来 List 装飾の構成を変える際の参照点として残す）。
+// 単独利用がないため `unused_imports` lint を抑制する。他の re-export 項目には影響しない。
 #[allow(unused_imports)]
+pub use common::LIST_HIGHLIGHT_WIDTH;
 pub use common::{
     content_rect, render_filter_bar, truncate_to_width, BLOCK_BORDER_WIDTH, HORIZONTAL_PADDING,
-    LIST_DECORATION_WIDTH, LIST_HIGHLIGHT_WIDTH, MIN_CONTENT_WIDTH,
+    LIST_DECORATION_WIDTH, MIN_CONTENT_WIDTH,
 };
 pub use data::{DataStore, MarketplaceItem, PluginId};
 pub use filter::filter_plugins;

--- a/src/tui/manager/core.rs
+++ b/src/tui/manager/core.rs
@@ -19,14 +19,15 @@ mod data_test;
 mod filter_test;
 
 pub use app::{update, view, Model, Tab};
-// `LIST_HIGHLIGHT_WIDTH` は現状内部利用がないが、`LIST_DECORATION_WIDTH` の内訳として
-// 公開 API を維持する（将来 List 装飾の構成を変える際の参照点として残す）。
-// 単独利用がないため `unused_imports` lint を抑制する。他の re-export 項目には影響しない。
-#[allow(unused_imports)]
-pub use common::LIST_HIGHLIGHT_WIDTH;
+// `LIST_HIGHLIGHT_WIDTH` / `BLOCK_BORDER_WIDTH` は現状クレート内で直接参照していないが、
+// 装飾幅の内訳定数として公開 API を維持する（List 装飾構成や Paragraph 系切り詰め予算を
+// 外部から再構成できる参照点として残す）。単独利用がないため `unused_imports` lint を
+// 抑制する。他の re-export 項目には影響しない。
 pub use common::{
-    content_rect, render_filter_bar, truncate_to_width, BLOCK_BORDER_WIDTH, HORIZONTAL_PADDING,
-    LIST_DECORATION_WIDTH, MIN_CONTENT_WIDTH,
+    content_rect, render_filter_bar, truncate_for_list, truncate_for_paragraph, truncate_to_width,
+    HORIZONTAL_PADDING, LIST_DECORATION_WIDTH, MIN_CONTENT_WIDTH,
 };
+#[allow(unused_imports)]
+pub use common::{BLOCK_BORDER_WIDTH, LIST_HIGHLIGHT_WIDTH};
 pub use data::{DataStore, MarketplaceItem, PluginId};
 pub use filter::filter_plugins;

--- a/src/tui/manager/core/common.rs
+++ b/src/tui/manager/core/common.rs
@@ -4,6 +4,7 @@
 
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Paragraph};
+use std::borrow::Cow;
 
 /// フィルタ入力欄を描画（ボーダー付き、高さ3行）
 ///
@@ -118,30 +119,41 @@ pub fn truncate_to_width(text: &str, max_width: u16) -> String {
 
 /// `content_width` が `MIN_CONTENT_WIDTH` 未満のときだけ `text` を装飾幅 `decoration_width` 引きで切り詰める。
 ///
-/// それ以外（通常幅）は `text` を所有形式に変換するだけで何も変えない。
+/// それ以外（通常幅）は入力をそのまま返す。
+/// `Cow<'a, str>` を返すことで、通常幅では呼び側が渡した `String` / `&str` を所有権ごと
+/// パススルーでき、`text.to_string()` による余分な clone/allocation を避けられる。
 /// ウィジェット種類で異なる装飾幅を呼び側が選び、共通の if 分岐をここに集約する。
-fn truncate_when_narrow(content_width: u16, decoration_width: u16, text: &str) -> String {
+fn truncate_when_narrow<'a>(
+    content_width: u16,
+    decoration_width: u16,
+    text: impl Into<Cow<'a, str>>,
+) -> Cow<'a, str> {
+    let text = text.into();
     if content_width < MIN_CONTENT_WIDTH {
         let inner_width = content_width.saturating_sub(decoration_width);
-        truncate_to_width(text, inner_width)
+        Cow::Owned(truncate_to_width(&text, inner_width))
     } else {
-        text.to_string()
+        text
     }
 }
 
 /// `List`（`Borders::ALL` + `highlight_symbol("> ")`）行用の狭幅フォールバック。
 ///
 /// `content_width < MIN_CONTENT_WIDTH` のときだけ `LIST_DECORATION_WIDTH` を差し引いた
-/// inner width で `truncate_to_width` を適用する。それ以外はそのまま返す。
-pub fn truncate_for_list(content_width: u16, text: &str) -> String {
+/// inner width で `truncate_to_width` を適用する。それ以外は入力をそのまま `Cow` で返す
+/// （`String` を渡せば所有権ごとパススルーされ、wide path での余分な clone は発生しない）。
+pub fn truncate_for_list<'a>(content_width: u16, text: impl Into<Cow<'a, str>>) -> Cow<'a, str> {
     truncate_when_narrow(content_width, LIST_DECORATION_WIDTH, text)
 }
 
 /// `Paragraph + Block(Borders::ALL)`（`highlight_symbol` なし）行用の狭幅フォールバック。
 ///
 /// `content_width < MIN_CONTENT_WIDTH` のときだけ `BLOCK_BORDER_WIDTH` を差し引いた
-/// inner width で `truncate_to_width` を適用する。それ以外はそのまま返す。
-pub fn truncate_for_paragraph(content_width: u16, text: &str) -> String {
+/// inner width で `truncate_to_width` を適用する。それ以外は入力をそのまま `Cow` で返す。
+pub fn truncate_for_paragraph<'a>(
+    content_width: u16,
+    text: impl Into<Cow<'a, str>>,
+) -> Cow<'a, str> {
     truncate_when_narrow(content_width, BLOCK_BORDER_WIDTH, text)
 }
 

--- a/src/tui/manager/core/common.rs
+++ b/src/tui/manager/core/common.rs
@@ -46,18 +46,69 @@ pub fn render_filter_bar(f: &mut Frame, area: Rect, filter_text: &str, focused: 
     f.render_widget(content, area);
 }
 
-/// コンテンツに合わせたダイアログ領域を計算（左寄せ）
+/// フレーム全体の左右パディング（cells）。タブバー・フィルタ・コンテンツ・ヘルプ全てに適用。
+pub const HORIZONTAL_PADDING: u16 = 2;
+
+/// 通常レイアウトとして扱う最小コンテンツ幅。これを下回ると各行を `truncate_to_width` で切り詰める。
+///
+/// これは閾値判定にのみ使い、切り詰め予算にはウィジェット種類ごとの装飾幅
+/// (`LIST_DECORATION_WIDTH` / `BLOCK_BORDER_WIDTH`) を差し引いた値を使う。
+pub const MIN_CONTENT_WIDTH: u16 = 40;
+
+/// `Block(Borders::ALL)` の左右ボーダー分の幅 cells（左右で合計 2 cells）。
+///
+/// `Paragraph + Block(Borders::ALL)`（`highlight_symbol` を持たないウィジェット）の
+/// inner width 算出に使う: `inner = outer.width.saturating_sub(BLOCK_BORDER_WIDTH)`。
+pub const BLOCK_BORDER_WIDTH: u16 = 2;
+
+/// `List` ウィジェットの選択記号 `highlight_symbol("> ")` 分の幅 cells（"> " で 2 cells）。
+pub const LIST_HIGHLIGHT_WIDTH: u16 = 2;
+
+/// `List` ウィジェットの装飾分（描画不可領域）の合計幅 cells。
+///
+/// 内訳: ボーダー左右 2 cells (`BLOCK_BORDER_WIDTH`) + `highlight_symbol("> ")` 2 cells
+/// (`LIST_HIGHLIGHT_WIDTH`) = 4 cells。
+/// `outer.width` から `LIST_DECORATION_WIDTH` を差し引いた値が、`List` の行内に
+/// 実際に描画可能な幅。
+///
+/// 閾値判定 (`MIN_CONTENT_WIDTH`) と切り詰め予算は別物。
+/// **Paragraph 系には `BLOCK_BORDER_WIDTH`、List 系には `LIST_DECORATION_WIDTH` を使い分ける**。
+pub const LIST_DECORATION_WIDTH: u16 = BLOCK_BORDER_WIDTH + LIST_HIGHLIGHT_WIDTH;
+
+/// フレーム領域から左右パディングのみを差し引いたコンテンツ領域を返す純粋関数。
+///
+/// 高さ・y 座標は変更しない（モーダルの縦サイズを保つため、上下パディングは加えない）。
 ///
 /// # Arguments
 ///
-/// * `width` - desired dialog width in cells (clamped to `area.width`)
-/// * `height` - desired dialog height in cells (clamped to `area.height`)
-/// * `area` - the containing rectangle the dialog is anchored to
-pub fn dialog_rect(width: u16, height: u16, area: Rect) -> Rect {
-    Rect::new(
-        area.x,
-        area.y,
-        width.min(area.width),
-        height.min(area.height),
-    )
+/// * `area` - 元の Frame 領域（通常 `f.area()`）
+/// * `padding` - 左右に差し引くパディング cells（左右共通、合計 `2 * padding`）
+pub fn content_rect(area: Rect, padding: u16) -> Rect {
+    let total_pad = padding.saturating_mul(2);
+    let width = area.width.saturating_sub(total_pad);
+    Rect::new(area.x.saturating_add(padding), area.y, width, area.height)
 }
+
+/// 文字列を最大幅 `max_width` cells に収まるように切り詰める純粋関数。
+///
+/// `text.chars().count() <= max_width` ならそのまま返す。
+/// 超える場合、`max_width > 3` なら先頭 `max_width - 3` 文字 + `"..."`、
+/// `max_width <= 3` なら先頭 `max_width` 文字を返す。
+///
+/// 想定用途は ASCII / 半角英数字主体のリスト行・タイトル・説明文。
+/// 全角文字を含む場合は表示幅と文字数が一致しないため目安として動作する。
+pub fn truncate_to_width(text: &str, max_width: u16) -> String {
+    let max = max_width as usize;
+    if text.chars().count() <= max {
+        return text.to_string();
+    }
+    if max <= 3 {
+        return text.chars().take(max).collect();
+    }
+    let head: String = text.chars().take(max - 3).collect();
+    format!("{head}...")
+}
+
+#[cfg(test)]
+#[path = "common_test.rs"]
+mod common_test;

--- a/src/tui/manager/core/common.rs
+++ b/src/tui/manager/core/common.rs
@@ -89,11 +89,17 @@ pub fn content_rect(area: Rect, padding: u16) -> Rect {
     Rect::new(area.x.saturating_add(padding), area.y, width, area.height)
 }
 
+/// 切り詰め時の省略記号文字列。
+pub const ELLIPSIS: &str = "...";
+
+/// 切り詰め時の省略記号の文字数（cells）。`ELLIPSIS.chars().count()` と整合させる。
+pub const ELLIPSIS_LEN: u16 = 3;
+
 /// 文字列を最大幅 `max_width` cells に収まるように切り詰める純粋関数。
 ///
 /// `text.chars().count() <= max_width` ならそのまま返す。
-/// 超える場合、`max_width > 3` なら先頭 `max_width - 3` 文字 + `"..."`、
-/// `max_width <= 3` なら先頭 `max_width` 文字を返す。
+/// 超える場合、`max_width > ELLIPSIS_LEN` なら先頭 `max_width - ELLIPSIS_LEN` 文字 + `ELLIPSIS`、
+/// `max_width <= ELLIPSIS_LEN` なら先頭 `max_width` 文字を返す（省略記号を載せる余地が無い）。
 ///
 /// 想定用途は ASCII / 半角英数字主体のリスト行・タイトル・説明文。
 /// 全角文字を含む場合は表示幅と文字数が一致しないため目安として動作する。
@@ -102,11 +108,41 @@ pub fn truncate_to_width(text: &str, max_width: u16) -> String {
     if text.chars().count() <= max {
         return text.to_string();
     }
-    if max <= 3 {
+    let ellipsis_len = ELLIPSIS_LEN as usize;
+    if max <= ellipsis_len {
         return text.chars().take(max).collect();
     }
-    let head: String = text.chars().take(max - 3).collect();
-    format!("{head}...")
+    let head: String = text.chars().take(max - ellipsis_len).collect();
+    format!("{head}{ELLIPSIS}")
+}
+
+/// `content_width` が `MIN_CONTENT_WIDTH` 未満のときだけ `text` を装飾幅 `decoration_width` 引きで切り詰める。
+///
+/// それ以外（通常幅）は `text` を所有形式に変換するだけで何も変えない。
+/// ウィジェット種類で異なる装飾幅を呼び側が選び、共通の if 分岐をここに集約する。
+fn truncate_when_narrow(content_width: u16, decoration_width: u16, text: &str) -> String {
+    if content_width < MIN_CONTENT_WIDTH {
+        let inner_width = content_width.saturating_sub(decoration_width);
+        truncate_to_width(text, inner_width)
+    } else {
+        text.to_string()
+    }
+}
+
+/// `List`（`Borders::ALL` + `highlight_symbol("> ")`）行用の狭幅フォールバック。
+///
+/// `content_width < MIN_CONTENT_WIDTH` のときだけ `LIST_DECORATION_WIDTH` を差し引いた
+/// inner width で `truncate_to_width` を適用する。それ以外はそのまま返す。
+pub fn truncate_for_list(content_width: u16, text: &str) -> String {
+    truncate_when_narrow(content_width, LIST_DECORATION_WIDTH, text)
+}
+
+/// `Paragraph + Block(Borders::ALL)`（`highlight_symbol` なし）行用の狭幅フォールバック。
+///
+/// `content_width < MIN_CONTENT_WIDTH` のときだけ `BLOCK_BORDER_WIDTH` を差し引いた
+/// inner width で `truncate_to_width` を適用する。それ以外はそのまま返す。
+pub fn truncate_for_paragraph(content_width: u16, text: &str) -> String {
+    truncate_when_narrow(content_width, BLOCK_BORDER_WIDTH, text)
 }
 
 #[cfg(test)]

--- a/src/tui/manager/core/common_test.rs
+++ b/src/tui/manager/core/common_test.rs
@@ -147,3 +147,36 @@ fn truncate_to_width_at_boundary_41() {
     let text = "a".repeat(40);
     assert_eq!(truncate_to_width(&text, 41), text);
 }
+
+// =============================================================================
+// truncate_for_list / truncate_for_paragraph — 狭幅フォールバック
+// =============================================================================
+
+#[test]
+fn truncate_for_list_returns_text_when_wide() {
+    let text = "a".repeat(50);
+    assert_eq!(truncate_for_list(80, &text), text);
+}
+
+#[test]
+fn truncate_for_list_truncates_with_list_decoration_width_when_narrow() {
+    let text = "a".repeat(50);
+    let result = truncate_for_list(30, &text);
+    let inner = (30u16 - LIST_DECORATION_WIDTH) as usize;
+    assert_eq!(result.chars().count(), inner);
+    assert!(result.ends_with(ELLIPSIS));
+}
+
+#[test]
+fn truncate_for_paragraph_truncates_with_block_border_width_when_narrow() {
+    let text = "a".repeat(50);
+    let result = truncate_for_paragraph(30, &text);
+    let inner = (30u16 - BLOCK_BORDER_WIDTH) as usize;
+    assert_eq!(result.chars().count(), inner);
+    assert!(result.ends_with(ELLIPSIS));
+}
+
+#[test]
+fn truncate_for_list_does_not_panic_at_zero_width() {
+    let _ = truncate_for_list(0, "abc");
+}

--- a/src/tui/manager/core/common_test.rs
+++ b/src/tui/manager/core/common_test.rs
@@ -1,0 +1,144 @@
+//! `content_rect` と `truncate_to_width` の境界値テスト
+
+use super::*;
+use ratatui::layout::Rect;
+
+// =============================================================================
+// content_rect — 横はパディング差し引き、縦は触らない
+// =============================================================================
+
+#[test]
+fn content_rect_subtracts_horizontal_padding_from_full_width() {
+    let area = Rect::new(0, 0, 100, 30);
+    let result = content_rect(area, 2);
+    assert_eq!(result, Rect::new(2, 0, 96, 30));
+}
+
+#[test]
+fn content_rect_with_zero_padding_returns_same_area() {
+    let area = Rect::new(0, 0, 100, 30);
+    assert_eq!(content_rect(area, 0), area);
+}
+
+#[test]
+fn content_rect_preserves_height() {
+    let area = Rect::new(0, 0, 50, 17);
+    let result = content_rect(area, 2);
+    assert_eq!(result.height, 17);
+}
+
+#[test]
+fn content_rect_preserves_y() {
+    let area = Rect::new(0, 5, 50, 10);
+    let result = content_rect(area, 3);
+    assert_eq!(result.y, 5);
+}
+
+#[test]
+fn content_rect_shifts_x_by_padding() {
+    let area = Rect::new(10, 0, 50, 10);
+    let result = content_rect(area, 2);
+    assert_eq!(result.x, 12);
+}
+
+#[test]
+fn content_rect_with_width_equal_to_padding_returns_zero_width() {
+    let area = Rect::new(0, 0, 4, 10);
+    let result = content_rect(area, 2);
+    assert_eq!(result.width, 0);
+}
+
+#[test]
+fn content_rect_with_width_one_above_padding_returns_one() {
+    let area = Rect::new(0, 0, 5, 10);
+    let result = content_rect(area, 2);
+    assert_eq!(result.width, 1);
+}
+
+#[test]
+fn content_rect_with_narrow_width_saturates_to_zero() {
+    let area = Rect::new(0, 0, 3, 10);
+    let result = content_rect(area, 2);
+    assert_eq!(result.width, 0);
+}
+
+#[test]
+fn content_rect_with_zero_width_does_not_panic() {
+    let area = Rect::new(0, 0, 0, 10);
+    let result = content_rect(area, 2);
+    assert_eq!(result.width, 0);
+}
+
+#[test]
+fn content_rect_with_huge_padding_does_not_overflow() {
+    let area = Rect::new(0, 0, 10, 10);
+    let result = content_rect(area, u16::MAX);
+    assert_eq!(result.width, 0);
+}
+
+#[test]
+fn content_rect_with_max_x_does_not_overflow() {
+    let area = Rect::new(u16::MAX, 0, 10, 10);
+    let result = content_rect(area, 2);
+    assert_eq!(result.x, u16::MAX);
+}
+
+// =============================================================================
+// truncate_to_width — 文字数ベースの切り詰め
+// =============================================================================
+
+#[test]
+fn truncate_to_width_returns_text_when_within_limit() {
+    assert_eq!(truncate_to_width("hello", 10), "hello");
+}
+
+#[test]
+fn truncate_to_width_returns_text_when_exactly_at_limit() {
+    assert_eq!(truncate_to_width("hello", 5), "hello");
+}
+
+#[test]
+fn truncate_to_width_appends_ellipsis_when_exceeded() {
+    assert_eq!(truncate_to_width("hello world", 8), "hello...");
+}
+
+#[test]
+fn truncate_to_width_with_width_three_truncates_without_ellipsis() {
+    assert_eq!(truncate_to_width("abc", 3), "abc");
+    assert_eq!(truncate_to_width("abcd", 3), "abc");
+}
+
+#[test]
+fn truncate_to_width_with_width_one_returns_first_char() {
+    assert_eq!(truncate_to_width("abc", 1), "a");
+}
+
+#[test]
+fn truncate_to_width_with_zero_width_returns_empty() {
+    assert_eq!(truncate_to_width("abc", 0), "");
+}
+
+#[test]
+fn truncate_to_width_with_empty_text_returns_empty() {
+    assert_eq!(truncate_to_width("", 10), "");
+}
+
+#[test]
+fn truncate_to_width_at_boundary_39() {
+    let text = "a".repeat(40);
+    let result = truncate_to_width(&text, 39);
+    assert_eq!(result.chars().count(), 39);
+    assert!(result.ends_with("..."));
+}
+
+#[test]
+fn truncate_to_width_at_boundary_40() {
+    let text = "a".repeat(40);
+    assert_eq!(truncate_to_width(&text, 40), text);
+}
+
+#[test]
+fn truncate_to_width_at_boundary_41() {
+    let text = "a".repeat(40);
+    assert_eq!(truncate_to_width(&text, 41), text);
+}

--- a/src/tui/manager/core/common_test.rs
+++ b/src/tui/manager/core/common_test.rs
@@ -77,10 +77,15 @@ fn content_rect_with_huge_padding_does_not_overflow() {
 }
 
 #[test]
-fn content_rect_with_max_x_does_not_overflow() {
+fn content_rect_with_max_x_saturates_x_without_panic() {
+    // area.x = u16::MAX で `area.x + padding` が桁あふれするケース。
+    // saturating_add によって panic せず x が u16::MAX に飽和することを保証する。
+    // （`Rect::new` は `x + width` の overflow を防ぐため width を clamp する点に注意）
     let area = Rect::new(u16::MAX, 0, 10, 10);
     let result = content_rect(area, 2);
-    assert_eq!(result.x, u16::MAX);
+    assert_eq!(result.x, u16::MAX, "x should saturate to u16::MAX");
+    assert_eq!(result.y, 0);
+    assert_eq!(result.height, 10, "height is preserved");
 }
 
 // =============================================================================

--- a/src/tui/manager/core/common_test.rs
+++ b/src/tui/manager/core/common_test.rs
@@ -180,3 +180,24 @@ fn truncate_for_paragraph_truncates_with_block_border_width_when_narrow() {
 fn truncate_for_list_does_not_panic_at_zero_width() {
     let _ = truncate_for_list(0, "abc");
 }
+
+#[test]
+fn truncate_for_list_borrows_input_when_wide() {
+    use std::borrow::Cow;
+    let text = "a".repeat(50);
+    // 通常幅では入力を所有権パススルーし、新規アロケーションを発生させない。
+    assert!(matches!(
+        truncate_for_list(80, text.as_str()),
+        Cow::Borrowed(_)
+    ));
+}
+
+#[test]
+fn truncate_for_list_owns_truncated_text_when_narrow() {
+    use std::borrow::Cow;
+    let text = "a".repeat(50);
+    assert!(matches!(
+        truncate_for_list(30, text.as_str()),
+        Cow::Owned(_)
+    ));
+}

--- a/src/tui/manager/screens/discover.rs
+++ b/src/tui/manager/screens/discover.rs
@@ -2,7 +2,9 @@
 //!
 //! 利用可能なプラグインの検索と閲覧。
 
-use crate::tui::manager::core::{dialog_rect, render_filter_bar, DataStore, PluginId, Tab};
+use crate::tui::manager::core::{
+    content_rect, render_filter_bar, DataStore, PluginId, Tab, HORIZONTAL_PADDING,
+};
 use crossterm::event::KeyCode;
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Clear, ListState, Paragraph, Tabs};
@@ -94,11 +96,8 @@ pub fn view(
     filter_text: &str,
     filter_focused: bool,
 ) {
-    let dialog_width = 55u16;
-    let dialog_height = 11u16; // +3 for filter bar
-
-    let dialog_area = dialog_rect(dialog_width, dialog_height, f.area());
-    f.render_widget(Clear, dialog_area);
+    let outer = content_rect(f.area(), HORIZONTAL_PADDING);
+    f.render_widget(Clear, outer);
 
     let chunks = Layout::default()
         .direction(Direction::Vertical)
@@ -108,7 +107,7 @@ pub fn view(
             Constraint::Min(1),    // コンテンツ
             Constraint::Length(1), // ヘルプ
         ])
-        .split(dialog_area);
+        .split(outer);
 
     let tab_titles: Vec<&str> = Tab::all().iter().map(|t| t.title()).collect();
     let tabs = Tabs::new(tab_titles)

--- a/src/tui/manager/screens/errors.rs
+++ b/src/tui/manager/screens/errors.rs
@@ -2,7 +2,9 @@
 //!
 //! エラー表示と再試行。
 
-use crate::tui::manager::core::{dialog_rect, render_filter_bar, DataStore, Tab};
+use crate::tui::manager::core::{
+    content_rect, render_filter_bar, DataStore, Tab, HORIZONTAL_PADDING,
+};
 use crossterm::event::KeyCode;
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Clear, Paragraph, Tabs};
@@ -64,11 +66,8 @@ pub fn view(
     filter_text: &str,
     filter_focused: bool,
 ) {
-    let dialog_width = 55u16;
-    let dialog_height = 11u16; // +3 for filter bar
-
-    let dialog_area = dialog_rect(dialog_width, dialog_height, f.area());
-    f.render_widget(Clear, dialog_area);
+    let outer = content_rect(f.area(), HORIZONTAL_PADDING);
+    f.render_widget(Clear, outer);
 
     let chunks = Layout::default()
         .direction(Direction::Vertical)
@@ -78,7 +77,7 @@ pub fn view(
             Constraint::Min(1),    // コンテンツ
             Constraint::Length(1), // ヘルプ
         ])
-        .split(dialog_area);
+        .split(outer);
 
     let tab_titles: Vec<&str> = Tab::all().iter().map(|t| t.title()).collect();
     let tabs = Tabs::new(tab_titles)

--- a/src/tui/manager/screens/installed/view.rs
+++ b/src/tui/manager/screens/installed/view.rs
@@ -4,8 +4,10 @@
 
 use super::model::{DetailAction, Model, UpdateStatusDisplay};
 use crate::component::ComponentKind;
+use crate::plugin::InstalledPlugin;
 use crate::tui::manager::core::{
-    dialog_rect, filter_plugins, render_filter_bar, DataStore, PluginId, Tab,
+    content_rect, filter_plugins, render_filter_bar, truncate_to_width, DataStore, PluginId, Tab,
+    HORIZONTAL_PADDING, LIST_DECORATION_WIDTH, MIN_CONTENT_WIDTH,
 };
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph, Tabs};
@@ -104,6 +106,73 @@ fn sanitize_reason(reason: &str) -> String {
     }
 }
 
+/// プラグイン 1 行分の Span 列を構築する。
+///
+/// 通常時は `[prefix + name/version/disabled + update_status]` の複数 Span を返し、
+/// `content_width < MIN_CONTENT_WIDTH` の狭幅時は更新ステータス Span を落とし、
+/// `prefix + body` の最大 2 Span に切り詰める。`content_width` には `outer.width` を渡す。
+pub(super) fn build_plugin_row_spans<'a>(
+    plugin: &'a InstalledPlugin,
+    is_marked: bool,
+    update_status: Option<&'a UpdateStatusDisplay>,
+    content_width: u16,
+) -> Vec<Span<'a>> {
+    let mark_indicator = if is_marked { "[x] " } else { "[ ] " };
+    let prefix = format!("  {}", mark_indicator);
+
+    let marketplace_str = plugin
+        .marketplace()
+        .map(|m| format!(" @{}", m))
+        .unwrap_or_default();
+    let status_str = if plugin.enabled() { "" } else { " [disabled]" };
+    let name_text = format!(
+        "{}{}  v{}{}",
+        plugin.name(),
+        marketplace_str,
+        plugin.version(),
+        status_str
+    );
+
+    let base_style = if is_marked {
+        Style::default().fg(Color::Yellow)
+    } else if plugin.enabled() {
+        Style::default()
+    } else {
+        Style::default().fg(Color::DarkGray)
+    };
+
+    if content_width < MIN_CONTENT_WIDTH {
+        let list_inner_width = content_width.saturating_sub(LIST_DECORATION_WIDTH);
+        let prefix_w = prefix.chars().count() as u16;
+        let body_budget = list_inner_width.saturating_sub(prefix_w);
+        let body = truncate_to_width(&name_text, body_budget);
+        vec![
+            Span::styled(prefix, base_style),
+            Span::styled(body, base_style),
+        ]
+    } else {
+        let mut spans = vec![
+            Span::styled(prefix, base_style),
+            Span::styled(name_text, base_style),
+        ];
+        if let Some(status) = update_status {
+            spans.push(update_status_span(status));
+        }
+        spans
+    }
+}
+
+/// プラグイン 1 行分の `ListItem` を構築する。
+pub(super) fn build_plugin_row<'a>(
+    plugin: &'a InstalledPlugin,
+    is_marked: bool,
+    update_status: Option<&'a UpdateStatusDisplay>,
+    content_width: u16,
+) -> ListItem<'a> {
+    let spans = build_plugin_row_spans(plugin, is_marked, update_status, content_width);
+    ListItem::new(Line::from(spans))
+}
+
 /// 更新ステータスの表示文字列とスタイルを取得
 ///
 /// # Arguments
@@ -146,12 +215,8 @@ fn view_plugin_list(
     update_statuses: &HashMap<PluginId, UpdateStatusDisplay>,
 ) {
     let filtered = filter_plugins(&ctx.data.plugins, ctx.filter_text);
-    let content_height = (filtered.len() as u16).max(1) + 9; // +3 for filter bar
-    let dialog_width = 55u16;
-    let dialog_height = content_height.min(24);
-
-    let dialog_area = dialog_rect(dialog_width, dialog_height, f.area());
-    f.render_widget(Clear, dialog_area);
+    let outer = content_rect(f.area(), HORIZONTAL_PADDING);
+    f.render_widget(Clear, outer);
 
     let chunks = Layout::default()
         .direction(Direction::Vertical)
@@ -161,7 +226,7 @@ fn view_plugin_list(
             Constraint::Min(1),    // コンテンツ
             Constraint::Length(1), // ヘルプ
         ])
-        .split(dialog_area);
+        .split(outer);
 
     // タブバー
     let tab_titles: Vec<&str> = Tab::all().iter().map(|t| t.title()).collect();
@@ -207,44 +272,8 @@ fn view_plugin_list(
             .iter()
             .map(|p| {
                 let is_marked = marked_ids.contains(p.id());
-                let mark_indicator = if is_marked { "[x] " } else { "[ ] " };
-
-                let marketplace_str = p
-                    .marketplace()
-                    .map(|m| format!(" @{}", m))
-                    .unwrap_or_default();
-                let status_str = if p.enabled() { "" } else { " [disabled]" };
-
-                // 行のベーススタイル（マーク・disabled 状態に応じて統一）
-                let base_style = if is_marked {
-                    Style::default().fg(Color::Yellow)
-                } else if p.enabled() {
-                    Style::default()
-                } else {
-                    Style::default().fg(Color::DarkGray)
-                };
-
-                let mut spans = vec![];
-
-                // マークインジケータ（ベーススタイルと統一）
-                spans.push(Span::styled(format!("  {}", mark_indicator), base_style));
-
-                // プラグイン名
-                let name_text = format!(
-                    "{}{}  v{}{}",
-                    p.name(),
-                    marketplace_str,
-                    p.version(),
-                    status_str
-                );
-                spans.push(Span::styled(name_text, base_style));
-
-                // 更新ステータス
-                if let Some(update_status) = update_statuses.get(p.id()) {
-                    spans.push(update_status_span(update_status));
-                }
-
-                ListItem::new(Line::from(spans))
+                let update_status = update_statuses.get(p.id());
+                build_plugin_row(p, is_marked, update_status, outer.width)
             })
             .collect();
 
@@ -286,11 +315,8 @@ fn view_plugin_detail(
         return;
     };
 
-    // ダイアログサイズ
-    let dialog_width = 65u16;
-    let dialog_height = 21u16; // +3 for filter bar
-    let dialog_area = dialog_rect(dialog_width, dialog_height, f.area());
-    f.render_widget(Clear, dialog_area);
+    let outer = content_rect(f.area(), HORIZONTAL_PADDING);
+    f.render_widget(Clear, outer);
 
     let chunks = Layout::default()
         .direction(Direction::Vertical)
@@ -301,7 +327,7 @@ fn view_plugin_detail(
             Constraint::Min(1),    // アクションメニュー
             Constraint::Length(1), // ヘルプ
         ])
-        .split(dialog_area);
+        .split(outer);
 
     // タブバー
     let tab_titles: Vec<&str> = Tab::all().iter().map(|t| t.title()).collect();
@@ -394,15 +420,9 @@ fn view_component_types(
     };
 
     let counts = ctx.data.available_component_kinds(plugin);
-    let has_marketplace = plugin.marketplace().is_some();
-    let base_lines = if has_marketplace { 4 } else { 3 };
-    let type_lines = if counts.is_empty() { 1 } else { counts.len() };
-    let content_height = (base_lines + type_lines) as u16 + 7; // +3 for filter bar
-    let dialog_width = 55u16;
-    let dialog_height = content_height.min(18);
 
-    let dialog_area = dialog_rect(dialog_width, dialog_height, f.area());
-    f.render_widget(Clear, dialog_area);
+    let outer = content_rect(f.area(), HORIZONTAL_PADDING);
+    f.render_widget(Clear, outer);
 
     let chunks = Layout::default()
         .direction(Direction::Vertical)
@@ -411,7 +431,7 @@ fn view_component_types(
             Constraint::Min(1),    // コンテンツ
             Constraint::Length(1), // ヘルプ
         ])
-        .split(dialog_area);
+        .split(outer);
 
     // フィルタバー（read-only）
     render_filter_bar(f, chunks[0], ctx.filter_text, ctx.filter_focused);
@@ -489,12 +509,8 @@ fn view_component_list(
         .map(|c| ListItem::new(format!("  {}", c)))
         .collect();
 
-    let content_height = (components.len() as u16).max(1) + 7; // +3 for filter bar
-    let dialog_width = 55u16;
-    let dialog_height = content_height.min(23);
-
-    let dialog_area = dialog_rect(dialog_width, dialog_height, f.area());
-    f.render_widget(Clear, dialog_area);
+    let outer = content_rect(f.area(), HORIZONTAL_PADDING);
+    f.render_widget(Clear, outer);
 
     let chunks = Layout::default()
         .direction(Direction::Vertical)
@@ -503,7 +519,7 @@ fn view_component_list(
             Constraint::Min(1),    // コンテンツ
             Constraint::Length(1), // ヘルプ
         ])
-        .split(dialog_area);
+        .split(outer);
 
     // フィルタバー（read-only）
     render_filter_bar(f, chunks[0], ctx.filter_text, ctx.filter_focused);
@@ -530,3 +546,7 @@ fn view_component_list(
         .style(Style::default().fg(Color::DarkGray));
     f.render_widget(help, chunks[2]);
 }
+
+#[cfg(test)]
+#[path = "view_test.rs"]
+mod view_test;

--- a/src/tui/manager/screens/installed/view.rs
+++ b/src/tui/manager/screens/installed/view.rs
@@ -3,8 +3,8 @@
 //! 各画面状態に応じた描画ロジック。
 
 use super::model::{DetailAction, Model, UpdateStatusDisplay};
-use crate::component::ComponentKind;
 use crate::application::InstalledPlugin;
+use crate::component::ComponentKind;
 use crate::tui::manager::core::{
     content_rect, filter_plugins, render_filter_bar, truncate_to_width, DataStore, PluginId, Tab,
     HORIZONTAL_PADDING, LIST_DECORATION_WIDTH, MIN_CONTENT_WIDTH,
@@ -106,6 +106,74 @@ fn sanitize_reason(reason: &str) -> String {
     }
 }
 
+/// マーク状態 / 有効状態に応じた行のベーススタイルを返す。
+fn plugin_row_style(is_marked: bool, enabled: bool) -> Style {
+    match (is_marked, enabled) {
+        (true, _) => Style::default().fg(Color::Yellow),
+        (false, true) => Style::default(),
+        (false, false) => Style::default().fg(Color::DarkGray),
+    }
+}
+
+/// マーク有無からチェック印 prefix を組み立てる。
+fn plugin_row_prefix(is_marked: bool) -> String {
+    let mark_indicator = if is_marked { "[x] " } else { "[ ] " };
+    format!("  {}", mark_indicator)
+}
+
+/// 名前 + (marketplace) + バージョン + (disabled) を組み立てる。
+fn plugin_row_name_text(plugin: &InstalledPlugin) -> String {
+    let marketplace_str = plugin
+        .marketplace()
+        .map(|m| format!(" @{}", m))
+        .unwrap_or_default();
+    let status_str = if plugin.enabled() { "" } else { " [disabled]" };
+    format!(
+        "{}{}  v{}{}",
+        plugin.name(),
+        marketplace_str,
+        plugin.version(),
+        status_str
+    )
+}
+
+/// 狭幅 (`content_width < MIN_CONTENT_WIDTH`) フォールバック用の Span 列。
+///
+/// 更新ステータス Span を落とし、`prefix` のスタイルを保ったまま
+/// 残り幅 (`list_inner_width - prefix_w`) で `name_text` を切り詰めた最大 2 Span 構成。
+fn narrow_plugin_row_spans<'a>(
+    prefix: String,
+    name_text: &str,
+    content_width: u16,
+    base_style: Style,
+) -> Vec<Span<'a>> {
+    let list_inner_width = content_width.saturating_sub(LIST_DECORATION_WIDTH);
+    let prefix_w = prefix.chars().count() as u16;
+    let body_budget = list_inner_width.saturating_sub(prefix_w);
+    let body = truncate_to_width(name_text, body_budget);
+    vec![
+        Span::styled(prefix, base_style),
+        Span::styled(body, base_style),
+    ]
+}
+
+/// 通常幅用の Span 列。`prefix + name_text` に更新ステータス Span を追記する。
+fn wide_plugin_row_spans<'a>(
+    prefix: String,
+    name_text: String,
+    update_status: Option<&'a UpdateStatusDisplay>,
+    base_style: Style,
+) -> Vec<Span<'a>> {
+    let mut spans = vec![
+        Span::styled(prefix, base_style),
+        Span::styled(name_text, base_style),
+    ];
+    if let Some(status) = update_status {
+        spans.push(update_status_span(status));
+    }
+    spans
+}
+
 /// プラグイン 1 行分の Span 列を構築する。
 ///
 /// 通常時は `[prefix + name/version/disabled + update_status]` の複数 Span を返し、
@@ -117,48 +185,14 @@ pub(super) fn build_plugin_row_spans<'a>(
     update_status: Option<&'a UpdateStatusDisplay>,
     content_width: u16,
 ) -> Vec<Span<'a>> {
-    let mark_indicator = if is_marked { "[x] " } else { "[ ] " };
-    let prefix = format!("  {}", mark_indicator);
-
-    let marketplace_str = plugin
-        .marketplace()
-        .map(|m| format!(" @{}", m))
-        .unwrap_or_default();
-    let status_str = if plugin.enabled() { "" } else { " [disabled]" };
-    let name_text = format!(
-        "{}{}  v{}{}",
-        plugin.name(),
-        marketplace_str,
-        plugin.version(),
-        status_str
-    );
-
-    let base_style = if is_marked {
-        Style::default().fg(Color::Yellow)
-    } else if plugin.enabled() {
-        Style::default()
-    } else {
-        Style::default().fg(Color::DarkGray)
-    };
+    let prefix = plugin_row_prefix(is_marked);
+    let name_text = plugin_row_name_text(plugin);
+    let base_style = plugin_row_style(is_marked, plugin.enabled());
 
     if content_width < MIN_CONTENT_WIDTH {
-        let list_inner_width = content_width.saturating_sub(LIST_DECORATION_WIDTH);
-        let prefix_w = prefix.chars().count() as u16;
-        let body_budget = list_inner_width.saturating_sub(prefix_w);
-        let body = truncate_to_width(&name_text, body_budget);
-        vec![
-            Span::styled(prefix, base_style),
-            Span::styled(body, base_style),
-        ]
+        narrow_plugin_row_spans(prefix, &name_text, content_width, base_style)
     } else {
-        let mut spans = vec![
-            Span::styled(prefix, base_style),
-            Span::styled(name_text, base_style),
-        ];
-        if let Some(status) = update_status {
-            spans.push(update_status_span(status));
-        }
-        spans
+        wide_plugin_row_spans(prefix, name_text, update_status, base_style)
     }
 }
 

--- a/src/tui/manager/screens/installed/view.rs
+++ b/src/tui/manager/screens/installed/view.rs
@@ -4,7 +4,7 @@
 
 use super::model::{DetailAction, Model, UpdateStatusDisplay};
 use crate::component::ComponentKind;
-use crate::plugin::InstalledPlugin;
+use crate::application::InstalledPlugin;
 use crate::tui::manager::core::{
     content_rect, filter_plugins, render_filter_bar, truncate_to_width, DataStore, PluginId, Tab,
     HORIZONTAL_PADDING, LIST_DECORATION_WIDTH, MIN_CONTENT_WIDTH,

--- a/src/tui/manager/screens/installed/view_test.rs
+++ b/src/tui/manager/screens/installed/view_test.rs
@@ -1,0 +1,64 @@
+//! `build_plugin_row_spans` の狭幅フォールバックテスト
+
+use super::*;
+use crate::plugin::InstalledPlugin;
+use crate::tui::manager::core::LIST_DECORATION_WIDTH;
+
+fn make_test_plugin(name: &str) -> InstalledPlugin {
+    InstalledPlugin::new_for_test(name, "1.0.0", Vec::new(), None, None, true)
+}
+
+fn span_texts(spans: &[Span<'_>]) -> Vec<String> {
+    spans.iter().map(|s| s.content.to_string()).collect()
+}
+
+#[test]
+fn build_plugin_row_uses_multi_span_when_wide() {
+    let plugin = make_test_plugin("plugin-name");
+    let status = UpdateStatusDisplay::AlreadyUpToDate;
+    let spans = build_plugin_row_spans(&plugin, false, Some(&status), 80);
+    assert!(
+        spans.len() >= 3,
+        "wide path should keep multiple spans, got {}",
+        spans.len()
+    );
+    let texts = span_texts(&spans);
+    assert!(
+        texts.iter().any(|s| s.contains("Up to date")),
+        "update status span should be present in wide path: {:?}",
+        texts
+    );
+}
+
+#[test]
+fn build_plugin_row_falls_back_to_single_span_when_narrow() {
+    let plugin = make_test_plugin("very-long-plugin-name-that-exceeds-width");
+    let status = UpdateStatusDisplay::AlreadyUpToDate;
+    let content_width = 30u16;
+    let spans = build_plugin_row_spans(&plugin, false, Some(&status), content_width);
+    assert!(
+        spans.len() <= 2,
+        "narrow path should collapse to <=2 spans, got {}",
+        spans.len()
+    );
+    let texts = span_texts(&spans);
+    assert!(
+        !texts.iter().any(|s| s.contains("Up to date")),
+        "update status span should be dropped in narrow path: {:?}",
+        texts
+    );
+    let list_inner_width = content_width.saturating_sub(LIST_DECORATION_WIDTH) as usize;
+    let total_chars: usize = texts.iter().map(|s| s.chars().count()).sum();
+    assert!(
+        total_chars <= list_inner_width,
+        "total {} > list_inner_width {}",
+        total_chars,
+        list_inner_width
+    );
+}
+
+#[test]
+fn build_plugin_row_does_not_panic_at_zero_width() {
+    let plugin = make_test_plugin("p");
+    let _ = build_plugin_row_spans(&plugin, false, None, 0);
+}

--- a/src/tui/manager/screens/installed/view_test.rs
+++ b/src/tui/manager/screens/installed/view_test.rs
@@ -1,7 +1,7 @@
 //! `build_plugin_row_spans` の狭幅フォールバックテスト
 
 use super::*;
-use crate::plugin::InstalledPlugin;
+use crate::application::InstalledPlugin;
 use crate::tui::manager::core::LIST_DECORATION_WIDTH;
 
 fn make_test_plugin(name: &str) -> InstalledPlugin {

--- a/src/tui/manager/screens/marketplaces/view.rs
+++ b/src/tui/manager/screens/marketplaces/view.rs
@@ -220,7 +220,7 @@ fn view_market_list(
                 "  {}    {}{}    {}    {}",
                 m.name, m.source, source_path_info, plugin_info, updated_info
             );
-            ListItem::new(truncate_for_list(outer.width, &raw))
+            ListItem::new(truncate_for_list(outer.width, raw))
         })
         .collect();
 
@@ -433,7 +433,7 @@ fn view_plugin_list(
                 } else {
                     format!("  {}", name)
                 };
-                ListItem::new(truncate_for_list(outer.width, &raw))
+                ListItem::new(truncate_for_list(outer.width, raw))
             })
             .collect();
 
@@ -889,7 +889,7 @@ fn view_install_result(f: &mut Frame, summary: &InstallSummary) {
     for result in &summary.results {
         let (raw, color) = format_install_result_line(result);
         lines.push(Line::from(Span::styled(
-            truncate_for_paragraph(outer.width, &raw),
+            truncate_for_paragraph(outer.width, raw),
             Style::default().fg(color),
         )));
     }

--- a/src/tui/manager/screens/marketplaces/view.rs
+++ b/src/tui/manager/screens/marketplaces/view.rs
@@ -5,7 +5,10 @@ use super::model::{
 };
 use crate::component::Scope;
 use crate::marketplace::PluginSource;
-use crate::tui::manager::core::{dialog_rect, render_filter_bar, DataStore, Tab};
+use crate::tui::manager::core::{
+    content_rect, render_filter_bar, truncate_to_width, DataStore, Tab, BLOCK_BORDER_WIDTH,
+    HORIZONTAL_PADDING, LIST_DECORATION_WIDTH, MIN_CONTENT_WIDTH,
+};
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Clear, Gauge, List, ListItem, ListState, Paragraph, Tabs};
 use std::collections::HashSet;
@@ -162,18 +165,12 @@ fn view_market_list(
     operation_status: &Option<OperationStatus>,
     error_message: &Option<String>,
 ) {
-    // リスト長: マーケットプレイス数 + 1（"+ Add new"）
-    let list_len = ctx.data.marketplaces.len() + 1;
     let has_status = operation_status.is_some();
     let has_error = error_message.is_some();
     let extra_lines = if has_status { 1 } else { 0 } + if has_error { 1 } else { 0 };
 
-    let content_height = (list_len as u16).max(1) + 2 + extra_lines; // +2 for borders
-    let dialog_width = 65u16;
-    let dialog_height = (content_height + 5).min(24); // +5 for tab+filter+help
-
-    let dialog_area = dialog_rect(dialog_width, dialog_height, f.area());
-    f.render_widget(Clear, dialog_area);
+    let outer = content_rect(f.area(), HORIZONTAL_PADDING);
+    f.render_widget(Clear, outer);
 
     let chunks = Layout::default()
         .direction(Direction::Vertical)
@@ -183,7 +180,7 @@ fn view_market_list(
             Constraint::Min(1),    // コンテンツ
             Constraint::Length(1), // ヘルプ
         ])
-        .split(dialog_area);
+        .split(outer);
 
     // タブバー
     render_tab_bar(f, chunks[0]);
@@ -218,10 +215,16 @@ fn view_market_list(
                 .map(|p| format!(" ({})", p))
                 .unwrap_or_default();
 
-            let text = format!(
+            let raw = format!(
                 "  {}    {}{}    {}    {}",
                 m.name, m.source, source_path_info, plugin_info, updated_info
             );
+            let text = if outer.width < MIN_CONTENT_WIDTH {
+                let list_inner_width = outer.width.saturating_sub(LIST_DECORATION_WIDTH);
+                truncate_to_width(&raw, list_inner_width)
+            } else {
+                raw
+            };
             ListItem::new(text)
         })
         .collect();
@@ -288,11 +291,8 @@ fn view_market_detail(
     ctx: &ViewCtx<'_>,
     error_message: &Option<String>,
 ) {
-    let dialog_width = 65u16;
-    let dialog_height = 20u16;
-
-    let dialog_area = dialog_rect(dialog_width, dialog_height, f.area());
-    f.render_widget(Clear, dialog_area);
+    let outer = content_rect(f.area(), HORIZONTAL_PADDING);
+    f.render_widget(Clear, outer);
 
     let has_error = error_message.is_some();
     let error_height = if has_error { 1 } else { 0 };
@@ -307,7 +307,7 @@ fn view_market_detail(
             Constraint::Length(error_height), // エラー
             Constraint::Length(1),            // ヘルプ
         ])
-        .split(dialog_area);
+        .split(outer);
 
     // タブバー
     render_tab_bar(f, chunks[0]);
@@ -400,12 +400,8 @@ fn view_plugin_list(
     plugins: &[(String, Option<String>)],
     filter: &FilterCtx<'_>,
 ) {
-    let content_height = (plugins.len() as u16).max(1) + 2; // +2 for borders
-    let dialog_width = 65u16;
-    let dialog_height = (content_height + 5).min(24);
-
-    let dialog_area = dialog_rect(dialog_width, dialog_height, f.area());
-    f.render_widget(Clear, dialog_area);
+    let outer = content_rect(f.area(), HORIZONTAL_PADDING);
+    f.render_widget(Clear, outer);
 
     let chunks = Layout::default()
         .direction(Direction::Vertical)
@@ -415,7 +411,7 @@ fn view_plugin_list(
             Constraint::Min(1),    // コンテンツ
             Constraint::Length(1), // ヘルプ
         ])
-        .split(dialog_area);
+        .split(outer);
 
     // タブバー
     render_tab_bar(f, chunks[0]);
@@ -437,10 +433,16 @@ fn view_plugin_list(
         let items: Vec<ListItem> = plugins
             .iter()
             .map(|(name, desc)| {
-                let text = if let Some(description) = desc {
+                let raw = if let Some(description) = desc {
                     format!("  {} - {}", name, description)
                 } else {
                     format!("  {}", name)
+                };
+                let text = if outer.width < MIN_CONTENT_WIDTH {
+                    let list_inner_width = outer.width.saturating_sub(LIST_DECORATION_WIDTH);
+                    truncate_to_width(&raw, list_inner_width)
+                } else {
+                    raw
                 };
                 ListItem::new(text)
             })
@@ -472,11 +474,8 @@ fn view_plugin_list(
 /// * `filter_text` - Current filter input text.
 /// * `filter_focused` - Whether the filter bar currently has focus.
 fn view_add_form(f: &mut Frame, form: &AddFormModel, filter_text: &str, filter_focused: bool) {
-    let dialog_width = 65u16;
-    let dialog_height = 15u16;
-
-    let dialog_area = dialog_rect(dialog_width, dialog_height, f.area());
-    f.render_widget(Clear, dialog_area);
+    let outer = content_rect(f.area(), HORIZONTAL_PADDING);
+    f.render_widget(Clear, outer);
 
     let chunks = Layout::default()
         .direction(Direction::Vertical)
@@ -486,7 +485,7 @@ fn view_add_form(f: &mut Frame, form: &AddFormModel, filter_text: &str, filter_f
             Constraint::Min(1),    // コンテンツ
             Constraint::Length(1), // ヘルプ
         ])
-        .split(dialog_area);
+        .split(outer);
 
     // タブバー
     render_tab_bar(f, chunks[0]);
@@ -627,11 +626,8 @@ fn view_plugin_browse(
     mut state: ListState,
     filter: &FilterCtx<'_>,
 ) {
-    let dialog_width = 80u16;
-    let dialog_height = 24u16;
-
-    let dialog_area = dialog_rect(dialog_width, dialog_height, f.area());
-    f.render_widget(Clear, dialog_area);
+    let outer = content_rect(f.area(), HORIZONTAL_PADDING);
+    f.render_widget(Clear, outer);
 
     let chunks = Layout::default()
         .direction(Direction::Vertical)
@@ -641,7 +637,7 @@ fn view_plugin_browse(
             Constraint::Min(1),    // コンテンツ
             Constraint::Length(1), // ヘルプ
         ])
-        .split(dialog_area);
+        .split(outer);
 
     // タブバー
     render_tab_bar(f, chunks[0]);
@@ -706,11 +702,15 @@ fn view_target_select(
     _highlighted_idx: usize,
     mut state: ListState,
 ) {
-    let dialog_width = 45u16;
+    let outer = content_rect(f.area(), HORIZONTAL_PADDING);
     let dialog_height = (targets.len() as u16 + 5).min(16);
-
-    let dialog_area = dialog_rect(dialog_width, dialog_height, f.area());
-    f.render_widget(Clear, dialog_area);
+    let modal_area = Rect::new(
+        outer.x,
+        outer.y,
+        outer.width,
+        dialog_height.min(outer.height),
+    );
+    f.render_widget(Clear, modal_area);
 
     let chunks = Layout::default()
         .direction(Direction::Vertical)
@@ -718,7 +718,7 @@ fn view_target_select(
             Constraint::Min(1),    // コンテンツ
             Constraint::Length(1), // ヘルプ
         ])
-        .split(dialog_area);
+        .split(modal_area);
 
     let items = build_target_list_items(targets);
 
@@ -746,11 +746,15 @@ fn view_target_select(
 /// * `highlighted_idx` - Currently highlighted scope index.
 /// * `state` - List state used for scope highlight.
 fn view_scope_select(f: &mut Frame, highlighted_idx: usize, mut state: ListState) {
-    let dialog_width = 45u16;
+    let outer = content_rect(f.area(), HORIZONTAL_PADDING);
     let dialog_height = 8u16;
-
-    let dialog_area = dialog_rect(dialog_width, dialog_height, f.area());
-    f.render_widget(Clear, dialog_area);
+    let modal_area = Rect::new(
+        outer.x,
+        outer.y,
+        outer.width,
+        dialog_height.min(outer.height),
+    );
+    f.render_widget(Clear, modal_area);
 
     let chunks = Layout::default()
         .direction(Direction::Vertical)
@@ -758,7 +762,7 @@ fn view_scope_select(f: &mut Frame, highlighted_idx: usize, mut state: ListState
             Constraint::Min(1),    // コンテンツ
             Constraint::Length(1), // ヘルプ
         ])
-        .split(dialog_area);
+        .split(modal_area);
 
     let items = build_scope_list_items(highlighted_idx);
 
@@ -787,16 +791,20 @@ fn view_scope_select(f: &mut Frame, highlighted_idx: usize, mut state: ListState
 /// * `current_idx` - Index of the plugin currently being processed.
 /// * `total` - Total number of plugins in this install batch.
 fn view_installing(f: &mut Frame, plugin_names: &[String], current_idx: usize, total: usize) {
-    let dialog_width = 45u16;
+    let outer = content_rect(f.area(), HORIZONTAL_PADDING);
     let dialog_height = 7u16;
-
-    let dialog_area = dialog_rect(dialog_width, dialog_height, f.area());
-    f.render_widget(Clear, dialog_area);
+    let modal_area = Rect::new(
+        outer.x,
+        outer.y,
+        outer.width,
+        dialog_height.min(outer.height),
+    );
+    f.render_widget(Clear, modal_area);
 
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([Constraint::Min(1)])
-        .split(dialog_area);
+        .split(modal_area);
 
     let current_name = plugin_names
         .get(current_idx)
@@ -845,11 +853,16 @@ fn view_installing(f: &mut Frame, plugin_names: &[String], current_idx: usize, t
 /// * `summary` - Aggregated install summary to display.
 fn view_install_result(f: &mut Frame, summary: &InstallSummary) {
     let content_height = (summary.results.len() as u16 + 5).min(20);
-    let dialog_width = 50u16;
     let dialog_height = content_height + 3;
 
-    let dialog_area = dialog_rect(dialog_width, dialog_height, f.area());
-    f.render_widget(Clear, dialog_area);
+    let outer = content_rect(f.area(), HORIZONTAL_PADDING);
+    let modal_area = Rect::new(
+        outer.x,
+        outer.y,
+        outer.width,
+        dialog_height.min(outer.height),
+    );
+    f.render_widget(Clear, modal_area);
 
     let chunks = Layout::default()
         .direction(Direction::Vertical)
@@ -857,7 +870,7 @@ fn view_install_result(f: &mut Frame, summary: &InstallSummary) {
             Constraint::Min(1),    // コンテンツ
             Constraint::Length(1), // ヘルプ
         ])
-        .split(dialog_area);
+        .split(modal_area);
 
     let mut lines = vec![
         Line::raw(""),
@@ -868,16 +881,30 @@ fn view_install_result(f: &mut Frame, summary: &InstallSummary) {
         Line::raw(""),
     ];
 
+    let narrow = outer.width < MIN_CONTENT_WIDTH;
+    let paragraph_inner_width = outer.width.saturating_sub(BLOCK_BORDER_WIDTH);
     for result in &summary.results {
         if result.success {
+            let raw = format!("  ✓ {}", result.plugin_name);
+            let line_text = if narrow {
+                truncate_to_width(&raw, paragraph_inner_width)
+            } else {
+                raw
+            };
             lines.push(Line::from(Span::styled(
-                format!("  ✓ {}", result.plugin_name),
+                line_text,
                 Style::default().fg(Color::Green),
             )));
         } else {
             let error_msg = result.error.as_deref().unwrap_or("Unknown error");
+            let raw = format!("  ✗ {}: {}", result.plugin_name, error_msg);
+            let line_text = if narrow {
+                truncate_to_width(&raw, paragraph_inner_width)
+            } else {
+                raw
+            };
             lines.push(Line::from(Span::styled(
-                format!("  ✗ {}: {}", result.plugin_name, error_msg),
+                line_text,
                 Style::default().fg(Color::Red),
             )));
         }

--- a/src/tui/manager/screens/marketplaces/view.rs
+++ b/src/tui/manager/screens/marketplaces/view.rs
@@ -2,12 +2,13 @@
 
 use super::model::{
     AddFormModel, BrowsePlugin, DetailAction, InstallSummary, Model, OperationStatus,
+    PluginInstallResult,
 };
 use crate::component::Scope;
 use crate::marketplace::PluginSource;
 use crate::tui::manager::core::{
-    content_rect, render_filter_bar, truncate_to_width, DataStore, Tab, BLOCK_BORDER_WIDTH,
-    HORIZONTAL_PADDING, LIST_DECORATION_WIDTH, MIN_CONTENT_WIDTH,
+    content_rect, render_filter_bar, truncate_for_list, truncate_for_paragraph, DataStore, Tab,
+    HORIZONTAL_PADDING,
 };
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Clear, Gauge, List, ListItem, ListState, Paragraph, Tabs};
@@ -219,13 +220,7 @@ fn view_market_list(
                 "  {}    {}{}    {}    {}",
                 m.name, m.source, source_path_info, plugin_info, updated_info
             );
-            let text = if outer.width < MIN_CONTENT_WIDTH {
-                let list_inner_width = outer.width.saturating_sub(LIST_DECORATION_WIDTH);
-                truncate_to_width(&raw, list_inner_width)
-            } else {
-                raw
-            };
-            ListItem::new(text)
+            ListItem::new(truncate_for_list(outer.width, &raw))
         })
         .collect();
 
@@ -438,13 +433,7 @@ fn view_plugin_list(
                 } else {
                     format!("  {}", name)
                 };
-                let text = if outer.width < MIN_CONTENT_WIDTH {
-                    let list_inner_width = outer.width.saturating_sub(LIST_DECORATION_WIDTH);
-                    truncate_to_width(&raw, list_inner_width)
-                } else {
-                    raw
-                };
-                ListItem::new(text)
+                ListItem::new(truncate_for_list(outer.width, &raw))
             })
             .collect();
 
@@ -845,6 +834,22 @@ fn view_installing(f: &mut Frame, plugin_names: &[String], current_idx: usize, t
     f.render_widget(gauge, inner_chunks[1]);
 }
 
+/// インストール結果 1 件を描画用の `(行テキスト, 色)` に整形する。
+///
+/// 成功・失敗で接頭辞・色が異なるが、組み立て・切り詰め・スタイル付与の経路を
+/// 共通化するため、ここでは色とテキストの導出だけを担う。
+fn format_install_result_line(result: &PluginInstallResult) -> (String, Color) {
+    if result.success {
+        (format!("  ✓ {}", result.plugin_name), Color::Green)
+    } else {
+        let error_msg = result.error.as_deref().unwrap_or("Unknown error");
+        (
+            format!("  ✗ {}: {}", result.plugin_name, error_msg),
+            Color::Red,
+        )
+    }
+}
+
 /// インストール結果画面を描画
 ///
 /// # Arguments
@@ -881,33 +886,12 @@ fn view_install_result(f: &mut Frame, summary: &InstallSummary) {
         Line::raw(""),
     ];
 
-    let narrow = outer.width < MIN_CONTENT_WIDTH;
-    let paragraph_inner_width = outer.width.saturating_sub(BLOCK_BORDER_WIDTH);
     for result in &summary.results {
-        if result.success {
-            let raw = format!("  ✓ {}", result.plugin_name);
-            let line_text = if narrow {
-                truncate_to_width(&raw, paragraph_inner_width)
-            } else {
-                raw
-            };
-            lines.push(Line::from(Span::styled(
-                line_text,
-                Style::default().fg(Color::Green),
-            )));
-        } else {
-            let error_msg = result.error.as_deref().unwrap_or("Unknown error");
-            let raw = format!("  ✗ {}: {}", result.plugin_name, error_msg);
-            let line_text = if narrow {
-                truncate_to_width(&raw, paragraph_inner_width)
-            } else {
-                raw
-            };
-            lines.push(Line::from(Span::styled(
-                line_text,
-                Style::default().fg(Color::Red),
-            )));
-        }
+        let (raw, color) = format_install_result_line(result);
+        lines.push(Line::from(Span::styled(
+            truncate_for_paragraph(outer.width, &raw),
+            Style::default().fg(color),
+        )));
     }
 
     lines.push(Line::raw(""));


### PR DESCRIPTION
## 概要

`plm managed` の TUI 全画面で固定幅 `dialog_rect` (45/50/55/65/80 cells) を撤廃し、`f.area()` から左右 2 セルパディングだけを差し引いた `outer` 領域を共通で使う `content_rect` ヘルパへ置換した。広いターミナルで右側に大きな余白が生じる問題を解消し、TUI 全体（タブバー / フィルタ / コンテンツ / ヘルプ / モーダル）を横方向にフル幅化する。縦サイズは各 view の既存 constraints をそのまま温存。

## 変更の種類

- [x] 🎨 UI/UX (TUI レイアウト調整)
- [x] ♻️ Refactoring (`dialog_rect` 撤廃と `content_rect` への置換)
- [x] 🔥 Remove (旧 `dialog_rect` 関数の削除)
- [x] 📱 Responsive (`MIN_CONTENT_WIDTH = 40` 未満の狭幅フォールバック)
- [x] 🧪 Tests (`common_test.rs` 21 / `installed/view_test.rs` 3 ケース追加)

## 詳細な変更内容

### `src/tui/manager/core/common.rs`
- 追加: `HORIZONTAL_PADDING = 2` / `MIN_CONTENT_WIDTH = 40` / `BLOCK_BORDER_WIDTH = 2` / `LIST_HIGHLIGHT_WIDTH = 2` / `LIST_DECORATION_WIDTH = 4`
- 追加: `content_rect(area, padding)` — 左右パディングのみ差し引き、縦・y は不変、`saturating_*` でオーバーフロー安全
- 追加: `truncate_to_width(text, max_width)` — 文字数ベース切り詰め、`max_width > 3` で `"..."` 付与、`<= 3` は切り詰めのみ
- 削除: `dialog_rect` 関数本体

### `src/tui/manager/core.rs`
- 上記 API を `pub use` で公開、`dialog_rect` を pub use から除去

### 通常画面 11 箇所 — `outer = content_rect(f.area(), HORIZONTAL_PADDING)` 置換
縦 constraints の構造は各 view 既存のまま維持（タブ行を勝手に追加していない）。
- `screens/discover.rs` (テンプレ A、4 分割)
- `screens/errors.rs` (テンプレ A、4 分割)
- `screens/installed/view.rs::view_plugin_list` (テンプレ A、4 分割)
- `screens/installed/view.rs::view_plugin_detail` (テンプレ A、**5 分割を維持**)
- `screens/installed/view.rs::view_component_types` (テンプレ B、3 分割、タブ行追加禁止を遵守)
- `screens/installed/view.rs::view_component_list` (テンプレ B、3 分割、同上)
- `screens/marketplaces/view.rs::view_market_list` (テンプレ A、4 分割)
- `screens/marketplaces/view.rs::view_market_detail` (テンプレ A、**6 分割を維持**)
- `screens/marketplaces/view.rs::view_plugin_list` (テンプレ A、4 分割)
- `screens/marketplaces/view.rs::view_add_form` (テンプレ A、4 分割)
- `screens/marketplaces/view.rs::view_plugin_browse` (テンプレ A、`should_split_layout` と `Percentage(40)/(60)` は維持)

### モーダル 4 箇所 — 横はフル幅、`dialog_height` 計算式と上端揃えを温存
- `view_target_select` — `(targets.len() + 5).min(16)` を温存、`y = outer.y` で左上固定
- `view_scope_select` — `dialog_height = 8` を温存
- `view_installing` — `dialog_height = 7` を温存
- `view_install_result` — 現行 `content_height + 3` を温存

### 狭幅フォールバック (`outer.width < MIN_CONTENT_WIDTH`)
ウィジェット種類別に切り詰め予算を使い分け:
- **List 系** (Borders::ALL + `highlight_symbol("> ")`): `list_inner_width = outer.width - LIST_DECORATION_WIDTH (= 4)`
  - `marketplaces/view.rs` L221 (marketplace 行)
  - `marketplaces/view.rs` L441 (plugin 行)
- **Paragraph + Block(Borders::ALL)** (`highlight_symbol` なし): `paragraph_inner_width = outer.width - BLOCK_BORDER_WIDTH (= 2)`
  - `marketplaces/view.rs` L885 周辺 (`view_install_result` の各行)

### `installed/view.rs` の複数 Span 構成 plugin 行
- 新規: `build_plugin_row_spans(plugin, is_marked, update_status, content_width) -> Vec<Span<'_>>`
- 新規: `build_plugin_row` — 上記を `ListItem` でラップ
- 通常時は `[prefix + name/version/disabled + update_status]` の複数 Span
- `content_width < 40` では更新ステータス Span を落とし、`[prefix + truncated_body]` の最大 2 Span に退避

### テスト
- 新規 `src/tui/manager/core/common_test.rs` (21 ケース): `content_rect` 境界値 / `truncate_to_width` 境界値 (39/40/41 含む)
- 新規 `src/tui/manager/screens/installed/view_test.rs` (3 ケース): `build_plugin_row_spans` の wide / narrow / zero-width

## システム図

```
                   terminal.draw(|f| view(f, &model))
                                 │
                                 ▼
               outer = content_rect(f.area(), HORIZONTAL_PADDING=2)
               outer.width  = W.saturating_sub(4)
               outer.height = H        ← 縦は触らない
                                 │
        ┌────────────────────────┼────────────────────────┐
        ▼                        ▼                        ▼
  outer.width = 0      0 < outer.width < 40       outer.width >= 40
  ZERO_WIDTH           NARROW_LAYOUT              FULL_LAYOUT
  (ratatui が          (List 系: list_inner_      (通常レイアウト)
   自動クリップ)        width = outer.width - 4
                        Paragraph 系:
                        paragraph_inner_width =
                        outer.width - 2)
                                 │
                                 ▼
                  各 view の既存 constraints をそのまま温存
                  Layout::split の引数を outer に置換するのみ
```

## 関連 Issue

なし（spec ベース変更: `.plugin-workspace/.specs/007-tui-full-width-layout/`）

## テスト

- ✅ `cargo fmt --check` 差分なし
- ✅ `cargo check --all-targets` エラー 0 件
- ✅ `cargo test` **1426 passed / 0 failed / 0 ignored**
  - `tui::manager::core::common_test` 21 件 (`content_rect` 境界値 / `truncate_to_width` 39/40/41 境界値含む)
  - `tui::manager::screens::installed::view_test` 3 件 (`build_plugin_row_spans` wide / narrow / zero)
  - `marketplaces::view_test::should_split_layout` リグレッション継続パス
- ⚠️ 手動目視確認 (ターミナル幅 200 / 40 / 35 / 4 cols でのレイアウト確認、リサイズ動作、モーダル縦サイズ温存) は本ブランチでの実機確認が未実施。レビュー時にご確認ください。

## レビューポイント

1. **テンプレ A/B/C は「`outer` 引数の使い方」の整理であり、縦 constraints の統一ではない** — `view_plugin_detail` は 5 分割、`view_market_detail` は 6 分割、テンプレ B (`view_component_types` / `view_component_list`) は 3 分割を維持しており、テンプレ分類のためにタブ行が追加されていないことを確認してほしい。
2. **モーダルは横のみフル化**、縦サイズと上端揃えは現行温存（`Installing` の `Gauge` や選択肢が縦に伸びすぎないため）。`dialog_height` 計算式は書き換えていない。
3. **切り詰め予算の使い分け** — Paragraph 系 (`view_install_result`) で `LIST_DECORATION_WIDTH` を使っていないこと、List 系で `BLOCK_BORDER_WIDTH` のみで済ませていないことが要点。
4. **計画範囲外の指摘** — Codex レビューで `view_plugin_browse` / `view_target_select` / `view_scope_select` の List 系にも狭幅フォールバックを適用するよう提案された。implementation-plan.md §「適用対象」と DoD は明示的に 4 箇所のみを対象としているため本 PR では対応せず、必要なら別 spec で扱う方針。

## チェックリスト

- [x] セルフレビューを実施した
- [x] `cargo fmt` 適用済み (サブエージェント経由)
- [x] `cargo check` (`rust-workflow-plugin:type-check`) でエラーなし
- [x] `cargo test` (`rust-workflow-plugin:test`) で全件 GREEN (1426 passed)
- [x] コミットメッセージが絵文字 + タイプ形式で書かれている
- [x] 実装計画 (`.plugin-workspace/.specs/007-tui-full-width-layout/implementation-plan.md`) と差分に齟齬がない
- [x] 破壊的変更なし