### PR TITLE
✨ [New Feature]: TUI spacing と装飾統一 + 共通 layout/style API 新設

### DIFF
--- a/src/tui/manager/core.rs
+++ b/src/tui/manager/core.rs
@@ -26,8 +26,8 @@ pub use app::{update, view, Model, Tab};
 // 外部から再構成できる参照点として残す）。単独利用がないため `unused_imports` lint を
 // 抑制する。他の re-export 項目には影響しない。
 pub use common::{
-    content_rect, render_filter_bar, truncate_for_list, truncate_for_paragraph, truncate_to_width,
-    HORIZONTAL_PADDING, LIST_DECORATION_WIDTH, MIN_CONTENT_WIDTH,
+    render_filter_bar, truncate_for_list, truncate_for_paragraph, truncate_to_width,
+    LIST_DECORATION_WIDTH, MIN_CONTENT_WIDTH,
 };
 #[allow(unused_imports)]
 pub use common::{BLOCK_BORDER_WIDTH, LIST_HIGHLIGHT_WIDTH};

--- a/src/tui/manager/core.rs
+++ b/src/tui/manager/core.rs
@@ -10,6 +10,8 @@ mod app;
 mod common;
 mod data;
 pub mod filter;
+pub mod layout;
+pub mod style;
 
 #[cfg(test)]
 mod app_test;

--- a/src/tui/manager/core/layout.rs
+++ b/src/tui/manager/core/layout.rs
@@ -106,30 +106,29 @@ pub fn detail_layout(content: Rect, action_menu_rows: u16) -> [Rect; 3] {
 ///
 /// `width_pct`, `height_pct` は `0..=100`。100 超は `min(100)` に丸める。
 pub fn modal_layout(area: Rect, width_pct: u16, height_pct: u16) -> Rect {
-    let w = width_pct.min(100);
-    let h = height_pct.min(100);
-    // 上下/左右の余白は剰余分を末尾に寄せて合計 100 を保ち、中央寄せを決定的にする。
-    let top = (100 - h) / 2;
-    let bottom = 100 - h - top;
-    let left = (100 - w) / 2;
-    let right = 100 - w - left;
-    let v_chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Percentage(top),
-            Constraint::Percentage(h),
-            Constraint::Percentage(bottom),
-        ])
-        .split(area);
-    let h_chunks = Layout::default()
-        .direction(Direction::Horizontal)
-        .constraints([
-            Constraint::Percentage(left),
-            Constraint::Percentage(w),
-            Constraint::Percentage(right),
-        ])
-        .split(v_chunks[1]);
-    h_chunks[1]
+    let modal_w = scale_with_min_visible(area.width, width_pct);
+    let modal_h = scale_with_min_visible(area.height, height_pct);
+    let modal_w = modal_w.min(area.width);
+    let modal_h = modal_h.min(area.height);
+    let x = area.x + (area.width.saturating_sub(modal_w)) / 2;
+    let y = area.y + (area.height.saturating_sub(modal_h)) / 2;
+    Rect::new(x, y, modal_w, modal_h)
+}
+
+/// `axis_size * pct / 100` を計算し、`pct > 0` かつ `axis_size > 0` の
+/// ときは最低 1 セルを返す（極小ターミナルでもモーダルが消えないため）。
+/// `pct` は内部で `min(100)` に丸める。
+fn scale_with_min_visible(axis_size: u16, pct: u16) -> u16 {
+    let p = pct.min(100);
+    if p == 0 || axis_size == 0 {
+        return 0;
+    }
+    let scaled = (axis_size as u32 * p as u32) / 100;
+    if scaled == 0 {
+        1
+    } else {
+        scaled as u16
+    }
 }
 
 /// 水平 2 分割。Marketplaces browse の左右分割用。

--- a/src/tui/manager/core/layout.rs
+++ b/src/tui/manager/core/layout.rs
@@ -107,20 +107,25 @@ pub fn detail_layout(content: Rect, action_menu_rows: u16) -> [Rect; 3] {
 pub fn modal_layout(area: Rect, width_pct: u16, height_pct: u16) -> Rect {
     let w = width_pct.min(100);
     let h = height_pct.min(100);
+    // 上下/左右の余白は剰余分を末尾に寄せて合計 100 を保ち、中央寄せを決定的にする。
+    let top = (100 - h) / 2;
+    let bottom = 100 - h - top;
+    let left = (100 - w) / 2;
+    let right = 100 - w - left;
     let v_chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Percentage((100 - h) / 2),
+            Constraint::Percentage(top),
             Constraint::Percentage(h),
-            Constraint::Percentage((100 - h) / 2),
+            Constraint::Percentage(bottom),
         ])
         .split(area);
     let h_chunks = Layout::default()
         .direction(Direction::Horizontal)
         .constraints([
-            Constraint::Percentage((100 - w) / 2),
+            Constraint::Percentage(left),
             Constraint::Percentage(w),
-            Constraint::Percentage((100 - w) / 2),
+            Constraint::Percentage(right),
         ])
         .split(v_chunks[1]);
     h_chunks[1]

--- a/src/tui/manager/core/layout.rs
+++ b/src/tui/manager/core/layout.rs
@@ -1,0 +1,150 @@
+//! 共通レイアウト API
+//!
+//! TUI 各画面で共有するレイアウト計算ユーティリティ。
+//! 各 view からは `outer_rect` を起点として呼び、`frame_rect` は内部実装用。
+
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+
+/// 外周パディング水平方向（cells）
+pub const OUTER_PADDING_H: u16 = 1;
+
+/// 外周パディング垂直方向（cells）
+pub const OUTER_PADDING_V: u16 = 1;
+
+/// このターミナル高さ未満はパディング 0 にフォールバック
+pub const MIN_TERMINAL_HEIGHT: u16 = 8;
+
+/// このターミナル幅未満は左右パディング 0 にフォールバック
+pub const MIN_TERMINAL_WIDTH: u16 = 20;
+
+/// 指定矩形の上下左右にパディングを適用した内側 Rect を返す。
+///
+/// `area.width < 2*h_pad` または `area.height < 2*v_pad` の場合は
+/// 該当方向のみ縮退（パディング 0 に丸める）して overflow を回避する。
+pub fn frame_rect(area: Rect, h_pad: u16, v_pad: u16) -> Rect {
+    let (h_pad_eff, h_total_eff) = effective_padding(area.width, h_pad);
+    let (v_pad_eff, v_total_eff) = effective_padding(area.height, v_pad);
+
+    Rect::new(
+        area.x.saturating_add(h_pad_eff),
+        area.y.saturating_add(v_pad_eff),
+        area.width.saturating_sub(h_total_eff),
+        area.height.saturating_sub(v_total_eff),
+    )
+}
+
+/// `axis_size < 2*pad` のとき pad/total を 0 に縮退する。
+fn effective_padding(axis_size: u16, pad: u16) -> (u16, u16) {
+    let total = pad.saturating_mul(2);
+    if axis_size < total {
+        (0, 0)
+    } else {
+        (pad, total)
+    }
+}
+
+/// 外周マージンを適用した内側 Rect を返す（**各 view から呼ぶ正式 API**）。
+///
+/// 極小ターミナル時は自動でマージン 0 にフォールバックする。
+/// - `area.height < MIN_TERMINAL_HEIGHT` のとき上下マージンを 0
+/// - `area.width < MIN_TERMINAL_WIDTH` のとき左右マージンを 0
+pub fn outer_rect(area: Rect) -> Rect {
+    let v_pad = if area.height < MIN_TERMINAL_HEIGHT {
+        0
+    } else {
+        OUTER_PADDING_V
+    };
+    let h_pad = if area.width < MIN_TERMINAL_WIDTH {
+        0
+    } else {
+        OUTER_PADDING_H
+    };
+    frame_rect(area, h_pad, v_pad)
+}
+
+/// タブバー (1) / フィルタ (3) / コンテンツ (Min(1)) / ヘルプ (1) の
+/// トップレベル 4 区画に縦分割した Rect を返す。
+///
+/// **注**: トップレベル専用。詳細画面やモーダルでは使わない。
+pub fn framed_layout(outer: Rect) -> [Rect; 4] {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(1),
+            Constraint::Length(3),
+            Constraint::Min(1),
+            Constraint::Length(1),
+        ])
+        .split(outer);
+    [chunks[0], chunks[1], chunks[2], chunks[3]]
+}
+
+/// Installed plugin detail 用 3 区画レイアウト
+/// `(info_pane: Min(1), action_menu: Length(action_menu_rows), help: Length(1))`
+///
+/// `action_menu_rows` は **action menu の描画行数（論理 action 件数ではない）**。
+/// 2 行 ListItem 採用後は呼び出し側で `items.iter().map(ListItem::height).sum()`
+/// もしくは `actions.len() as u16 * 2` を渡すこと。
+pub fn detail_layout(content: Rect, action_menu_rows: u16) -> [Rect; 3] {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Min(1),
+            Constraint::Length(action_menu_rows),
+            Constraint::Length(1),
+        ])
+        .split(content);
+    [chunks[0], chunks[1], chunks[2]]
+}
+
+/// 中央寄せモーダルの **外枠 (centered area) のみ** を返す。
+///
+/// 内部分割（コンテンツ / help / gauge など）は本 API の責務外。
+/// 各モーダル側で `Layout::default().direction(Vertical).constraints([...]).split(outer)`
+/// として内部分割する。
+///
+/// `width_pct`, `height_pct` は `0..=100`。100 超は `min(100)` に丸める。
+pub fn modal_layout(area: Rect, width_pct: u16, height_pct: u16) -> Rect {
+    let w = width_pct.min(100);
+    let h = height_pct.min(100);
+    let v_chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Percentage((100 - h) / 2),
+            Constraint::Percentage(h),
+            Constraint::Percentage((100 - h) / 2),
+        ])
+        .split(area);
+    let h_chunks = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage((100 - w) / 2),
+            Constraint::Percentage(w),
+            Constraint::Percentage((100 - w) / 2),
+        ])
+        .split(v_chunks[1]);
+    h_chunks[1]
+}
+
+/// 水平 2 分割。Marketplaces browse の左右分割用。
+///
+/// `ratio == (0, 0)` でも panic せず、左 Rect が 0 幅・右 Rect が `area` 全体になる。
+pub fn split_horizontal(area: Rect, ratio: (u32, u32)) -> [Rect; 2] {
+    let total = ratio.0.saturating_add(ratio.1);
+    if total == 0 {
+        let left = Rect::new(area.x, area.y, 0, area.height);
+        return [left, area];
+    }
+    let chunks = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Ratio(ratio.0, total),
+            Constraint::Ratio(ratio.1, total),
+        ])
+        .split(area);
+    [chunks[0], chunks[1]]
+}
+
+#[cfg(test)]
+#[path = "layout_test.rs"]
+mod layout_test;

--- a/src/tui/manager/core/layout.rs
+++ b/src/tui/manager/core/layout.rs
@@ -83,8 +83,9 @@ pub fn framed_layout(outer: Rect) -> [Rect; 4] {
 /// `(info_pane: Min(1), action_menu: Length(action_menu_rows), help: Length(1))`
 ///
 /// `action_menu_rows` は **action menu の描画行数（論理 action 件数ではない）**。
-/// 2 行 ListItem 採用後は呼び出し側で `items.iter().map(ListItem::height).sum()`
-/// もしくは `actions.len() as u16 * 2` を渡すこと。
+/// 呼び出し側では固定係数で見積もらず、
+/// `items.iter().map(ListItem::height).sum()` のように
+/// 実際に描画する item の高さ合計を渡すこと。
 pub fn detail_layout(content: Rect, action_menu_rows: u16) -> [Rect; 3] {
     let chunks = Layout::default()
         .direction(Direction::Vertical)

--- a/src/tui/manager/core/layout.rs
+++ b/src/tui/manager/core/layout.rs
@@ -1,7 +1,8 @@
 //! 共通レイアウト API
 //!
 //! TUI 各画面で共有するレイアウト計算ユーティリティ。
-//! 各 view からは `outer_rect` を起点として呼び、`frame_rect` は内部実装用。
+//! 各 view では通常 `outer_rect` を起点として呼ぶ。
+//! `frame_rect` は明示的にパディング量を指定したい場合に使う低レベル API。
 
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 
@@ -109,8 +110,12 @@ pub fn modal_layout(area: Rect, width_pct: u16, height_pct: u16) -> Rect {
     let modal_h = scale_with_min_visible(area.height, height_pct);
     let modal_w = modal_w.min(area.width);
     let modal_h = modal_h.min(area.height);
-    let x = area.x + (area.width.saturating_sub(modal_w)) / 2;
-    let y = area.y + (area.height.saturating_sub(modal_h)) / 2;
+    let x = area
+        .x
+        .saturating_add((area.width.saturating_sub(modal_w)) / 2);
+    let y = area
+        .y
+        .saturating_add((area.height.saturating_sub(modal_h)) / 2);
     Rect::new(x, y, modal_w, modal_h)
 }
 

--- a/src/tui/manager/core/layout.rs
+++ b/src/tui/manager/core/layout.rs
@@ -79,23 +79,22 @@ pub fn framed_layout(outer: Rect) -> [Rect; 4] {
     [chunks[0], chunks[1], chunks[2], chunks[3]]
 }
 
-/// Installed plugin detail 用 3 区画レイアウト
-/// `(info_pane: Min(1), action_menu: Length(action_menu_rows), help: Length(1))`
+/// Installed plugin detail 用 2 区画レイアウト
+/// `(info_pane: Min(1), action_menu: Length(action_menu_rows))`
+///
+/// help 行は呼び出し元で既に `framed_layout` の help_area に確保しているため、
+/// ここでは含めない。
 ///
 /// `action_menu_rows` は **action menu の描画行数（論理 action 件数ではない）**。
 /// 呼び出し側では固定係数で見積もらず、
 /// `items.iter().map(ListItem::height).sum()` のように
 /// 実際に描画する item の高さ合計を渡すこと。
-pub fn detail_layout(content: Rect, action_menu_rows: u16) -> [Rect; 3] {
+pub fn detail_layout(content: Rect, action_menu_rows: u16) -> [Rect; 2] {
     let chunks = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Min(1),
-            Constraint::Length(action_menu_rows),
-            Constraint::Length(1),
-        ])
+        .constraints([Constraint::Min(1), Constraint::Length(action_menu_rows)])
         .split(content);
-    [chunks[0], chunks[1], chunks[2]]
+    [chunks[0], chunks[1]]
 }
 
 /// 中央寄せモーダルの **外枠 (centered area) のみ** を返す。

--- a/src/tui/manager/core/layout_test.rs
+++ b/src/tui/manager/core/layout_test.rs
@@ -1,0 +1,154 @@
+use super::*;
+use ratatui::layout::Rect;
+
+#[test]
+fn frame_rect_applies_padding_for_normal_size() {
+    let area = Rect::new(0, 0, 80, 24);
+    let inner = frame_rect(area, 1, 1);
+    assert_eq!(inner, Rect::new(1, 1, 78, 22));
+}
+
+#[test]
+fn frame_rect_collapses_when_width_smaller_than_padding() {
+    let area = Rect::new(0, 0, 1, 24);
+    let inner = frame_rect(area, 1, 1);
+    assert_eq!(inner, Rect::new(0, 1, 1, 22));
+}
+
+#[test]
+fn frame_rect_collapses_when_height_smaller_than_padding() {
+    let area = Rect::new(0, 0, 80, 1);
+    let inner = frame_rect(area, 1, 1);
+    assert_eq!(inner, Rect::new(1, 0, 78, 1));
+}
+
+#[test]
+fn frame_rect_collapses_completely_for_tiny_input() {
+    let area = Rect::new(0, 0, 1, 1);
+    let inner = frame_rect(area, 1, 1);
+    assert_eq!(inner, Rect::new(0, 0, 1, 1));
+}
+
+#[test]
+fn frame_rect_handles_zero_input_without_panic() {
+    let area = Rect::new(0, 0, 0, 0);
+    let inner = frame_rect(area, 1, 1);
+    assert_eq!(inner, Rect::new(0, 0, 0, 0));
+}
+
+#[test]
+fn outer_rect_applies_default_margin() {
+    let area = Rect::new(0, 0, 80, 24);
+    let inner = outer_rect(area);
+    assert_eq!(inner, Rect::new(1, 1, 78, 22));
+}
+
+#[test]
+fn outer_rect_collapses_when_height_below_min() {
+    let area = Rect::new(0, 0, 80, 4);
+    let inner = outer_rect(area);
+    assert_eq!(inner.y, 0);
+    assert_eq!(inner.height, 4);
+}
+
+#[test]
+fn outer_rect_collapses_when_width_below_min() {
+    let area = Rect::new(0, 0, 10, 24);
+    let inner = outer_rect(area);
+    assert_eq!(inner.x, 0);
+    assert_eq!(inner.width, 10);
+}
+
+#[test]
+fn outer_rect_uses_zero_padding_for_small_height() {
+    let area = Rect::new(0, 0, 80, 6);
+    let inner = outer_rect(area);
+    assert_eq!(inner.y, 0);
+    assert_eq!(inner.height, 6);
+}
+
+#[test]
+fn framed_layout_distributes_constraints_for_24_rows() {
+    let outer = Rect::new(0, 0, 80, 24);
+    let chunks = framed_layout(outer);
+    let total: u16 = chunks.iter().map(|r| r.height).sum();
+    assert_eq!(total, 24);
+    assert_eq!(chunks[0].height, 1);
+    assert_eq!(chunks[1].height, 3);
+    assert!(chunks[2].height >= 1);
+    assert_eq!(chunks[3].height, 1);
+}
+
+#[test]
+fn framed_layout_min_terminal_height() {
+    let outer = Rect::new(0, 0, 80, 6);
+    let chunks = framed_layout(outer);
+    assert!(chunks[2].height >= 1);
+}
+
+#[test]
+fn detail_layout_returns_3_chunks_with_specified_action_menu_height() {
+    let content = Rect::new(0, 0, 80, 20);
+    let chunks = detail_layout(content, 4);
+    assert_eq!(chunks[1].height, 4);
+    assert_eq!(chunks[2].height, 1);
+    assert!(chunks[0].height >= 1);
+}
+
+#[test]
+fn detail_layout_action_menu_rows_respected_for_2line_items() {
+    let content = Rect::new(0, 0, 80, 20);
+    let chunks = detail_layout(content, 10);
+    assert_eq!(chunks[0].height, 9);
+    assert_eq!(chunks[1].height, 10);
+    assert_eq!(chunks[2].height, 1);
+}
+
+#[test]
+fn detail_layout_action_menu_rows_zero_returns_empty_menu() {
+    let content = Rect::new(0, 0, 80, 20);
+    let chunks = detail_layout(content, 0);
+    assert_eq!(chunks[1].height, 0);
+    assert_eq!(chunks[2].height, 1);
+    assert!(chunks[0].height >= 1);
+}
+
+#[test]
+fn modal_layout_centers_within_area() {
+    let area = Rect::new(0, 0, 100, 50);
+    let inner = modal_layout(area, 50, 50);
+    // 中央寄せ。height=25 (50%), width=50 (50%)
+    assert_eq!(inner.width, 50);
+    assert_eq!(inner.height, 25);
+}
+
+#[test]
+fn modal_layout_with_pct_over_100_clamps_to_100() {
+    let area = Rect::new(0, 0, 100, 50);
+    let inner = modal_layout(area, 150, 200);
+    assert_eq!(inner.width, area.width);
+    assert_eq!(inner.height, area.height);
+}
+
+#[test]
+fn modal_layout_with_zero_pct_returns_zero_size() {
+    let area = Rect::new(0, 0, 100, 50);
+    let inner = modal_layout(area, 0, 0);
+    assert!(inner.width == 0 || inner.height == 0);
+}
+
+#[test]
+fn split_horizontal_respects_ratio() {
+    let area = Rect::new(0, 0, 100, 10);
+    let chunks = split_horizontal(area, (30, 70));
+    assert_eq!(chunks[0].width, 30);
+    assert_eq!(chunks[1].width, 70);
+}
+
+#[test]
+fn split_horizontal_with_zero_ratio_does_not_panic() {
+    let area = Rect::new(0, 0, 100, 10);
+    let chunks = split_horizontal(area, (0, 0));
+    assert_eq!(chunks[0].width, 0);
+    assert_eq!(chunks[1].width, 100);
+}

--- a/src/tui/manager/core/layout_test.rs
+++ b/src/tui/manager/core/layout_test.rs
@@ -87,21 +87,19 @@ fn framed_layout_min_terminal_height() {
 }
 
 #[test]
-fn detail_layout_returns_3_chunks_with_specified_action_menu_height() {
+fn detail_layout_returns_2_chunks_with_specified_action_menu_height() {
     let content = Rect::new(0, 0, 80, 20);
     let chunks = detail_layout(content, 4);
     assert_eq!(chunks[1].height, 4);
-    assert_eq!(chunks[2].height, 1);
-    assert!(chunks[0].height >= 1);
+    assert_eq!(chunks[0].height, 16);
 }
 
 #[test]
 fn detail_layout_respects_action_menu_rows() {
     let content = Rect::new(0, 0, 80, 20);
     let chunks = detail_layout(content, 10);
-    assert_eq!(chunks[0].height, 9);
+    assert_eq!(chunks[0].height, 10);
     assert_eq!(chunks[1].height, 10);
-    assert_eq!(chunks[2].height, 1);
 }
 
 #[test]
@@ -109,8 +107,7 @@ fn detail_layout_action_menu_rows_zero_returns_empty_menu() {
     let content = Rect::new(0, 0, 80, 20);
     let chunks = detail_layout(content, 0);
     assert_eq!(chunks[1].height, 0);
-    assert_eq!(chunks[2].height, 1);
-    assert!(chunks[0].height >= 1);
+    assert_eq!(chunks[0].height, 20);
 }
 
 #[test]

--- a/src/tui/manager/core/layout_test.rs
+++ b/src/tui/manager/core/layout_test.rs
@@ -96,7 +96,7 @@ fn detail_layout_returns_3_chunks_with_specified_action_menu_height() {
 }
 
 #[test]
-fn detail_layout_action_menu_rows_respected_for_2line_items() {
+fn detail_layout_respects_action_menu_rows() {
     let content = Rect::new(0, 0, 80, 20);
     let chunks = detail_layout(content, 10);
     assert_eq!(chunks[0].height, 9);

--- a/src/tui/manager/core/layout_test.rs
+++ b/src/tui/manager/core/layout_test.rs
@@ -138,6 +138,30 @@ fn modal_layout_with_zero_pct_returns_zero_size() {
 }
 
 #[test]
+fn modal_layout_with_tiny_area_keeps_modal_visible() {
+    // pct>0 かつ area>0 のとき、丸め誤差で 0 にならず最低 1 セル確保される。
+    let area = Rect::new(0, 0, 1, 1);
+    let inner = modal_layout(area, 50, 50);
+    assert!(inner.width >= 1, "width should stay visible: {:?}", inner);
+    assert!(inner.height >= 1, "height should stay visible: {:?}", inner);
+}
+
+#[test]
+fn modal_layout_with_one_row_keeps_modal_visible() {
+    let area = Rect::new(0, 0, 80, 1);
+    let inner = modal_layout(area, 60, 40);
+    assert!(inner.height >= 1, "height should stay visible: {:?}", inner);
+}
+
+#[test]
+fn modal_layout_with_zero_area_returns_zero_without_panic() {
+    let area = Rect::new(0, 0, 0, 0);
+    let inner = modal_layout(area, 50, 50);
+    assert_eq!(inner.width, 0);
+    assert_eq!(inner.height, 0);
+}
+
+#[test]
 fn split_horizontal_respects_ratio() {
     let area = Rect::new(0, 0, 100, 10);
     let chunks = split_horizontal(area, (30, 70));

--- a/src/tui/manager/core/style.rs
+++ b/src/tui/manager/core/style.rs
@@ -3,7 +3,7 @@
 //! TUI 各画面で共有するスタイル（タイトル装飾、選択行強調、リストアイコン）。
 
 use ratatui::style::{Color, Modifier, Style};
-use ratatui::text::Span;
+use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, List, ListItem};
 
 /// リスト項目の左インデント（highlight_symbol "> " と整合させるため固定）
@@ -56,23 +56,26 @@ pub fn highlight_style() -> Style {
         .bg(Color::Green)
 }
 
-/// 選択行のときに各 Span を `highlight_style()` で patch して返す。
+/// 選択行用の `Line` を組み立てる。
 ///
-/// 既存の Span スタイル（fg 色など）の上に highlight_style を上書きすることで、
-/// 緑色の文字が緑背景で見えなくなるなどの問題を防ぐ。`is_selected = false` の
-/// ときは入力をそのまま返す。
-pub fn highlight_spans<'a>(spans: Vec<Span<'a>>, is_selected: bool) -> Vec<Span<'a>> {
+/// `is_selected = true` のとき、行全体の `Line::style` に `highlight_style()` を
+/// 適用して、テキスト後ろの余白セルまで含めて水平方向に緑背景で塗る。さらに
+/// 既存の Span スタイル（fg 色など）の上にも `highlight_style()` を patch して、
+/// 緑色の文字が緑背景に埋もれるのを防ぐ。`is_selected = false` のときは入力の
+/// Span 列をそのまま `Line::from` で返す。
+pub fn highlight_line<'a>(spans: Vec<Span<'a>>, is_selected: bool) -> Line<'a> {
     if !is_selected {
-        return spans;
+        return Line::from(spans);
     }
     let hl = highlight_style();
-    spans
+    let styled: Vec<Span<'a>> = spans
         .into_iter()
         .map(|s| {
             let style = s.style.patch(hl);
             Span::styled(s.content, style)
         })
-        .collect()
+        .collect();
+    Line::from(styled).style(hl)
 }
 
 /// `bordered_block(title)` + `HIGHLIGHT_SYMBOL` を組み合わせた List ファクトリ。

--- a/src/tui/manager/core/style.rs
+++ b/src/tui/manager/core/style.rs
@@ -33,10 +33,12 @@ pub const RADIO_UNSELECTED: &str = "( )";
 pub const RADIO_LEN: usize = 3;
 
 /// BOLD タイトル付きのボーダーブロックを返す。
-pub fn bordered_block(title: &str) -> Block<'_> {
+///
+/// `title` はそのまま `Block` に借用させ、レンダリングごとの `String` 確保を避ける。
+pub fn bordered_block<'a>(title: &'a str) -> Block<'a> {
     Block::default()
         .title(Span::styled(
-            title.to_string(),
+            title,
             Style::default().add_modifier(Modifier::BOLD),
         ))
         .borders(Borders::ALL)

--- a/src/tui/manager/core/style.rs
+++ b/src/tui/manager/core/style.rs
@@ -44,7 +44,11 @@ pub fn bordered_block<'a>(title: &'a str) -> Block<'a> {
         .borders(Borders::ALL)
 }
 
-/// 選択行用 Style を返す（fg=Black + bg=Green + BOLD）。
+/// 選択行の **内容セル** にだけ適用する Style（fg=Black + bg=Green + BOLD）。
+///
+/// 直接 `List::highlight_style` には設定しない。`List::highlight_style` は ListItem
+/// 全体に塗布されるため、空行も緑背景になってしまう。代わりに各画面の builder が
+/// 内容行の Span にだけ `highlight_spans` 経由でこのスタイルを適用する。
 pub fn highlight_style() -> Style {
     Style::default()
         .add_modifier(Modifier::BOLD)
@@ -52,22 +56,43 @@ pub fn highlight_style() -> Style {
         .bg(Color::Green)
 }
 
-/// `bordered_block(title)` + `highlight_style()` + `HIGHLIGHT_SYMBOL`
-/// を組み合わせた List ファクトリ。
-/// `repeat_highlight_symbol(false)` を明示。
+/// 選択行のときに各 Span を `highlight_style()` で patch して返す。
+///
+/// 既存の Span スタイル（fg 色など）の上に highlight_style を上書きすることで、
+/// 緑色の文字が緑背景で見えなくなるなどの問題を防ぐ。`is_selected = false` の
+/// ときは入力をそのまま返す。
+pub fn highlight_spans<'a>(spans: Vec<Span<'a>>, is_selected: bool) -> Vec<Span<'a>> {
+    if !is_selected {
+        return spans;
+    }
+    let hl = highlight_style();
+    spans
+        .into_iter()
+        .map(|s| {
+            let style = s.style.patch(hl);
+            Span::styled(s.content, style)
+        })
+        .collect()
+}
+
+/// `bordered_block(title)` + `HIGHLIGHT_SYMBOL` を組み合わせた List ファクトリ。
+///
+/// `repeat_highlight_symbol(false)` を明示。`highlight_style` は **設定しない**：
+/// 緑背景は内容行の Span 側で `highlight_spans` 経由で適用するため、
+/// ListItem 全体（空行を含む）には塗布しない。
 pub fn selectable_list<'a>(items: Vec<ListItem<'a>>, title: &'a str) -> List<'a> {
     List::new(items)
         .block(bordered_block(title))
-        .highlight_style(highlight_style())
         .highlight_symbol(HIGHLIGHT_SYMBOL)
         .repeat_highlight_symbol(false)
 }
 
 /// Block なしの action menu 用 List ファクトリ。
-/// `repeat_highlight_symbol(false)` を明示。
+///
+/// `repeat_highlight_symbol(false)` を明示。`highlight_style` は **設定しない**：
+/// 緑背景は内容行の Span 側で `highlight_spans` 経由で適用する。
 pub fn menu_list<'a>(items: Vec<ListItem<'a>>) -> List<'a> {
     List::new(items)
-        .highlight_style(highlight_style())
         .highlight_symbol(HIGHLIGHT_SYMBOL)
         .repeat_highlight_symbol(false)
 }

--- a/src/tui/manager/core/style.rs
+++ b/src/tui/manager/core/style.rs
@@ -1,0 +1,75 @@
+//! 共通スタイル API
+//!
+//! TUI 各画面で共有するスタイル（タイトル装飾、選択行強調、リストアイコン）。
+
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::Span;
+use ratatui::widgets::{Block, Borders, List, ListItem};
+
+/// リスト項目の左インデント（highlight_symbol "> " と整合させるため固定）
+pub const LIST_ITEM_INDENT: &str = "  ";
+
+/// 選択行プレフィックス
+pub const HIGHLIGHT_SYMBOL: &str = "> ";
+
+/// 単一文字状態アイコン
+pub const ICON_ENABLED: &str = "●";
+pub const ICON_DISABLED: &str = "○";
+pub const ICON_CHECK: &str = "✓";
+
+/// Installed plugin list の mark ブロック
+pub const MARK_MARKED: &str = "[✓]";
+pub const MARK_UNMARKED: &str = "[ ]";
+pub const MARK_LEN: usize = 3;
+
+/// Marketplaces target チェックボックス
+pub const CHECKBOX_SELECTED: &str = "[x]";
+pub const CHECKBOX_UNSELECTED: &str = "[ ]";
+pub const CHECKBOX_LEN: usize = 3;
+
+/// Marketplaces scope ラジオ
+pub const RADIO_SELECTED: &str = "(●)";
+pub const RADIO_UNSELECTED: &str = "( )";
+pub const RADIO_LEN: usize = 3;
+
+/// BOLD タイトル付きのボーダーブロックを返す。
+pub fn bordered_block(title: &str) -> Block<'_> {
+    Block::default()
+        .title(Span::styled(
+            title.to_string(),
+            Style::default().add_modifier(Modifier::BOLD),
+        ))
+        .borders(Borders::ALL)
+}
+
+/// 選択行用 Style を返す（fg=Black + bg=Green + BOLD）。
+pub fn highlight_style() -> Style {
+    Style::default()
+        .add_modifier(Modifier::BOLD)
+        .fg(Color::Black)
+        .bg(Color::Green)
+}
+
+/// `bordered_block(title)` + `highlight_style()` + `HIGHLIGHT_SYMBOL`
+/// を組み合わせた List ファクトリ。
+/// `repeat_highlight_symbol(false)` を明示。
+pub fn selectable_list<'a>(items: Vec<ListItem<'a>>, title: &'a str) -> List<'a> {
+    List::new(items)
+        .block(bordered_block(title))
+        .highlight_style(highlight_style())
+        .highlight_symbol(HIGHLIGHT_SYMBOL)
+        .repeat_highlight_symbol(false)
+}
+
+/// Block なしの action menu 用 List ファクトリ。
+/// `repeat_highlight_symbol(false)` を明示。
+pub fn menu_list<'a>(items: Vec<ListItem<'a>>) -> List<'a> {
+    List::new(items)
+        .highlight_style(highlight_style())
+        .highlight_symbol(HIGHLIGHT_SYMBOL)
+        .repeat_highlight_symbol(false)
+}
+
+#[cfg(test)]
+#[path = "style_test.rs"]
+mod style_test;

--- a/src/tui/manager/core/style.rs
+++ b/src/tui/manager/core/style.rs
@@ -48,7 +48,7 @@ pub fn bordered_block<'a>(title: &'a str) -> Block<'a> {
 ///
 /// 直接 `List::highlight_style` には設定しない。`List::highlight_style` は ListItem
 /// 全体に塗布されるため、空行も緑背景になってしまう。代わりに各画面の builder が
-/// 内容行の Span にだけ `highlight_spans` 経由でこのスタイルを適用する。
+/// 内容行の Span にだけ `highlight_line` 経由でこのスタイルを適用する。
 pub fn highlight_style() -> Style {
     Style::default()
         .add_modifier(Modifier::BOLD)
@@ -81,7 +81,7 @@ pub fn highlight_line<'a>(spans: Vec<Span<'a>>, is_selected: bool) -> Line<'a> {
 /// `bordered_block(title)` + `HIGHLIGHT_SYMBOL` を組み合わせた List ファクトリ。
 ///
 /// `repeat_highlight_symbol(false)` を明示。`highlight_style` は **設定しない**：
-/// 緑背景は内容行の Span 側で `highlight_spans` 経由で適用するため、
+/// 緑背景は内容行の Span 側で `highlight_line` 経由で適用するため、
 /// ListItem 全体（空行を含む）には塗布しない。
 pub fn selectable_list<'a>(items: Vec<ListItem<'a>>, title: &'a str) -> List<'a> {
     List::new(items)
@@ -93,7 +93,7 @@ pub fn selectable_list<'a>(items: Vec<ListItem<'a>>, title: &'a str) -> List<'a>
 /// Block なしの action menu 用 List ファクトリ。
 ///
 /// `repeat_highlight_symbol(false)` を明示。`highlight_style` は **設定しない**：
-/// 緑背景は内容行の Span 側で `highlight_spans` 経由で適用する。
+/// 緑背景は内容行の Span 側で `highlight_line` 経由で適用する。
 pub fn menu_list<'a>(items: Vec<ListItem<'a>>) -> List<'a> {
     List::new(items)
         .highlight_symbol(HIGHLIGHT_SYMBOL)

--- a/src/tui/manager/core/style_test.rs
+++ b/src/tui/manager/core/style_test.rs
@@ -1,5 +1,6 @@
 use super::*;
-use ratatui::style::{Color, Modifier};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::Span;
 use ratatui::widgets::ListItem;
 
 #[test]
@@ -68,4 +69,41 @@ fn selectable_list_smoke() {
 fn menu_list_smoke() {
     let items = vec![ListItem::new("a"), ListItem::new("b")];
     let _list = menu_list(items);
+}
+
+#[test]
+fn highlight_line_unselected_preserves_span_styles() {
+    let yellow = Style::default().fg(Color::Yellow);
+    let spans = vec![Span::styled("alpha", yellow), Span::raw(" beta")];
+    let line = highlight_line(spans.clone(), false);
+    assert_eq!(line.style, Style::default());
+    assert_eq!(line.spans, spans);
+}
+
+#[test]
+fn highlight_line_selected_paints_line_and_overrides_span_fg() {
+    let green_fg = Style::default().fg(Color::Green);
+    let yellow_fg = Style::default().fg(Color::Yellow);
+    let spans = vec![
+        Span::styled("Update now", green_fg),
+        Span::styled(" tail", yellow_fg),
+    ];
+    let line = highlight_line(spans, true);
+    let hl = highlight_style();
+    // Line.style 全体に highlight_style() が乗る → 余白セルも緑背景
+    assert_eq!(line.style, hl);
+    // 各 Span は元 fg を上書きされ、bg=Green / fg=Black / BOLD になる
+    for span in line.spans.iter() {
+        assert_eq!(span.style.fg, Some(Color::Black));
+        assert_eq!(span.style.bg, Some(Color::Green));
+        assert!(span.style.add_modifier.contains(Modifier::BOLD));
+    }
+}
+
+#[test]
+fn highlight_line_selected_with_empty_spans_returns_styled_line() {
+    let spans: Vec<Span<'static>> = Vec::new();
+    let line = highlight_line(spans, true);
+    assert_eq!(line.style, highlight_style());
+    assert!(line.spans.is_empty());
 }

--- a/src/tui/manager/core/style_test.rs
+++ b/src/tui/manager/core/style_test.rs
@@ -21,7 +21,7 @@ fn icon_constants_values() {
 }
 
 #[test]
-fn icon_constants_are_single_grapheme() {
+fn icon_constants_are_single_char() {
     assert_eq!(ICON_ENABLED.chars().count(), 1);
     assert_eq!(ICON_DISABLED.chars().count(), 1);
     assert_eq!(ICON_CHECK.chars().count(), 1);

--- a/src/tui/manager/core/style_test.rs
+++ b/src/tui/manager/core/style_test.rs
@@ -1,0 +1,71 @@
+use super::*;
+use ratatui::style::{Color, Modifier};
+use ratatui::widgets::ListItem;
+
+#[test]
+fn list_item_indent_is_two_spaces() {
+    assert_eq!(LIST_ITEM_INDENT, "  ");
+    assert_eq!(LIST_ITEM_INDENT.chars().count(), 2);
+}
+
+#[test]
+fn highlight_symbol_is_arrow_space() {
+    assert_eq!(HIGHLIGHT_SYMBOL, "> ");
+}
+
+#[test]
+fn icon_constants_values() {
+    assert_eq!(ICON_ENABLED, "●");
+    assert_eq!(ICON_DISABLED, "○");
+    assert_eq!(ICON_CHECK, "✓");
+}
+
+#[test]
+fn icon_constants_are_single_grapheme() {
+    assert_eq!(ICON_ENABLED.chars().count(), 1);
+    assert_eq!(ICON_DISABLED.chars().count(), 1);
+    assert_eq!(ICON_CHECK.chars().count(), 1);
+}
+
+#[test]
+fn mark_constants_have_fixed_len() {
+    assert_eq!(MARK_MARKED.chars().count(), MARK_LEN);
+    assert_eq!(MARK_UNMARKED.chars().count(), MARK_LEN);
+}
+
+#[test]
+fn checkbox_constants_have_fixed_len() {
+    assert_eq!(CHECKBOX_SELECTED.chars().count(), CHECKBOX_LEN);
+    assert_eq!(CHECKBOX_UNSELECTED.chars().count(), CHECKBOX_LEN);
+}
+
+#[test]
+fn radio_constants_have_fixed_len() {
+    assert_eq!(RADIO_SELECTED.chars().count(), RADIO_LEN);
+    assert_eq!(RADIO_UNSELECTED.chars().count(), RADIO_LEN);
+}
+
+#[test]
+fn highlight_style_has_bold_black_fg_and_green_bg() {
+    let s = highlight_style();
+    assert_eq!(s.fg, Some(Color::Black));
+    assert_eq!(s.bg, Some(Color::Green));
+    assert!(s.add_modifier.contains(Modifier::BOLD));
+}
+
+#[test]
+fn bordered_block_smoke() {
+    let _block = bordered_block(" Title ");
+}
+
+#[test]
+fn selectable_list_smoke() {
+    let items = vec![ListItem::new("a"), ListItem::new("b")];
+    let _list = selectable_list(items, " Title ");
+}
+
+#[test]
+fn menu_list_smoke() {
+    let items = vec![ListItem::new("a"), ListItem::new("b")];
+    let _list = menu_list(items);
+}

--- a/src/tui/manager/screens/discover.rs
+++ b/src/tui/manager/screens/discover.rs
@@ -2,12 +2,12 @@
 //!
 //! 利用可能なプラグインの検索と閲覧。
 
-use crate::tui::manager::core::{
-    content_rect, render_filter_bar, DataStore, PluginId, Tab, HORIZONTAL_PADDING,
-};
+use crate::tui::manager::core::layout::{framed_layout, outer_rect};
+use crate::tui::manager::core::style::bordered_block;
+use crate::tui::manager::core::{render_filter_bar, DataStore, PluginId, Tab};
 use crossterm::event::KeyCode;
 use ratatui::prelude::*;
-use ratatui::widgets::{Block, Borders, Clear, ListState, Paragraph, Tabs};
+use ratatui::widgets::{Clear, ListState, Paragraph, Tabs};
 
 /// キャッシュ状態（タブ切替時に保持）
 #[derive(Debug, Default)]
@@ -96,18 +96,10 @@ pub fn view(
     filter_text: &str,
     filter_focused: bool,
 ) {
-    let outer = content_rect(f.area(), HORIZONTAL_PADDING);
+    let outer = outer_rect(f.area());
     f.render_widget(Clear, outer);
 
-    let chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Length(1), // タブバー
-            Constraint::Length(3), // フィルタバー
-            Constraint::Min(1),    // コンテンツ
-            Constraint::Length(1), // ヘルプ
-        ])
-        .split(outer);
+    let [tabs_area, filter_area, content_area, help_area] = framed_layout(outer);
 
     let tab_titles: Vec<&str> = Tab::all().iter().map(|t| t.title()).collect();
     let tabs = Tabs::new(tab_titles)
@@ -119,16 +111,16 @@ pub fn view(
                 .add_modifier(Modifier::BOLD),
         )
         .divider(" | ");
-    f.render_widget(tabs, chunks[0]);
+    f.render_widget(tabs, tabs_area);
 
     // フィルタバー（Discover タブではフィルタ機能は未対応、UI のみ表示）
-    render_filter_bar(f, chunks[1], filter_text, filter_focused);
+    render_filter_bar(f, filter_area, filter_text, filter_focused);
 
     let content = Paragraph::new("\n  Browse available plugins")
-        .block(Block::default().title(" Discover ").borders(Borders::ALL))
+        .block(bordered_block(" Discover "))
         .style(Style::default().fg(Color::DarkGray));
-    f.render_widget(content, chunks[2]);
+    f.render_widget(content, content_area);
 
     let help = Paragraph::new(" Tab: switch | q: quit").style(Style::default().fg(Color::DarkGray));
-    f.render_widget(help, chunks[3]);
+    f.render_widget(help, help_area);
 }

--- a/src/tui/manager/screens/discover.rs
+++ b/src/tui/manager/screens/discover.rs
@@ -97,7 +97,7 @@ pub fn view(
     filter_focused: bool,
 ) {
     let outer = outer_rect(f.area());
-    f.render_widget(Clear, outer);
+    f.render_widget(Clear, f.area());
 
     let [tabs_area, filter_area, content_area, help_area] = framed_layout(outer);
 

--- a/src/tui/manager/screens/errors.rs
+++ b/src/tui/manager/screens/errors.rs
@@ -67,7 +67,7 @@ pub fn view(
     filter_focused: bool,
 ) {
     let outer = outer_rect(f.area());
-    f.render_widget(Clear, outer);
+    f.render_widget(Clear, f.area());
 
     let [tabs_area, filter_area, content_area, help_area] = framed_layout(outer);
 

--- a/src/tui/manager/screens/errors.rs
+++ b/src/tui/manager/screens/errors.rs
@@ -2,12 +2,12 @@
 //!
 //! エラー表示と再試行。
 
-use crate::tui::manager::core::{
-    content_rect, render_filter_bar, DataStore, Tab, HORIZONTAL_PADDING,
-};
+use crate::tui::manager::core::layout::{framed_layout, outer_rect};
+use crate::tui::manager::core::style::bordered_block;
+use crate::tui::manager::core::{render_filter_bar, DataStore, Tab};
 use crossterm::event::KeyCode;
 use ratatui::prelude::*;
-use ratatui::widgets::{Block, Borders, Clear, Paragraph, Tabs};
+use ratatui::widgets::{Clear, Paragraph, Tabs};
 
 /// Errors タブの画面状態
 pub struct Model {
@@ -66,18 +66,10 @@ pub fn view(
     filter_text: &str,
     filter_focused: bool,
 ) {
-    let outer = content_rect(f.area(), HORIZONTAL_PADDING);
+    let outer = outer_rect(f.area());
     f.render_widget(Clear, outer);
 
-    let chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Length(1), // タブバー
-            Constraint::Length(3), // フィルタバー
-            Constraint::Min(1),    // コンテンツ
-            Constraint::Length(1), // ヘルプ
-        ])
-        .split(outer);
+    let [tabs_area, filter_area, content_area, help_area] = framed_layout(outer);
 
     let tab_titles: Vec<&str> = Tab::all().iter().map(|t| t.title()).collect();
     let tabs = Tabs::new(tab_titles)
@@ -89,10 +81,10 @@ pub fn view(
                 .add_modifier(Modifier::BOLD),
         )
         .divider(" | ");
-    f.render_widget(tabs, chunks[0]);
+    f.render_widget(tabs, tabs_area);
 
     // フィルタバー（Errors タブではフィルタ機能は未対応、UI のみ表示）
-    render_filter_bar(f, chunks[1], filter_text, filter_focused);
+    render_filter_bar(f, filter_area, filter_text, filter_focused);
 
     let message = if let Some(error) = &data.last_error {
         format!("\n  {}", error)
@@ -101,10 +93,10 @@ pub fn view(
     };
 
     let content = Paragraph::new(message)
-        .block(Block::default().title(" Errors ").borders(Borders::ALL))
+        .block(bordered_block(" Errors "))
         .style(Style::default().fg(Color::DarkGray));
-    f.render_widget(content, chunks[2]);
+    f.render_widget(content, content_area);
 
     let help = Paragraph::new(" Tab: switch | q: quit").style(Style::default().fg(Color::DarkGray));
-    f.render_widget(help, chunks[3]);
+    f.render_widget(help, help_area);
 }

--- a/src/tui/manager/screens/installed/view.rs
+++ b/src/tui/manager/screens/installed/view.rs
@@ -5,12 +5,17 @@
 use super::model::{DetailAction, Model, UpdateStatusDisplay};
 use crate::application::InstalledPlugin;
 use crate::component::ComponentKind;
+use crate::tui::manager::core::layout::{detail_layout, framed_layout, outer_rect};
+use crate::tui::manager::core::style::{
+    bordered_block, menu_list, selectable_list, ICON_DISABLED, ICON_ENABLED, LIST_ITEM_INDENT,
+    MARK_MARKED, MARK_UNMARKED,
+};
 use crate::tui::manager::core::{
-    content_rect, filter_plugins, render_filter_bar, truncate_to_width, DataStore, PluginId, Tab,
-    HORIZONTAL_PADDING, LIST_DECORATION_WIDTH, MIN_CONTENT_WIDTH,
+    filter_plugins, render_filter_bar, truncate_to_width, DataStore, PluginId, Tab,
+    LIST_DECORATION_WIDTH, MIN_CONTENT_WIDTH,
 };
 use ratatui::prelude::*;
-use ratatui::widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph, Tabs};
+use ratatui::widgets::{Clear, ListItem, ListState, Paragraph, Tabs};
 use std::collections::{HashMap, HashSet};
 
 /// 描画用共通コンテキスト
@@ -115,10 +120,17 @@ fn plugin_row_style(is_marked: bool, enabled: bool) -> Style {
     }
 }
 
-/// マーク有無からチェック印 prefix を組み立てる。
-fn plugin_row_prefix(is_marked: bool) -> String {
-    let mark_indicator = if is_marked { "[x] " } else { "[ ] " };
-    format!("  {}", mark_indicator)
+/// マーク状態 + enabled 状態から行の prefix を組み立てる。
+///
+/// 完成形例: `"  [✓] ● "` (marked + enabled) / `"  [ ] ○ "` (unmarked + disabled)
+fn plugin_row_prefix(is_marked: bool, enabled: bool) -> String {
+    let mark = if is_marked {
+        MARK_MARKED
+    } else {
+        MARK_UNMARKED
+    };
+    let icon = if enabled { ICON_ENABLED } else { ICON_DISABLED };
+    format!("{}{} {} ", LIST_ITEM_INDENT, mark, icon)
 }
 
 /// 名前 + (marketplace) + バージョン + (disabled) を組み立てる。
@@ -185,7 +197,7 @@ pub(super) fn build_plugin_row_spans<'a>(
     update_status: Option<&'a UpdateStatusDisplay>,
     content_width: u16,
 ) -> Vec<Span<'a>> {
-    let prefix = plugin_row_prefix(is_marked);
+    let prefix = plugin_row_prefix(is_marked, plugin.enabled());
     let name_text = plugin_row_name_text(plugin);
     let base_style = plugin_row_style(is_marked, plugin.enabled());
 
@@ -204,7 +216,7 @@ pub(super) fn build_plugin_row<'a>(
     content_width: u16,
 ) -> ListItem<'a> {
     let spans = build_plugin_row_spans(plugin, is_marked, update_status, content_width);
-    ListItem::new(Line::from(spans))
+    ListItem::new(vec![Line::from(spans), Line::raw("")])
 }
 
 /// 更新ステータスの表示文字列とスタイルを取得
@@ -249,18 +261,10 @@ fn view_plugin_list(
     update_statuses: &HashMap<PluginId, UpdateStatusDisplay>,
 ) {
     let filtered = filter_plugins(&ctx.data.plugins, ctx.filter_text);
-    let outer = content_rect(f.area(), HORIZONTAL_PADDING);
+    let outer = outer_rect(f.area());
     f.render_widget(Clear, outer);
 
-    let chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Length(1), // タブバー
-            Constraint::Length(3), // フィルタバー
-            Constraint::Min(1),    // コンテンツ
-            Constraint::Length(1), // ヘルプ
-        ])
-        .split(outer);
+    let [tabs_area, filter_area, content_area, help_area] = framed_layout(outer);
 
     // タブバー
     let tab_titles: Vec<&str> = Tab::all().iter().map(|t| t.title()).collect();
@@ -273,10 +277,10 @@ fn view_plugin_list(
                 .add_modifier(Modifier::BOLD),
         )
         .divider(" | ");
-    f.render_widget(tabs, chunks[0]);
+    f.render_widget(tabs, tabs_area);
 
     // フィルタバー
-    render_filter_bar(f, chunks[1], ctx.filter_text, ctx.filter_focused);
+    render_filter_bar(f, filter_area, ctx.filter_text, ctx.filter_focused);
 
     // タイトル（マーク数表示付き）
     let marked_count = marked_ids.len();
@@ -298,9 +302,9 @@ fn view_plugin_list(
     // プラグインリスト（フィルタ済み）
     if filtered.is_empty() {
         let no_match = Paragraph::new("  No matching plugins")
-            .block(Block::default().title(title).borders(Borders::ALL))
+            .block(bordered_block(&title))
             .style(Style::default().fg(Color::DarkGray));
-        f.render_widget(no_match, chunks[2]);
+        f.render_widget(no_match, content_area);
     } else {
         let items: Vec<ListItem> = filtered
             .iter()
@@ -311,16 +315,9 @@ fn view_plugin_list(
             })
             .collect();
 
-        let list = List::new(items)
-            .block(Block::default().title(title).borders(Borders::ALL))
-            .highlight_style(
-                Style::default()
-                    .add_modifier(Modifier::BOLD)
-                    .fg(Color::Green),
-            )
-            .highlight_symbol("> ");
+        let list = selectable_list(items, &title);
 
-        f.render_stateful_widget(list, chunks[2], &mut state);
+        f.render_stateful_widget(list, content_area, &mut state);
     }
 
     // ヘルプ
@@ -328,7 +325,7 @@ fn view_plugin_list(
         " Space: mark | a: all | U: update | A: update all | Tab: switch | ↑↓: move | Enter: details | q: quit",
     )
     .style(Style::default().fg(Color::DarkGray));
-    f.render_widget(help, chunks[3]);
+    f.render_widget(help, help_area);
 }
 
 /// プラグイン詳細画面を描画
@@ -349,19 +346,10 @@ fn view_plugin_detail(
         return;
     };
 
-    let outer = content_rect(f.area(), HORIZONTAL_PADDING);
+    let outer = outer_rect(f.area());
     f.render_widget(Clear, outer);
 
-    let chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Length(1), // タブバー
-            Constraint::Length(3), // フィルタバー
-            Constraint::Length(7), // プラグイン情報
-            Constraint::Min(1),    // アクションメニュー
-            Constraint::Length(1), // ヘルプ
-        ])
-        .split(outer);
+    let [tabs_area, filter_area, content_area, help_area] = framed_layout(outer);
 
     // タブバー
     let tab_titles: Vec<&str> = Tab::all().iter().map(|t| t.title()).collect();
@@ -374,10 +362,10 @@ fn view_plugin_detail(
                 .add_modifier(Modifier::BOLD),
         )
         .divider(" | ");
-    f.render_widget(tabs, chunks[0]);
+    f.render_widget(tabs, tabs_area);
 
     // フィルタバー（read-only）
-    render_filter_bar(f, chunks[1], ctx.filter_text, ctx.filter_focused);
+    render_filter_bar(f, filter_area, ctx.filter_text, ctx.filter_focused);
 
     // プラグイン情報
     let marketplace_str = plugin
@@ -412,27 +400,29 @@ fn view_plugin_detail(
         ]),
     ];
 
-    let info_block = Block::default().title(title).borders(Borders::ALL);
-    let info_para = Paragraph::new(info_lines).block(info_block);
-    f.render_widget(info_para, chunks[2]);
-
     // アクションメニュー（enabled 状態に応じて動的に切り替え）
     let actions = DetailAction::for_plugin(plugin.enabled());
     let items: Vec<ListItem> = actions
         .iter()
-        .map(|a| ListItem::new(format!("  {}", a.label())).style(a.style()))
+        .map(|a| {
+            let line_text = format!("{}{}", LIST_ITEM_INDENT, a.label());
+            ListItem::new(vec![Line::from(line_text), Line::raw("")]).style(a.style())
+        })
         .collect();
 
-    let list = List::new(items)
-        .highlight_style(Style::default().add_modifier(Modifier::BOLD))
-        .highlight_symbol("> ");
+    let action_menu_rows: u16 = items.iter().map(|i| i.height() as u16).sum();
+    let [info_area, menu_area, _detail_help] = detail_layout(content_area, action_menu_rows);
 
-    f.render_stateful_widget(list, chunks[3], &mut state);
+    let info_para = Paragraph::new(info_lines).block(bordered_block(&title));
+    f.render_widget(info_para, info_area);
+
+    let list = menu_list(items);
+    f.render_stateful_widget(list, menu_area, &mut state);
 
     // ヘルプ
     let help = Paragraph::new(" Navigate: ↑↓ • Select: Enter • Back: Esc")
         .style(Style::default().fg(Color::DarkGray));
-    f.render_widget(help, chunks[4]);
+    f.render_widget(help, help_area);
 }
 
 /// コンポーネント種別選択画面を描画
@@ -455,7 +445,7 @@ fn view_component_types(
 
     let counts = ctx.data.available_component_kinds(plugin);
 
-    let outer = content_rect(f.area(), HORIZONTAL_PADDING);
+    let outer = outer_rect(f.area());
     f.render_widget(Clear, outer);
 
     let chunks = Layout::default()
@@ -482,27 +472,24 @@ fn view_component_types(
         lines.push(String::new());
         lines.push("  Components: (none)".to_string());
 
-        let paragraph = Paragraph::new(lines.join("\n"))
-            .block(Block::default().title(title).borders(Borders::ALL));
+        let paragraph = Paragraph::new(lines.join("\n")).block(bordered_block(&title));
         f.render_widget(paragraph, chunks[1]);
     } else {
         // コンポーネントがある場合
         let items: Vec<ListItem> = counts
             .iter()
             .map(|(kind, count)| {
-                let text = format!("  {} ({})", component_kind_title(*kind), count);
-                ListItem::new(text)
+                let line_text = format!(
+                    "{}{} ({})",
+                    LIST_ITEM_INDENT,
+                    component_kind_title(*kind),
+                    count
+                );
+                ListItem::new(vec![Line::from(line_text), Line::raw("")])
             })
             .collect();
 
-        let list = List::new(items)
-            .block(Block::default().title(title).borders(Borders::ALL))
-            .highlight_style(
-                Style::default()
-                    .add_modifier(Modifier::BOLD)
-                    .fg(Color::Green),
-            )
-            .highlight_symbol("> ");
+        let list = selectable_list(items, &title);
 
         f.render_stateful_widget(list, chunks[1], &mut state);
     }
@@ -540,10 +527,13 @@ fn view_component_list(
     let components = ctx.data.component_names(plugin, kind);
     let items: Vec<ListItem> = components
         .iter()
-        .map(|c| ListItem::new(format!("  {}", c)))
+        .map(|c| {
+            let line_text = format!("{}{}", LIST_ITEM_INDENT, c);
+            ListItem::new(vec![Line::from(line_text), Line::raw("")])
+        })
         .collect();
 
-    let outer = content_rect(f.area(), HORIZONTAL_PADDING);
+    let outer = outer_rect(f.area());
     f.render_widget(Clear, outer);
 
     let chunks = Layout::default()
@@ -564,14 +554,7 @@ fn view_component_list(
         component_kind_title(kind),
         components.len()
     );
-    let list = List::new(items)
-        .block(Block::default().title(title).borders(Borders::ALL))
-        .highlight_style(
-            Style::default()
-                .add_modifier(Modifier::BOLD)
-                .fg(Color::Green),
-        )
-        .highlight_symbol("> ");
+    let list = selectable_list(items, &title);
 
     f.render_stateful_widget(list, chunks[1], &mut state);
 

--- a/src/tui/manager/screens/installed/view.rs
+++ b/src/tui/manager/screens/installed/view.rs
@@ -302,7 +302,7 @@ fn view_plugin_list(
 ) {
     let filtered = filter_plugins(&ctx.data.plugins, ctx.filter_text);
     let outer = outer_rect(f.area());
-    f.render_widget(Clear, outer);
+    f.render_widget(Clear, f.area());
 
     let [tabs_area, filter_area, content_area, help_area] = framed_layout(outer);
 
@@ -387,7 +387,7 @@ fn view_plugin_detail(
     };
 
     let outer = outer_rect(f.area());
-    f.render_widget(Clear, outer);
+    f.render_widget(Clear, f.area());
 
     let [tabs_area, filter_area, content_area, help_area] = framed_layout(outer);
 
@@ -474,7 +474,7 @@ fn view_component_types(
     let counts = ctx.data.available_component_kinds(plugin);
 
     let outer = outer_rect(f.area());
-    f.render_widget(Clear, outer);
+    f.render_widget(Clear, f.area());
 
     let chunks = Layout::default()
         .direction(Direction::Vertical)
@@ -551,7 +551,7 @@ fn view_component_list(
         .collect();
 
     let outer = outer_rect(f.area());
-    f.render_widget(Clear, outer);
+    f.render_widget(Clear, f.area());
 
     let chunks = Layout::default()
         .direction(Direction::Vertical)

--- a/src/tui/manager/screens/installed/view.rs
+++ b/src/tui/manager/screens/installed/view.rs
@@ -7,7 +7,7 @@ use crate::application::InstalledPlugin;
 use crate::component::ComponentKind;
 use crate::tui::manager::core::layout::{detail_layout, framed_layout, outer_rect};
 use crate::tui::manager::core::style::{
-    bordered_block, highlight_spans, menu_list, selectable_list, ICON_DISABLED, ICON_ENABLED,
+    bordered_block, highlight_line, menu_list, selectable_list, ICON_DISABLED, ICON_ENABLED,
     LIST_ITEM_INDENT, MARK_MARKED, MARK_UNMARKED,
 };
 use crate::tui::manager::core::{
@@ -220,8 +220,7 @@ pub(super) fn build_plugin_row<'a>(
     is_selected: bool,
 ) -> ListItem<'a> {
     let spans = build_plugin_row_spans(plugin, is_marked, update_status, content_width);
-    let spans = highlight_spans(spans, is_selected);
-    ListItem::new(vec![Line::from(spans), Line::raw("")])
+    ListItem::new(vec![highlight_line(spans, is_selected), Line::raw("")])
 }
 
 /// 詳細画面の action メニュー項目を 2 行 ListItem (内容 + 空行) として構築する。
@@ -233,8 +232,7 @@ pub(super) fn build_plugin_row<'a>(
 fn build_detail_action_item(action: &DetailAction, is_selected: bool) -> ListItem<'static> {
     let line_text = format!("{}{}", LIST_ITEM_INDENT, action.label());
     let spans = vec![Span::styled(line_text, action.style())];
-    let spans = highlight_spans(spans, is_selected);
-    ListItem::new(vec![Line::from(spans), Line::raw("")])
+    ListItem::new(vec![highlight_line(spans, is_selected), Line::raw("")])
 }
 
 /// 詳細画面の action メニュー全体を組み立て、`(items, action_menu_rows)` を返す。
@@ -270,8 +268,7 @@ fn build_component_types_item(
         count
     );
     let spans = vec![Span::raw(line_text)];
-    let spans = highlight_spans(spans, is_selected);
-    ListItem::new(vec![Line::from(spans), Line::raw("")])
+    ListItem::new(vec![highlight_line(spans, is_selected), Line::raw("")])
 }
 
 /// `view_component_list` のリスト項目を 2 行 ListItem (内容 + 空行) として構築する。
@@ -280,8 +277,7 @@ fn build_component_types_item(
 fn build_component_list_item(component_name: &str, is_selected: bool) -> ListItem<'static> {
     let line_text = format!("{}{}", LIST_ITEM_INDENT, component_name);
     let spans = vec![Span::raw(line_text)];
-    let spans = highlight_spans(spans, is_selected);
-    ListItem::new(vec![Line::from(spans), Line::raw("")])
+    ListItem::new(vec![highlight_line(spans, is_selected), Line::raw("")])
 }
 
 /// 更新ステータスの表示文字列とスタイルを取得

--- a/src/tui/manager/screens/installed/view.rs
+++ b/src/tui/manager/screens/installed/view.rs
@@ -7,8 +7,8 @@ use crate::application::InstalledPlugin;
 use crate::component::ComponentKind;
 use crate::tui::manager::core::layout::{detail_layout, framed_layout, outer_rect};
 use crate::tui::manager::core::style::{
-    bordered_block, menu_list, selectable_list, ICON_DISABLED, ICON_ENABLED, LIST_ITEM_INDENT,
-    MARK_MARKED, MARK_UNMARKED,
+    bordered_block, highlight_spans, menu_list, selectable_list, ICON_DISABLED, ICON_ENABLED,
+    LIST_ITEM_INDENT, MARK_MARKED, MARK_UNMARKED,
 };
 use crate::tui::manager::core::{
     filter_plugins, render_filter_bar, truncate_to_width, DataStore, PluginId, Tab,
@@ -209,13 +209,18 @@ pub(super) fn build_plugin_row_spans<'a>(
 }
 
 /// プラグイン 1 行分の `ListItem` を構築する。
+///
+/// `is_selected = true` のときは内容行の Span に `highlight_style()` を patch する。
+/// 空行 (2 行目) には適用しないため、選択時に空行が緑背景にならない。
 pub(super) fn build_plugin_row<'a>(
     plugin: &'a InstalledPlugin,
     is_marked: bool,
     update_status: Option<&'a UpdateStatusDisplay>,
     content_width: u16,
+    is_selected: bool,
 ) -> ListItem<'a> {
     let spans = build_plugin_row_spans(plugin, is_marked, update_status, content_width);
+    let spans = highlight_spans(spans, is_selected);
     ListItem::new(vec![Line::from(spans), Line::raw("")])
 }
 
@@ -223,41 +228,60 @@ pub(super) fn build_plugin_row<'a>(
 ///
 /// 1 行目に内容、2 行目に空行を持たせて、`highlight_symbol("> ")` を内容行に
 /// 整列させつつ行間に視覚的な余白を確保する。
-/// 返される `ListItem` は所有データのみで構成されるため `'static`。
-fn build_detail_action_item(action: &DetailAction) -> ListItem<'static> {
+/// `is_selected = true` のとき内容行の Span に `highlight_style()` を patch する
+/// （空行には適用しない）。返される `ListItem` は所有データのみで構成されるため `'static`。
+fn build_detail_action_item(action: &DetailAction, is_selected: bool) -> ListItem<'static> {
     let line_text = format!("{}{}", LIST_ITEM_INDENT, action.label());
-    ListItem::new(vec![Line::from(line_text), Line::raw("")]).style(action.style())
+    let spans = vec![Span::styled(line_text, action.style())];
+    let spans = highlight_spans(spans, is_selected);
+    ListItem::new(vec![Line::from(spans), Line::raw("")])
 }
 
 /// 詳細画面の action メニュー全体を組み立て、`(items, action_menu_rows)` を返す。
 ///
 /// `action_menu_rows` は描画行数（`items.iter().map(ListItem::height).sum()`）。
 /// 呼び出し側は `detail_layout` にこの値を渡して全 action の領域を確保する。
-fn build_detail_action_menu(actions: &[DetailAction]) -> (Vec<ListItem<'static>>, u16) {
-    let items: Vec<ListItem<'static>> = actions.iter().map(build_detail_action_item).collect();
+/// `selected` は現在ハイライト中の論理 index。
+fn build_detail_action_menu(
+    actions: &[DetailAction],
+    selected: Option<usize>,
+) -> (Vec<ListItem<'static>>, u16) {
+    let items: Vec<ListItem<'static>> = actions
+        .iter()
+        .enumerate()
+        .map(|(i, a)| build_detail_action_item(a, Some(i) == selected))
+        .collect();
     let rows: u16 = items.iter().map(|i| i.height() as u16).sum();
     (items, rows)
 }
 
 /// `view_component_types` のリスト項目を 2 行 ListItem (内容 + 空行) として構築する。
 ///
-/// 返される `ListItem` は所有データのみで構成されるため `'static`。
-fn build_component_types_item(kind: ComponentKind, count: usize) -> ListItem<'static> {
+/// `is_selected = true` のとき内容行の Span に `highlight_style()` を patch する。
+fn build_component_types_item(
+    kind: ComponentKind,
+    count: usize,
+    is_selected: bool,
+) -> ListItem<'static> {
     let line_text = format!(
         "{}{} ({})",
         LIST_ITEM_INDENT,
         component_kind_title(kind),
         count
     );
-    ListItem::new(vec![Line::from(line_text), Line::raw("")])
+    let spans = vec![Span::raw(line_text)];
+    let spans = highlight_spans(spans, is_selected);
+    ListItem::new(vec![Line::from(spans), Line::raw("")])
 }
 
 /// `view_component_list` のリスト項目を 2 行 ListItem (内容 + 空行) として構築する。
 ///
-/// 返される `ListItem` は所有データのみで構成されるため `'static`。
-fn build_component_list_item(component_name: &str) -> ListItem<'static> {
+/// `is_selected = true` のとき内容行の Span に `highlight_style()` を patch する。
+fn build_component_list_item(component_name: &str, is_selected: bool) -> ListItem<'static> {
     let line_text = format!("{}{}", LIST_ITEM_INDENT, component_name);
-    ListItem::new(vec![Line::from(line_text), Line::raw("")])
+    let spans = vec![Span::raw(line_text)];
+    let spans = highlight_spans(spans, is_selected);
+    ListItem::new(vec![Line::from(spans), Line::raw("")])
 }
 
 /// 更新ステータスの表示文字列とスタイルを取得
@@ -347,12 +371,15 @@ fn view_plugin_list(
             .style(Style::default().fg(Color::DarkGray));
         f.render_widget(no_match, content_area);
     } else {
+        let selected_idx = state.selected();
         let items: Vec<ListItem> = filtered
             .iter()
-            .map(|p| {
+            .enumerate()
+            .map(|(i, p)| {
                 let is_marked = marked_ids.contains(p.id());
                 let update_status = update_statuses.get(p.id());
-                build_plugin_row(p, is_marked, update_status, outer.width)
+                let is_selected = Some(i) == selected_idx;
+                build_plugin_row(p, is_marked, update_status, outer.width, is_selected)
             })
             .collect();
 
@@ -438,7 +465,7 @@ fn view_plugin_detail(
 
     // アクションメニュー（enabled 状態に応じて動的に切り替え）
     let actions = DetailAction::for_plugin(plugin.enabled());
-    let (items, action_menu_rows) = build_detail_action_menu(&actions);
+    let (items, action_menu_rows) = build_detail_action_menu(&actions, state.selected());
 
     let [info_area, menu_area] = detail_layout(content_area, action_menu_rows);
 
@@ -505,9 +532,13 @@ fn view_component_types(
         f.render_widget(paragraph, chunks[1]);
     } else {
         // コンポーネントがある場合
+        let selected_idx = state.selected();
         let items: Vec<ListItem> = counts
             .iter()
-            .map(|(kind, count)| build_component_types_item(*kind, *count))
+            .enumerate()
+            .map(|(i, (kind, count))| {
+                build_component_types_item(*kind, *count, Some(i) == selected_idx)
+            })
             .collect();
 
         let list = selectable_list(items, &title);
@@ -546,9 +577,11 @@ fn view_component_list(
     };
 
     let components = ctx.data.component_names(plugin, kind);
+    let selected_idx = state.selected();
     let items: Vec<ListItem> = components
         .iter()
-        .map(|c| build_component_list_item(c))
+        .enumerate()
+        .map(|(i, c)| build_component_list_item(c, Some(i) == selected_idx))
         .collect();
 
     let outer = outer_rect(f.area());

--- a/src/tui/manager/screens/installed/view.rs
+++ b/src/tui/manager/screens/installed/view.rs
@@ -222,7 +222,8 @@ pub(super) fn build_plugin_row<'a>(
 /// 詳細画面の action メニュー項目を 2 行 ListItem として構築する。
 ///
 /// `LIST_ITEM_INDENT + label` を 1 行目に、空行を 2 行目に持たせる。
-fn build_detail_action_item<'a>(action: &DetailAction) -> ListItem<'a> {
+/// 返される `ListItem` は所有データのみで構成されるため `'static`。
+fn build_detail_action_item(action: &DetailAction) -> ListItem<'static> {
     let line_text = format!("{}{}", LIST_ITEM_INDENT, action.label());
     ListItem::new(vec![Line::from(line_text), Line::raw("")]).style(action.style())
 }
@@ -231,8 +232,8 @@ fn build_detail_action_item<'a>(action: &DetailAction) -> ListItem<'a> {
 ///
 /// `action_menu_rows` は描画行数（`items.iter().map(ListItem::height).sum()`）。
 /// 呼び出し側は `detail_layout` にこの値を渡して全 action の領域を確保する。
-fn build_detail_action_menu<'a>(actions: &[DetailAction]) -> (Vec<ListItem<'a>>, u16) {
-    let items: Vec<ListItem> = actions.iter().map(build_detail_action_item).collect();
+fn build_detail_action_menu(actions: &[DetailAction]) -> (Vec<ListItem<'static>>, u16) {
+    let items: Vec<ListItem<'static>> = actions.iter().map(build_detail_action_item).collect();
     let rows: u16 = items.iter().map(|i| i.height() as u16).sum();
     (items, rows)
 }

--- a/src/tui/manager/screens/installed/view.rs
+++ b/src/tui/manager/screens/installed/view.rs
@@ -216,16 +216,16 @@ pub(super) fn build_plugin_row<'a>(
     content_width: u16,
 ) -> ListItem<'a> {
     let spans = build_plugin_row_spans(plugin, is_marked, update_status, content_width);
-    ListItem::new(vec![Line::from(spans), Line::raw("")])
+    ListItem::new(vec![Line::raw(""), Line::from(spans), Line::raw("")])
 }
 
-/// 詳細画面の action メニュー項目を 2 行 ListItem として構築する。
+/// 詳細画面の action メニュー項目を 3 行 ListItem (上下空行 + 内容) として構築する。
 ///
-/// `LIST_ITEM_INDENT + label` を 1 行目に、空行を 2 行目に持たせる。
+/// 内容行を上下空行で挟むことで、強調表示時に文字が縦中央に来る。
 /// 返される `ListItem` は所有データのみで構成されるため `'static`。
 fn build_detail_action_item(action: &DetailAction) -> ListItem<'static> {
     let line_text = format!("{}{}", LIST_ITEM_INDENT, action.label());
-    ListItem::new(vec![Line::from(line_text), Line::raw("")]).style(action.style())
+    ListItem::new(vec![Line::raw(""), Line::from(line_text), Line::raw("")]).style(action.style())
 }
 
 /// 詳細画面の action メニュー全体を組み立て、`(items, action_menu_rows)` を返す。
@@ -238,7 +238,7 @@ fn build_detail_action_menu(actions: &[DetailAction]) -> (Vec<ListItem<'static>>
     (items, rows)
 }
 
-/// `view_component_types` のリスト項目を 2 行 ListItem として構築する。
+/// `view_component_types` のリスト項目を 3 行 ListItem (上下空行 + 内容) として構築する。
 fn build_component_types_item<'a>(kind: ComponentKind, count: usize) -> ListItem<'a> {
     let line_text = format!(
         "{}{} ({})",
@@ -246,13 +246,13 @@ fn build_component_types_item<'a>(kind: ComponentKind, count: usize) -> ListItem
         component_kind_title(kind),
         count
     );
-    ListItem::new(vec![Line::from(line_text), Line::raw("")])
+    ListItem::new(vec![Line::raw(""), Line::from(line_text), Line::raw("")])
 }
 
-/// `view_component_list` のリスト項目を 2 行 ListItem として構築する。
+/// `view_component_list` のリスト項目を 3 行 ListItem (上下空行 + 内容) として構築する。
 fn build_component_list_item<'a>(component_name: &str) -> ListItem<'a> {
     let line_text = format!("{}{}", LIST_ITEM_INDENT, component_name);
-    ListItem::new(vec![Line::from(line_text), Line::raw("")])
+    ListItem::new(vec![Line::raw(""), Line::from(line_text), Line::raw("")])
 }
 
 /// 更新ステータスの表示文字列とスタイルを取得

--- a/src/tui/manager/screens/installed/view.rs
+++ b/src/tui/manager/screens/installed/view.rs
@@ -219,6 +219,31 @@ pub(super) fn build_plugin_row<'a>(
     ListItem::new(vec![Line::from(spans), Line::raw("")])
 }
 
+/// 詳細画面の action メニュー項目を 2 行 ListItem として構築する。
+///
+/// `LIST_ITEM_INDENT + label` を 1 行目に、空行を 2 行目に持たせる。
+fn build_detail_action_item<'a>(action: &DetailAction) -> ListItem<'a> {
+    let line_text = format!("{}{}", LIST_ITEM_INDENT, action.label());
+    ListItem::new(vec![Line::from(line_text), Line::raw("")]).style(action.style())
+}
+
+/// `view_component_types` のリスト項目を 2 行 ListItem として構築する。
+fn build_component_types_item<'a>(kind: ComponentKind, count: usize) -> ListItem<'a> {
+    let line_text = format!(
+        "{}{} ({})",
+        LIST_ITEM_INDENT,
+        component_kind_title(kind),
+        count
+    );
+    ListItem::new(vec![Line::from(line_text), Line::raw("")])
+}
+
+/// `view_component_list` のリスト項目を 2 行 ListItem として構築する。
+fn build_component_list_item<'a>(component_name: &str) -> ListItem<'a> {
+    let line_text = format!("{}{}", LIST_ITEM_INDENT, component_name);
+    ListItem::new(vec![Line::from(line_text), Line::raw("")])
+}
+
 /// 更新ステータスの表示文字列とスタイルを取得
 ///
 /// # Arguments
@@ -397,13 +422,7 @@ fn view_plugin_detail(
 
     // アクションメニュー（enabled 状態に応じて動的に切り替え）
     let actions = DetailAction::for_plugin(plugin.enabled());
-    let items: Vec<ListItem> = actions
-        .iter()
-        .map(|a| {
-            let line_text = format!("{}{}", LIST_ITEM_INDENT, a.label());
-            ListItem::new(vec![Line::from(line_text), Line::raw("")]).style(a.style())
-        })
-        .collect();
+    let items: Vec<ListItem> = actions.iter().map(build_detail_action_item).collect();
 
     let action_menu_rows: u16 = items.iter().map(|i| i.height() as u16).sum();
     let [info_area, menu_area, _detail_help] = detail_layout(content_area, action_menu_rows);
@@ -473,15 +492,7 @@ fn view_component_types(
         // コンポーネントがある場合
         let items: Vec<ListItem> = counts
             .iter()
-            .map(|(kind, count)| {
-                let line_text = format!(
-                    "{}{} ({})",
-                    LIST_ITEM_INDENT,
-                    component_kind_title(*kind),
-                    count
-                );
-                ListItem::new(vec![Line::from(line_text), Line::raw("")])
-            })
+            .map(|(kind, count)| build_component_types_item(*kind, *count))
             .collect();
 
         let list = selectable_list(items, &title);
@@ -522,10 +533,7 @@ fn view_component_list(
     let components = ctx.data.component_names(plugin, kind);
     let items: Vec<ListItem> = components
         .iter()
-        .map(|c| {
-            let line_text = format!("{}{}", LIST_ITEM_INDENT, c);
-            ListItem::new(vec![Line::from(line_text), Line::raw("")])
-        })
+        .map(|c| build_component_list_item(c))
         .collect();
 
     let outer = outer_rect(f.area());

--- a/src/tui/manager/screens/installed/view.rs
+++ b/src/tui/manager/screens/installed/view.rs
@@ -227,6 +227,16 @@ fn build_detail_action_item<'a>(action: &DetailAction) -> ListItem<'a> {
     ListItem::new(vec![Line::from(line_text), Line::raw("")]).style(action.style())
 }
 
+/// 詳細画面の action メニュー全体を組み立て、`(items, action_menu_rows)` を返す。
+///
+/// `action_menu_rows` は描画行数（`items.iter().map(ListItem::height).sum()`）。
+/// 呼び出し側は `detail_layout` にこの値を渡して全 action の領域を確保する。
+fn build_detail_action_menu<'a>(actions: &[DetailAction]) -> (Vec<ListItem<'a>>, u16) {
+    let items: Vec<ListItem> = actions.iter().map(build_detail_action_item).collect();
+    let rows: u16 = items.iter().map(|i| i.height() as u16).sum();
+    (items, rows)
+}
+
 /// `view_component_types` のリスト項目を 2 行 ListItem として構築する。
 fn build_component_types_item<'a>(kind: ComponentKind, count: usize) -> ListItem<'a> {
     let line_text = format!(
@@ -422,9 +432,8 @@ fn view_plugin_detail(
 
     // アクションメニュー（enabled 状態に応じて動的に切り替え）
     let actions = DetailAction::for_plugin(plugin.enabled());
-    let items: Vec<ListItem> = actions.iter().map(build_detail_action_item).collect();
+    let (items, action_menu_rows) = build_detail_action_menu(&actions);
 
-    let action_menu_rows: u16 = items.iter().map(|i| i.height() as u16).sum();
     let [info_area, menu_area, _detail_help] = detail_layout(content_area, action_menu_rows);
 
     let info_para = Paragraph::new(info_lines).block(bordered_block(&title));

--- a/src/tui/manager/screens/installed/view.rs
+++ b/src/tui/manager/screens/installed/view.rs
@@ -216,16 +216,17 @@ pub(super) fn build_plugin_row<'a>(
     content_width: u16,
 ) -> ListItem<'a> {
     let spans = build_plugin_row_spans(plugin, is_marked, update_status, content_width);
-    ListItem::new(vec![Line::raw(""), Line::from(spans), Line::raw("")])
+    ListItem::new(vec![Line::from(spans), Line::raw("")])
 }
 
-/// 詳細画面の action メニュー項目を 3 行 ListItem (上下空行 + 内容) として構築する。
+/// 詳細画面の action メニュー項目を 2 行 ListItem (内容 + 空行) として構築する。
 ///
-/// 内容行を上下空行で挟むことで、強調表示時に文字が縦中央に来る。
+/// 1 行目に内容、2 行目に空行を持たせて、`highlight_symbol("> ")` を内容行に
+/// 整列させつつ行間に視覚的な余白を確保する。
 /// 返される `ListItem` は所有データのみで構成されるため `'static`。
 fn build_detail_action_item(action: &DetailAction) -> ListItem<'static> {
     let line_text = format!("{}{}", LIST_ITEM_INDENT, action.label());
-    ListItem::new(vec![Line::raw(""), Line::from(line_text), Line::raw("")]).style(action.style())
+    ListItem::new(vec![Line::from(line_text), Line::raw("")]).style(action.style())
 }
 
 /// 詳細画面の action メニュー全体を組み立て、`(items, action_menu_rows)` を返す。
@@ -238,7 +239,7 @@ fn build_detail_action_menu(actions: &[DetailAction]) -> (Vec<ListItem<'static>>
     (items, rows)
 }
 
-/// `view_component_types` のリスト項目を 3 行 ListItem (上下空行 + 内容) として構築する。
+/// `view_component_types` のリスト項目を 2 行 ListItem (内容 + 空行) として構築する。
 ///
 /// 返される `ListItem` は所有データのみで構成されるため `'static`。
 fn build_component_types_item(kind: ComponentKind, count: usize) -> ListItem<'static> {
@@ -248,15 +249,15 @@ fn build_component_types_item(kind: ComponentKind, count: usize) -> ListItem<'st
         component_kind_title(kind),
         count
     );
-    ListItem::new(vec![Line::raw(""), Line::from(line_text), Line::raw("")])
+    ListItem::new(vec![Line::from(line_text), Line::raw("")])
 }
 
-/// `view_component_list` のリスト項目を 3 行 ListItem (上下空行 + 内容) として構築する。
+/// `view_component_list` のリスト項目を 2 行 ListItem (内容 + 空行) として構築する。
 ///
 /// 返される `ListItem` は所有データのみで構成されるため `'static`。
 fn build_component_list_item(component_name: &str) -> ListItem<'static> {
     let line_text = format!("{}{}", LIST_ITEM_INDENT, component_name);
-    ListItem::new(vec![Line::raw(""), Line::from(line_text), Line::raw("")])
+    ListItem::new(vec![Line::from(line_text), Line::raw("")])
 }
 
 /// 更新ステータスの表示文字列とスタイルを取得

--- a/src/tui/manager/screens/installed/view.rs
+++ b/src/tui/manager/screens/installed/view.rs
@@ -440,7 +440,7 @@ fn view_plugin_detail(
     let actions = DetailAction::for_plugin(plugin.enabled());
     let (items, action_menu_rows) = build_detail_action_menu(&actions);
 
-    let [info_area, menu_area, _detail_help] = detail_layout(content_area, action_menu_rows);
+    let [info_area, menu_area] = detail_layout(content_area, action_menu_rows);
 
     let info_para = Paragraph::new(info_lines).block(bordered_block(&title));
     f.render_widget(info_para, info_area);

--- a/src/tui/manager/screens/installed/view.rs
+++ b/src/tui/manager/screens/installed/view.rs
@@ -239,7 +239,9 @@ fn build_detail_action_menu(actions: &[DetailAction]) -> (Vec<ListItem<'static>>
 }
 
 /// `view_component_types` のリスト項目を 3 行 ListItem (上下空行 + 内容) として構築する。
-fn build_component_types_item<'a>(kind: ComponentKind, count: usize) -> ListItem<'a> {
+///
+/// 返される `ListItem` は所有データのみで構成されるため `'static`。
+fn build_component_types_item(kind: ComponentKind, count: usize) -> ListItem<'static> {
     let line_text = format!(
         "{}{} ({})",
         LIST_ITEM_INDENT,
@@ -250,7 +252,9 @@ fn build_component_types_item<'a>(kind: ComponentKind, count: usize) -> ListItem
 }
 
 /// `view_component_list` のリスト項目を 3 行 ListItem (上下空行 + 内容) として構築する。
-fn build_component_list_item<'a>(component_name: &str) -> ListItem<'a> {
+///
+/// 返される `ListItem` は所有データのみで構成されるため `'static`。
+fn build_component_list_item(component_name: &str) -> ListItem<'static> {
     let line_text = format!("{}{}", LIST_ITEM_INDENT, component_name);
     ListItem::new(vec![Line::raw(""), Line::from(line_text), Line::raw("")])
 }

--- a/src/tui/manager/screens/installed/view.rs
+++ b/src/tui/manager/screens/installed/view.rs
@@ -384,18 +384,13 @@ fn view_plugin_detail(
         Line::from(vec![
             Span::raw("Scope: "),
             Span::styled("project", Style::default().fg(Color::White)),
-        ]),
-        Line::from(vec![
-            Span::raw("Version: "),
+            Span::raw("    Version: "),
             Span::styled(plugin.version(), Style::default().fg(Color::White)),
         ]),
-        Line::raw(""),
         Line::from(vec![
             Span::raw("Author: "),
             Span::styled("N/A", Style::default().fg(Color::DarkGray)),
-        ]),
-        Line::from(vec![
-            Span::raw("Status: "),
+            Span::raw("    Status: "),
             Span::styled(status_text, Style::default().fg(status_color)),
         ]),
     ];

--- a/src/tui/manager/screens/installed/view_test.rs
+++ b/src/tui/manager/screens/installed/view_test.rs
@@ -64,35 +64,35 @@ fn build_plugin_row_does_not_panic_at_zero_width() {
 }
 
 #[test]
-fn build_plugin_row_returns_3_line_list_item() {
+fn build_plugin_row_returns_2_line_list_item() {
     let plugin = make_test_plugin("p");
     let item = build_plugin_row(&plugin, false, None, 80);
-    assert_eq!(item.height(), 3);
+    assert_eq!(item.height(), 2);
 }
 
 #[test]
-fn build_plugin_row_returns_3_line_list_item_when_marked() {
+fn build_plugin_row_returns_2_line_list_item_when_marked() {
     let plugin = make_test_plugin("p");
     let item = build_plugin_row(&plugin, true, None, 80);
-    assert_eq!(item.height(), 3);
+    assert_eq!(item.height(), 2);
 }
 
 #[test]
-fn build_plugin_row_returns_3_line_list_item_when_narrow() {
+fn build_plugin_row_returns_2_line_list_item_when_narrow() {
     let plugin = make_test_plugin("very-long-plugin-name");
     let item = build_plugin_row(&plugin, false, None, 30);
-    assert_eq!(item.height(), 3);
+    assert_eq!(item.height(), 2);
 }
 
 #[test]
-fn build_detail_action_item_returns_height_3() {
+fn build_detail_action_item_returns_height_2() {
     use crate::tui::manager::screens::installed::model::DetailAction;
     for action in DetailAction::for_enabled()
         .iter()
         .chain(DetailAction::for_disabled().iter())
     {
         let item = build_detail_action_item(action);
-        assert_eq!(item.height(), 3);
+        assert_eq!(item.height(), 2);
     }
 }
 
@@ -102,9 +102,9 @@ fn build_detail_action_menu_reserves_full_height_for_enabled() {
     let actions = DetailAction::for_enabled();
     let (items, rows) = build_detail_action_menu(&actions);
     assert_eq!(items.len(), actions.len());
-    assert_eq!(rows, actions.len() as u16 * 3);
+    assert_eq!(rows, actions.len() as u16 * 2);
     for item in &items {
-        assert_eq!(item.height(), 3);
+        assert_eq!(item.height(), 2);
     }
 }
 
@@ -114,21 +114,21 @@ fn build_detail_action_menu_reserves_full_height_for_disabled() {
     let actions = DetailAction::for_disabled();
     let (items, rows) = build_detail_action_menu(&actions);
     assert_eq!(items.len(), actions.len());
-    assert_eq!(rows, actions.len() as u16 * 3);
+    assert_eq!(rows, actions.len() as u16 * 2);
     for item in &items {
-        assert_eq!(item.height(), 3);
+        assert_eq!(item.height(), 2);
     }
 }
 
 #[test]
-fn build_component_types_item_returns_height_3() {
+fn build_component_types_item_returns_height_2() {
     use crate::component::ComponentKind;
     let item = build_component_types_item(ComponentKind::Skill, 3);
-    assert_eq!(item.height(), 3);
+    assert_eq!(item.height(), 2);
 }
 
 #[test]
-fn build_component_list_item_returns_height_3() {
+fn build_component_list_item_returns_height_2() {
     let item = build_component_list_item("my-component");
-    assert_eq!(item.height(), 3);
+    assert_eq!(item.height(), 2);
 }

--- a/src/tui/manager/screens/installed/view_test.rs
+++ b/src/tui/manager/screens/installed/view_test.rs
@@ -83,3 +83,41 @@ fn build_plugin_row_returns_2_line_list_item_when_narrow() {
     let item = build_plugin_row(&plugin, false, None, 30);
     assert_eq!(item.height(), 2);
 }
+
+#[test]
+fn build_detail_action_item_returns_height_2() {
+    use crate::component::ComponentKind;
+    use crate::tui::manager::screens::installed::model::DetailAction;
+    let _ = ComponentKind::Skill;
+    for action in DetailAction::for_enabled()
+        .iter()
+        .chain(DetailAction::for_disabled().iter())
+    {
+        let item = build_detail_action_item(action);
+        assert_eq!(item.height(), 2);
+    }
+}
+
+#[test]
+fn view_plugin_detail_action_menu_renders_all_actions_with_2line_items() {
+    use crate::tui::manager::screens::installed::model::DetailAction;
+    let actions = DetailAction::for_enabled();
+    let total: u16 = actions
+        .iter()
+        .map(|a| build_detail_action_item(a).height() as u16)
+        .sum();
+    assert_eq!(total, actions.len() as u16 * 2);
+}
+
+#[test]
+fn build_component_types_item_returns_height_2() {
+    use crate::component::ComponentKind;
+    let item = build_component_types_item(ComponentKind::Skill, 3);
+    assert_eq!(item.height(), 2);
+}
+
+#[test]
+fn build_component_list_item_returns_height_2() {
+    let item = build_component_list_item("my-component");
+    assert_eq!(item.height(), 2);
+}

--- a/src/tui/manager/screens/installed/view_test.rs
+++ b/src/tui/manager/screens/installed/view_test.rs
@@ -62,3 +62,24 @@ fn build_plugin_row_does_not_panic_at_zero_width() {
     let plugin = make_test_plugin("p");
     let _ = build_plugin_row_spans(&plugin, false, None, 0);
 }
+
+#[test]
+fn build_plugin_row_returns_2_line_list_item() {
+    let plugin = make_test_plugin("p");
+    let item = build_plugin_row(&plugin, false, None, 80);
+    assert_eq!(item.height(), 2);
+}
+
+#[test]
+fn build_plugin_row_returns_2_line_list_item_when_marked() {
+    let plugin = make_test_plugin("p");
+    let item = build_plugin_row(&plugin, true, None, 80);
+    assert_eq!(item.height(), 2);
+}
+
+#[test]
+fn build_plugin_row_returns_2_line_list_item_when_narrow() {
+    let plugin = make_test_plugin("very-long-plugin-name");
+    let item = build_plugin_row(&plugin, false, None, 30);
+    assert_eq!(item.height(), 2);
+}

--- a/src/tui/manager/screens/installed/view_test.rs
+++ b/src/tui/manager/screens/installed/view_test.rs
@@ -86,9 +86,7 @@ fn build_plugin_row_returns_2_line_list_item_when_narrow() {
 
 #[test]
 fn build_detail_action_item_returns_height_2() {
-    use crate::component::ComponentKind;
     use crate::tui::manager::screens::installed::model::DetailAction;
-    let _ = ComponentKind::Skill;
     for action in DetailAction::for_enabled()
         .iter()
         .chain(DetailAction::for_disabled().iter())
@@ -99,14 +97,27 @@ fn build_detail_action_item_returns_height_2() {
 }
 
 #[test]
-fn view_plugin_detail_action_menu_renders_all_actions_with_2line_items() {
+fn build_detail_action_menu_reserves_full_height_for_enabled() {
     use crate::tui::manager::screens::installed::model::DetailAction;
     let actions = DetailAction::for_enabled();
-    let total: u16 = actions
-        .iter()
-        .map(|a| build_detail_action_item(a).height() as u16)
-        .sum();
-    assert_eq!(total, actions.len() as u16 * 2);
+    let (items, rows) = build_detail_action_menu(&actions);
+    assert_eq!(items.len(), actions.len());
+    assert_eq!(rows, actions.len() as u16 * 2);
+    for item in &items {
+        assert_eq!(item.height(), 2);
+    }
+}
+
+#[test]
+fn build_detail_action_menu_reserves_full_height_for_disabled() {
+    use crate::tui::manager::screens::installed::model::DetailAction;
+    let actions = DetailAction::for_disabled();
+    let (items, rows) = build_detail_action_menu(&actions);
+    assert_eq!(items.len(), actions.len());
+    assert_eq!(rows, actions.len() as u16 * 2);
+    for item in &items {
+        assert_eq!(item.height(), 2);
+    }
 }
 
 #[test]

--- a/src/tui/manager/screens/installed/view_test.rs
+++ b/src/tui/manager/screens/installed/view_test.rs
@@ -67,21 +67,21 @@ fn build_plugin_row_does_not_panic_at_zero_width() {
 fn build_plugin_row_returns_2_line_list_item() {
     let plugin = make_test_plugin("p");
     let item = build_plugin_row(&plugin, false, None, 80);
-    assert_eq!(item.height(), 2);
+    assert_eq!(item.height(), 3);
 }
 
 #[test]
 fn build_plugin_row_returns_2_line_list_item_when_marked() {
     let plugin = make_test_plugin("p");
     let item = build_plugin_row(&plugin, true, None, 80);
-    assert_eq!(item.height(), 2);
+    assert_eq!(item.height(), 3);
 }
 
 #[test]
 fn build_plugin_row_returns_2_line_list_item_when_narrow() {
     let plugin = make_test_plugin("very-long-plugin-name");
     let item = build_plugin_row(&plugin, false, None, 30);
-    assert_eq!(item.height(), 2);
+    assert_eq!(item.height(), 3);
 }
 
 #[test]
@@ -92,7 +92,7 @@ fn build_detail_action_item_returns_height_2() {
         .chain(DetailAction::for_disabled().iter())
     {
         let item = build_detail_action_item(action);
-        assert_eq!(item.height(), 2);
+        assert_eq!(item.height(), 3);
     }
 }
 
@@ -102,9 +102,9 @@ fn build_detail_action_menu_reserves_full_height_for_enabled() {
     let actions = DetailAction::for_enabled();
     let (items, rows) = build_detail_action_menu(&actions);
     assert_eq!(items.len(), actions.len());
-    assert_eq!(rows, actions.len() as u16 * 2);
+    assert_eq!(rows, actions.len() as u16 * 3);
     for item in &items {
-        assert_eq!(item.height(), 2);
+        assert_eq!(item.height(), 3);
     }
 }
 
@@ -114,9 +114,9 @@ fn build_detail_action_menu_reserves_full_height_for_disabled() {
     let actions = DetailAction::for_disabled();
     let (items, rows) = build_detail_action_menu(&actions);
     assert_eq!(items.len(), actions.len());
-    assert_eq!(rows, actions.len() as u16 * 2);
+    assert_eq!(rows, actions.len() as u16 * 3);
     for item in &items {
-        assert_eq!(item.height(), 2);
+        assert_eq!(item.height(), 3);
     }
 }
 
@@ -124,11 +124,11 @@ fn build_detail_action_menu_reserves_full_height_for_disabled() {
 fn build_component_types_item_returns_height_2() {
     use crate::component::ComponentKind;
     let item = build_component_types_item(ComponentKind::Skill, 3);
-    assert_eq!(item.height(), 2);
+    assert_eq!(item.height(), 3);
 }
 
 #[test]
 fn build_component_list_item_returns_height_2() {
     let item = build_component_list_item("my-component");
-    assert_eq!(item.height(), 2);
+    assert_eq!(item.height(), 3);
 }

--- a/src/tui/manager/screens/installed/view_test.rs
+++ b/src/tui/manager/screens/installed/view_test.rs
@@ -64,28 +64,28 @@ fn build_plugin_row_does_not_panic_at_zero_width() {
 }
 
 #[test]
-fn build_plugin_row_returns_2_line_list_item() {
+fn build_plugin_row_returns_3_line_list_item() {
     let plugin = make_test_plugin("p");
     let item = build_plugin_row(&plugin, false, None, 80);
     assert_eq!(item.height(), 3);
 }
 
 #[test]
-fn build_plugin_row_returns_2_line_list_item_when_marked() {
+fn build_plugin_row_returns_3_line_list_item_when_marked() {
     let plugin = make_test_plugin("p");
     let item = build_plugin_row(&plugin, true, None, 80);
     assert_eq!(item.height(), 3);
 }
 
 #[test]
-fn build_plugin_row_returns_2_line_list_item_when_narrow() {
+fn build_plugin_row_returns_3_line_list_item_when_narrow() {
     let plugin = make_test_plugin("very-long-plugin-name");
     let item = build_plugin_row(&plugin, false, None, 30);
     assert_eq!(item.height(), 3);
 }
 
 #[test]
-fn build_detail_action_item_returns_height_2() {
+fn build_detail_action_item_returns_height_3() {
     use crate::tui::manager::screens::installed::model::DetailAction;
     for action in DetailAction::for_enabled()
         .iter()
@@ -121,14 +121,14 @@ fn build_detail_action_menu_reserves_full_height_for_disabled() {
 }
 
 #[test]
-fn build_component_types_item_returns_height_2() {
+fn build_component_types_item_returns_height_3() {
     use crate::component::ComponentKind;
     let item = build_component_types_item(ComponentKind::Skill, 3);
     assert_eq!(item.height(), 3);
 }
 
 #[test]
-fn build_component_list_item_returns_height_2() {
+fn build_component_list_item_returns_height_3() {
     let item = build_component_list_item("my-component");
     assert_eq!(item.height(), 3);
 }

--- a/src/tui/manager/screens/installed/view_test.rs
+++ b/src/tui/manager/screens/installed/view_test.rs
@@ -66,21 +66,21 @@ fn build_plugin_row_does_not_panic_at_zero_width() {
 #[test]
 fn build_plugin_row_returns_2_line_list_item() {
     let plugin = make_test_plugin("p");
-    let item = build_plugin_row(&plugin, false, None, 80);
+    let item = build_plugin_row(&plugin, false, None, 80, false);
     assert_eq!(item.height(), 2);
 }
 
 #[test]
 fn build_plugin_row_returns_2_line_list_item_when_marked() {
     let plugin = make_test_plugin("p");
-    let item = build_plugin_row(&plugin, true, None, 80);
+    let item = build_plugin_row(&plugin, true, None, 80, false);
     assert_eq!(item.height(), 2);
 }
 
 #[test]
 fn build_plugin_row_returns_2_line_list_item_when_narrow() {
     let plugin = make_test_plugin("very-long-plugin-name");
-    let item = build_plugin_row(&plugin, false, None, 30);
+    let item = build_plugin_row(&plugin, false, None, 30, false);
     assert_eq!(item.height(), 2);
 }
 
@@ -91,7 +91,7 @@ fn build_detail_action_item_returns_height_2() {
         .iter()
         .chain(DetailAction::for_disabled().iter())
     {
-        let item = build_detail_action_item(action);
+        let item = build_detail_action_item(action, false);
         assert_eq!(item.height(), 2);
     }
 }
@@ -100,7 +100,7 @@ fn build_detail_action_item_returns_height_2() {
 fn build_detail_action_menu_reserves_full_height_for_enabled() {
     use crate::tui::manager::screens::installed::model::DetailAction;
     let actions = DetailAction::for_enabled();
-    let (items, rows) = build_detail_action_menu(&actions);
+    let (items, rows) = build_detail_action_menu(&actions, None);
     assert_eq!(items.len(), actions.len());
     assert_eq!(rows, actions.len() as u16 * 2);
     for item in &items {
@@ -112,7 +112,7 @@ fn build_detail_action_menu_reserves_full_height_for_enabled() {
 fn build_detail_action_menu_reserves_full_height_for_disabled() {
     use crate::tui::manager::screens::installed::model::DetailAction;
     let actions = DetailAction::for_disabled();
-    let (items, rows) = build_detail_action_menu(&actions);
+    let (items, rows) = build_detail_action_menu(&actions, None);
     assert_eq!(items.len(), actions.len());
     assert_eq!(rows, actions.len() as u16 * 2);
     for item in &items {
@@ -123,12 +123,12 @@ fn build_detail_action_menu_reserves_full_height_for_disabled() {
 #[test]
 fn build_component_types_item_returns_height_2() {
     use crate::component::ComponentKind;
-    let item = build_component_types_item(ComponentKind::Skill, 3);
+    let item = build_component_types_item(ComponentKind::Skill, 3, false);
     assert_eq!(item.height(), 2);
 }
 
 #[test]
 fn build_component_list_item_returns_height_2() {
-    let item = build_component_list_item("my-component");
+    let item = build_component_list_item("my-component", false);
     assert_eq!(item.height(), 2);
 }

--- a/src/tui/manager/screens/marketplaces/view.rs
+++ b/src/tui/manager/screens/marketplaces/view.rs
@@ -298,13 +298,24 @@ fn view_market_detail(
     // フィルタバー（read-only）
     render_filter_bar(f, filter_area, ctx.filter_text, ctx.filter_focused);
 
+    // アクションメニュー（先に組み立て、描画行数を算出して area を確保する）
+    let actions = DetailAction::all();
+    let items: Vec<ListItem> = actions
+        .iter()
+        .map(|a| {
+            let line_text = format!("{}{}", LIST_ITEM_INDENT, a.label());
+            ListItem::new(vec![Line::from(line_text), Line::raw("")]).style(a.style())
+        })
+        .collect();
+    let action_menu_rows: u16 = items.iter().map(|i| i.height() as u16).sum();
+
     // コンテンツ領域を画面固有に再分割（info / action_menu / error）
     let content_chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(6),            // マーケットプレイス情報
-            Constraint::Min(1),               // アクションメニュー
-            Constraint::Length(error_height), // エラー
+            Constraint::Min(1),                   // マーケットプレイス情報
+            Constraint::Length(action_menu_rows), // アクションメニュー
+            Constraint::Length(error_height),     // エラー
         ])
         .split(content_area);
 
@@ -349,16 +360,6 @@ fn view_market_detail(
 
     let info_para = Paragraph::new(info_lines).block(bordered_block(&title));
     f.render_widget(info_para, content_chunks[0]);
-
-    // アクションメニュー
-    let actions = DetailAction::all();
-    let items: Vec<ListItem> = actions
-        .iter()
-        .map(|a| {
-            let line_text = format!("{}{}", LIST_ITEM_INDENT, a.label());
-            ListItem::new(vec![Line::from(line_text), Line::raw("")]).style(a.style())
-        })
-        .collect();
 
     let list = menu_list(items);
 
@@ -990,9 +991,13 @@ fn build_browse_list_items<'a>(
         .map(|p| {
             let selected = selected_plugins.contains(&p.name);
             let (mark, style) = browse_state_block(p.installed, selected);
+            let body = match p.description.as_deref() {
+                Some(desc) if !desc.is_empty() => format!("{} — {}", p.name, desc),
+                _ => p.name.clone(),
+            };
             let spans = vec![
                 Span::styled(format!("{}{} ", LIST_ITEM_INDENT, mark), style),
-                Span::styled(&*p.name, style),
+                Span::styled(body, style),
             ];
             ListItem::new(vec![Line::from(spans), Line::raw("")])
         })

--- a/src/tui/manager/screens/marketplaces/view.rs
+++ b/src/tui/manager/screens/marketplaces/view.rs
@@ -10,8 +10,8 @@ use crate::tui::manager::core::layout::{
     framed_layout, modal_layout, outer_rect, split_horizontal,
 };
 use crate::tui::manager::core::style::{
-    bordered_block, menu_list, selectable_list, CHECKBOX_SELECTED, CHECKBOX_UNSELECTED,
-    LIST_ITEM_INDENT, MARK_MARKED, RADIO_SELECTED, RADIO_UNSELECTED,
+    bordered_block, highlight_spans, menu_list, selectable_list, CHECKBOX_SELECTED,
+    CHECKBOX_UNSELECTED, LIST_ITEM_INDENT, MARK_MARKED, RADIO_SELECTED, RADIO_UNSELECTED,
 };
 use crate::tui::manager::core::{
     render_filter_bar, truncate_for_list, truncate_for_paragraph, DataStore, Tab,
@@ -198,11 +198,14 @@ fn view_market_list(
 
     // マーケットプレイスリスト
     let title = format!(" Marketplaces ({}) ", ctx.data.marketplaces.len());
+    let selected_idx = state.selected();
+    let total_items = ctx.data.marketplaces.len() + 1; // +1 = "+ Add new marketplace"
     let mut items: Vec<ListItem> = ctx
         .data
         .marketplaces
         .iter()
-        .map(|m| {
+        .enumerate()
+        .map(|(i, m)| {
             let plugin_info = m
                 .plugin_count
                 .map(|c| format!("{} plugins", c))
@@ -219,18 +222,21 @@ fn view_market_list(
                 LIST_ITEM_INDENT, m.name, m.source, source_path_info, plugin_info, updated_info
             );
             let line_text = truncate_for_list(outer.width, raw).into_owned();
-            ListItem::new(vec![Line::from(line_text), Line::raw("")])
+            let spans = highlight_spans(vec![Span::raw(line_text)], Some(i) == selected_idx);
+            ListItem::new(vec![Line::from(spans), Line::raw("")])
         })
         .collect();
 
     // "+ Add new marketplace" 項目を末尾に追加
-    items.push(
-        ListItem::new(vec![
-            Line::from(format!("{}+ Add new marketplace", LIST_ITEM_INDENT)),
-            Line::raw(""),
-        ])
-        .style(Style::default().fg(Color::Cyan)),
+    let add_idx = total_items - 1;
+    let add_spans = highlight_spans(
+        vec![Span::styled(
+            format!("{}+ Add new marketplace", LIST_ITEM_INDENT),
+            Style::default().fg(Color::Cyan),
+        )],
+        Some(add_idx) == selected_idx,
     );
+    items.push(ListItem::new(vec![Line::from(add_spans), Line::raw("")]));
 
     let list = selectable_list(items, &title);
 
@@ -300,7 +306,7 @@ fn view_market_detail(
 
     // アクションメニュー（先に組み立て、描画行数を算出して area を確保する）
     let actions = DetailAction::all();
-    let (items, action_menu_rows) = build_market_action_menu(actions);
+    let (items, action_menu_rows) = build_market_action_menu(actions, state.selected());
 
     // コンテンツ領域を画面固有に再分割（info / action_menu / error）
     let content_chunks = Layout::default()
@@ -409,16 +415,19 @@ fn view_plugin_list(
             .style(Style::default().fg(Color::DarkGray));
         f.render_widget(content, content_area);
     } else {
+        let selected_idx = state.selected();
         let items: Vec<ListItem> = plugins
             .iter()
-            .map(|(name, desc)| {
+            .enumerate()
+            .map(|(i, (name, desc))| {
                 let raw = if let Some(description) = desc {
                     format!("{}{} - {}", LIST_ITEM_INDENT, name, description)
                 } else {
                     format!("{}{}", LIST_ITEM_INDENT, name)
                 };
                 let line_text = truncate_for_list(outer.width, raw).into_owned();
-                ListItem::new(vec![Line::from(line_text), Line::raw("")])
+                let spans = highlight_spans(vec![Span::raw(line_text)], Some(i) == selected_idx);
+                ListItem::new(vec![Line::from(spans), Line::raw("")])
             })
             .collect();
 
@@ -594,8 +603,12 @@ fn view_plugin_browse(
         f.render_widget(msg, content_area);
     } else if !should_split_layout(content_area.width) {
         // 狭い端末: リストのみ描画
-        let items =
-            build_browse_list_items(browse.plugins, browse.selected_plugins, content_area.width);
+        let items = build_browse_list_items(
+            browse.plugins,
+            browse.selected_plugins,
+            content_area.width,
+            state.selected(),
+        );
         let list = selectable_list(items, &title);
         f.render_stateful_widget(list, content_area, &mut state);
     } else {
@@ -603,8 +616,12 @@ fn view_plugin_browse(
         let [list_area, detail_area] = split_horizontal(content_area, (40, 60));
 
         // 左パネル: プラグインリスト
-        let items =
-            build_browse_list_items(browse.plugins, browse.selected_plugins, list_area.width);
+        let items = build_browse_list_items(
+            browse.plugins,
+            browse.selected_plugins,
+            list_area.width,
+            state.selected(),
+        );
         let list = selectable_list(items, &title);
         f.render_stateful_widget(list, list_area, &mut state);
 
@@ -645,7 +662,7 @@ fn view_target_select(
         ])
         .split(modal_area);
 
-    let items = build_target_list_items(targets);
+    let items = build_target_list_items(targets, state.selected());
 
     let list = selectable_list(items, " Select targets ");
 
@@ -676,7 +693,7 @@ fn view_scope_select(f: &mut Frame, highlighted_idx: usize, mut state: ListState
         ])
         .split(modal_area);
 
-    let items = build_scope_list_items(highlighted_idx);
+    let items = build_scope_list_items(highlighted_idx, state.selected());
 
     let list = selectable_list(items, " Select scope ");
 
@@ -903,13 +920,19 @@ fn target_checkbox(selected: bool) -> (&'static str, Style) {
 /// # Arguments
 ///
 /// * `targets` - Target list as `(name, display_name, selected)` tuples.
-fn build_target_list_items(targets: &[(String, String, bool)]) -> Vec<ListItem<'static>> {
+fn build_target_list_items(
+    targets: &[(String, String, bool)],
+    highlighted: Option<usize>,
+) -> Vec<ListItem<'static>> {
     targets
         .iter()
-        .map(|(_name, display_name, selected)| {
+        .enumerate()
+        .map(|(i, (_name, display_name, selected))| {
             let (mark, style) = target_checkbox(*selected);
             let line_text = format!("{}{} {}", LIST_ITEM_INDENT, mark, display_name);
-            ListItem::new(vec![Line::from(line_text), Line::raw("")]).style(style)
+            let spans =
+                highlight_spans(vec![Span::styled(line_text, style)], Some(i) == highlighted);
+            ListItem::new(vec![Line::from(spans), Line::raw("")])
         })
         .collect()
 }
@@ -932,7 +955,10 @@ fn scope_radio(is_current: bool) -> (&'static str, Style) {
 /// # Arguments
 ///
 /// * `highlighted_idx` - Currently highlighted scope index.
-fn build_scope_list_items(highlighted_idx: usize) -> Vec<ListItem<'static>> {
+fn build_scope_list_items(
+    highlighted_idx: usize,
+    highlighted: Option<usize>,
+) -> Vec<ListItem<'static>> {
     let scopes = [(Scope::Personal, "(~/.plm/)"), (Scope::Project, "(./)")];
     let clamped = highlighted_idx.min(scopes.len() - 1);
     scopes
@@ -948,26 +974,39 @@ fn build_scope_list_items(highlighted_idx: usize) -> Vec<ListItem<'static>> {
                 scope.display_name(),
                 path
             );
-            ListItem::new(vec![Line::from(line_text), Line::raw("")]).style(style)
+            let spans = highlight_spans(
+                vec![Span::styled(line_text, style)],
+                Some(idx) == highlighted,
+            );
+            ListItem::new(vec![Line::from(spans), Line::raw("")])
         })
         .collect()
 }
 
 /// `view_market_detail` の action メニュー項目を 2 行 ListItem (内容 + 空行) として構築する。
 ///
-/// 1 行目に内容、2 行目に空行を持たせて、`highlight_symbol("> ")` を内容行に
-/// 整列させつつ行間に視覚的な余白を確保する。
-/// 返される `ListItem` は所有データのみで構成されるため `'static`。
-fn build_market_action_item(action: &DetailAction) -> ListItem<'static> {
+/// `is_selected = true` のとき内容行の Span に `highlight_style()` を patch する
+/// （空行には適用しない）。返される `ListItem` は所有データのみで構成されるため `'static`。
+fn build_market_action_item(action: &DetailAction, is_selected: bool) -> ListItem<'static> {
     let line_text = format!("{}{}", LIST_ITEM_INDENT, action.label());
-    ListItem::new(vec![Line::from(line_text), Line::raw("")]).style(action.style())
+    let spans = vec![Span::styled(line_text, action.style())];
+    let spans = highlight_spans(spans, is_selected);
+    ListItem::new(vec![Line::from(spans), Line::raw("")])
 }
 
 /// `view_market_detail` の action メニュー全体を組み立て、`(items, action_menu_rows)` を返す。
 ///
 /// `action_menu_rows` は描画行数（`items.iter().map(ListItem::height).sum()`）。
-fn build_market_action_menu(actions: &[DetailAction]) -> (Vec<ListItem<'static>>, u16) {
-    let items: Vec<ListItem<'static>> = actions.iter().map(build_market_action_item).collect();
+/// `selected` は現在ハイライト中の論理 index。
+fn build_market_action_menu(
+    actions: &[DetailAction],
+    selected: Option<usize>,
+) -> (Vec<ListItem<'static>>, u16) {
+    let items: Vec<ListItem<'static>> = actions
+        .iter()
+        .enumerate()
+        .map(|(i, a)| build_market_action_item(a, Some(i) == selected))
+        .collect();
     let rows: u16 = items.iter().map(|i| i.height() as u16).sum();
     (items, rows)
 }
@@ -1000,10 +1039,12 @@ fn build_browse_list_items(
     plugins: &[BrowsePlugin],
     selected_plugins: &HashSet<String>,
     content_width: u16,
+    highlighted: Option<usize>,
 ) -> Vec<ListItem<'static>> {
     plugins
         .iter()
-        .map(|p| {
+        .enumerate()
+        .map(|(i, p)| {
             let selected = selected_plugins.contains(&p.name);
             let (mark, style) = browse_state_block(p.installed, selected);
             let raw = match p.description.as_deref() {
@@ -1013,10 +1054,9 @@ fn build_browse_list_items(
                 _ => format!("{}{} {}", LIST_ITEM_INDENT, mark, p.name),
             };
             let line_text = truncate_for_list(content_width, raw).into_owned();
-            ListItem::new(vec![
-                Line::from(Span::styled(line_text, style)),
-                Line::raw(""),
-            ])
+            let spans =
+                highlight_spans(vec![Span::styled(line_text, style)], Some(i) == highlighted);
+            ListItem::new(vec![Line::from(spans), Line::raw("")])
         })
         .collect()
 }

--- a/src/tui/manager/screens/marketplaces/view.rs
+++ b/src/tui/manager/screens/marketplaces/view.rs
@@ -219,13 +219,14 @@ fn view_market_list(
                 LIST_ITEM_INDENT, m.name, m.source, source_path_info, plugin_info, updated_info
             );
             let line_text = truncate_for_list(outer.width, raw).into_owned();
-            ListItem::new(vec![Line::from(line_text), Line::raw("")])
+            ListItem::new(vec![Line::raw(""), Line::from(line_text), Line::raw("")])
         })
         .collect();
 
     // "+ Add new marketplace" 項目を末尾に追加
     items.push(
         ListItem::new(vec![
+            Line::raw(""),
             Line::from(format!("{}+ Add new marketplace", LIST_ITEM_INDENT)),
             Line::raw(""),
         ])
@@ -418,7 +419,7 @@ fn view_plugin_list(
                     format!("{}{}", LIST_ITEM_INDENT, name)
                 };
                 let line_text = truncate_for_list(outer.width, raw).into_owned();
-                ListItem::new(vec![Line::from(line_text), Line::raw("")])
+                ListItem::new(vec![Line::raw(""), Line::from(line_text), Line::raw("")])
             })
             .collect();
 
@@ -907,7 +908,7 @@ fn build_target_list_items(targets: &[(String, String, bool)]) -> Vec<ListItem<'
         .map(|(_name, display_name, selected)| {
             let (mark, style) = target_checkbox(*selected);
             let line_text = format!("{}{} {}", LIST_ITEM_INDENT, mark, display_name);
-            ListItem::new(vec![Line::from(line_text), Line::raw("")]).style(style)
+            ListItem::new(vec![Line::raw(""), Line::from(line_text), Line::raw("")]).style(style)
         })
         .collect()
 }
@@ -946,17 +947,18 @@ fn build_scope_list_items(highlighted_idx: usize) -> Vec<ListItem<'static>> {
                 scope.display_name(),
                 path
             );
-            ListItem::new(vec![Line::from(line_text), Line::raw("")]).style(style)
+            ListItem::new(vec![Line::raw(""), Line::from(line_text), Line::raw("")]).style(style)
         })
         .collect()
 }
 
-/// `view_market_detail` の action メニュー項目を 2 行 ListItem として構築する。
+/// `view_market_detail` の action メニュー項目を 3 行 ListItem (上下空行 + 内容) として構築する。
 ///
+/// 内容行を上下空行で挟むことで、強調表示時に文字が縦中央に来る。
 /// 返される `ListItem` は所有データのみで構成されるため `'static`。
 fn build_market_action_item(action: &DetailAction) -> ListItem<'static> {
     let line_text = format!("{}{}", LIST_ITEM_INDENT, action.label());
-    ListItem::new(vec![Line::from(line_text), Line::raw("")]).style(action.style())
+    ListItem::new(vec![Line::raw(""), Line::from(line_text), Line::raw("")]).style(action.style())
 }
 
 /// `view_market_detail` の action メニュー全体を組み立て、`(items, action_menu_rows)` を返す。
@@ -1009,7 +1011,7 @@ fn build_browse_list_items<'a>(
                 Span::styled(format!("{}{} ", LIST_ITEM_INDENT, mark), style),
                 Span::styled(body, style),
             ];
-            ListItem::new(vec![Line::from(spans), Line::raw("")])
+            ListItem::new(vec![Line::raw(""), Line::from(spans), Line::raw("")])
         })
         .collect()
 }

--- a/src/tui/manager/screens/marketplaces/view.rs
+++ b/src/tui/manager/screens/marketplaces/view.rs
@@ -300,13 +300,7 @@ fn view_market_detail(
 
     // アクションメニュー（先に組み立て、描画行数を算出して area を確保する）
     let actions = DetailAction::all();
-    let items: Vec<ListItem> = actions
-        .iter()
-        .map(|a| {
-            let line_text = format!("{}{}", LIST_ITEM_INDENT, a.label());
-            ListItem::new(vec![Line::from(line_text), Line::raw("")]).style(a.style())
-        })
-        .collect();
+    let items: Vec<ListItem> = actions.iter().map(build_market_action_item).collect();
     let action_menu_rows: u16 = items.iter().map(|i| i.height() as u16).sum();
 
     // コンテンツ領域を画面固有に再分割（info / action_menu / error）
@@ -956,6 +950,12 @@ fn build_scope_list_items(highlighted_idx: usize) -> Vec<ListItem<'static>> {
             ListItem::new(vec![Line::from(line_text), Line::raw("")]).style(style)
         })
         .collect()
+}
+
+/// `view_market_detail` の action メニュー項目を 2 行 ListItem として構築する。
+fn build_market_action_item<'a>(action: &DetailAction) -> ListItem<'a> {
+    let line_text = format!("{}{}", LIST_ITEM_INDENT, action.label());
+    ListItem::new(vec![Line::from(line_text), Line::raw("")]).style(action.style())
 }
 
 /// Browse 行の状態ブロックとスタイルを決定（installed / selected / idle の 3 状態）。

--- a/src/tui/manager/screens/marketplaces/view.rs
+++ b/src/tui/manager/screens/marketplaces/view.rs
@@ -6,12 +6,18 @@ use super::model::{
 };
 use crate::component::Scope;
 use crate::marketplace::PluginSource;
+use crate::tui::manager::core::layout::{
+    framed_layout, modal_layout, outer_rect, split_horizontal,
+};
+use crate::tui::manager::core::style::{
+    bordered_block, menu_list, selectable_list, CHECKBOX_SELECTED, CHECKBOX_UNSELECTED,
+    LIST_ITEM_INDENT, MARK_MARKED, RADIO_SELECTED, RADIO_UNSELECTED,
+};
 use crate::tui::manager::core::{
-    content_rect, render_filter_bar, truncate_for_list, truncate_for_paragraph, DataStore, Tab,
-    HORIZONTAL_PADDING,
+    render_filter_bar, truncate_for_list, truncate_for_paragraph, DataStore, Tab,
 };
 use ratatui::prelude::*;
-use ratatui::widgets::{Block, Borders, Clear, Gauge, List, ListItem, ListState, Paragraph, Tabs};
+use ratatui::widgets::{Block, Borders, Clear, Gauge, ListItem, ListState, Paragraph, Tabs};
 use std::collections::HashSet;
 
 /// 描画用共通コンテキスト（DataStore + フィルタ情報）
@@ -170,24 +176,16 @@ fn view_market_list(
     let has_error = error_message.is_some();
     let extra_lines = if has_status { 1 } else { 0 } + if has_error { 1 } else { 0 };
 
-    let outer = content_rect(f.area(), HORIZONTAL_PADDING);
+    let outer = outer_rect(f.area());
     f.render_widget(Clear, outer);
 
-    let chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Length(1), // タブバー
-            Constraint::Length(3), // フィルタバー
-            Constraint::Min(1),    // コンテンツ
-            Constraint::Length(1), // ヘルプ
-        ])
-        .split(outer);
+    let [tabs_area, filter_area, content_area, help_area] = framed_layout(outer);
 
     // タブバー
-    render_tab_bar(f, chunks[0]);
+    render_tab_bar(f, tabs_area);
 
     // フィルタバー
-    render_filter_bar(f, chunks[1], ctx.filter_text, ctx.filter_focused);
+    render_filter_bar(f, filter_area, ctx.filter_text, ctx.filter_focused);
 
     // コンテンツ領域を分割（リスト + ステータス/エラー）
     let content_chunks = Layout::default()
@@ -196,7 +194,7 @@ fn view_market_list(
             Constraint::Min(1),              // リスト
             Constraint::Length(extra_lines), // ステータス/エラー
         ])
-        .split(chunks[2]);
+        .split(content_area);
 
     // マーケットプレイスリスト
     let title = format!(" Marketplaces ({}) ", ctx.data.marketplaces.len());
@@ -217,24 +215,24 @@ fn view_market_list(
                 .unwrap_or_default();
 
             let raw = format!(
-                "  {}    {}{}    {}    {}",
-                m.name, m.source, source_path_info, plugin_info, updated_info
+                "{}{}    {}{}    {}    {}",
+                LIST_ITEM_INDENT, m.name, m.source, source_path_info, plugin_info, updated_info
             );
-            ListItem::new(truncate_for_list(outer.width, raw))
+            let line_text = truncate_for_list(outer.width, raw).into_owned();
+            ListItem::new(vec![Line::from(line_text), Line::raw("")])
         })
         .collect();
 
     // "+ Add new marketplace" 項目を末尾に追加
-    items.push(ListItem::new("  + Add new marketplace").style(Style::default().fg(Color::Cyan)));
+    items.push(
+        ListItem::new(vec![
+            Line::from(format!("{}+ Add new marketplace", LIST_ITEM_INDENT)),
+            Line::raw(""),
+        ])
+        .style(Style::default().fg(Color::Cyan)),
+    );
 
-    let list = List::new(items)
-        .block(Block::default().title(title).borders(Borders::ALL))
-        .highlight_style(
-            Style::default()
-                .add_modifier(Modifier::BOLD)
-                .fg(Color::Green),
-        )
-        .highlight_symbol("> ");
+    let list = selectable_list(items, &title);
 
     f.render_stateful_widget(list, content_chunks[0], &mut state);
 
@@ -267,7 +265,7 @@ fn view_market_list(
         " u: update | U: update all | Tab: switch | ↑↓: move | Enter: select | q: quit",
     )
     .style(Style::default().fg(Color::DarkGray));
-    f.render_widget(help, chunks[3]);
+    f.render_widget(help, help_area);
 }
 
 /// マーケットプレイス詳細画面を描画
@@ -286,29 +284,29 @@ fn view_market_detail(
     ctx: &ViewCtx<'_>,
     error_message: &Option<String>,
 ) {
-    let outer = content_rect(f.area(), HORIZONTAL_PADDING);
+    let outer = outer_rect(f.area());
     f.render_widget(Clear, outer);
 
     let has_error = error_message.is_some();
     let error_height = if has_error { 1 } else { 0 };
 
-    let chunks = Layout::default()
+    let [tabs_area, filter_area, content_area, help_area] = framed_layout(outer);
+
+    // タブバー
+    render_tab_bar(f, tabs_area);
+
+    // フィルタバー（read-only）
+    render_filter_bar(f, filter_area, ctx.filter_text, ctx.filter_focused);
+
+    // コンテンツ領域を画面固有に再分割（info / action_menu / error）
+    let content_chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(1),            // タブバー
-            Constraint::Length(3),            // フィルタバー
             Constraint::Length(6),            // マーケットプレイス情報
             Constraint::Min(1),               // アクションメニュー
             Constraint::Length(error_height), // エラー
-            Constraint::Length(1),            // ヘルプ
         ])
-        .split(outer);
-
-    // タブバー
-    render_tab_bar(f, chunks[0]);
-
-    // フィルタバー（read-only）
-    render_filter_bar(f, chunks[1], ctx.filter_text, ctx.filter_focused);
+        .split(content_area);
 
     // マーケットプレイス情報
     let marketplace = ctx.data.find_marketplace(marketplace_name);
@@ -349,34 +347,34 @@ fn view_market_detail(
         ))]
     };
 
-    let info_block = Block::default().title(title).borders(Borders::ALL);
-    let info_para = Paragraph::new(info_lines).block(info_block);
-    f.render_widget(info_para, chunks[2]);
+    let info_para = Paragraph::new(info_lines).block(bordered_block(&title));
+    f.render_widget(info_para, content_chunks[0]);
 
     // アクションメニュー
     let actions = DetailAction::all();
     let items: Vec<ListItem> = actions
         .iter()
-        .map(|a| ListItem::new(format!("  {}", a.label())).style(a.style()))
+        .map(|a| {
+            let line_text = format!("{}{}", LIST_ITEM_INDENT, a.label());
+            ListItem::new(vec![Line::from(line_text), Line::raw("")]).style(a.style())
+        })
         .collect();
 
-    let list = List::new(items)
-        .highlight_style(Style::default().add_modifier(Modifier::BOLD))
-        .highlight_symbol("> ");
+    let list = menu_list(items);
 
-    f.render_stateful_widget(list, chunks[3], &mut state);
+    f.render_stateful_widget(list, content_chunks[1], &mut state);
 
     // エラー表示
     if let Some(error) = error_message {
         let error_para =
             Paragraph::new(format!(" {}", error)).style(Style::default().fg(Color::Red));
-        f.render_widget(error_para, chunks[4]);
+        f.render_widget(error_para, content_chunks[2]);
     }
 
     // ヘルプ
     let help = Paragraph::new(" ↑↓: move | Enter: select | Esc: back")
         .style(Style::default().fg(Color::DarkGray));
-    f.render_widget(help, chunks[5]);
+    f.render_widget(help, help_area);
 }
 
 /// プラグイン一覧画面を描画
@@ -395,24 +393,16 @@ fn view_plugin_list(
     plugins: &[(String, Option<String>)],
     filter: &FilterCtx<'_>,
 ) {
-    let outer = content_rect(f.area(), HORIZONTAL_PADDING);
+    let outer = outer_rect(f.area());
     f.render_widget(Clear, outer);
 
-    let chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Length(1), // タブバー
-            Constraint::Length(3), // フィルタバー
-            Constraint::Min(1),    // コンテンツ
-            Constraint::Length(1), // ヘルプ
-        ])
-        .split(outer);
+    let [tabs_area, filter_area, content_area, help_area] = framed_layout(outer);
 
     // タブバー
-    render_tab_bar(f, chunks[0]);
+    render_tab_bar(f, tabs_area);
 
     // フィルタバー（read-only）
-    render_filter_bar(f, chunks[1], filter.text, filter.focused);
+    render_filter_bar(f, filter_area, filter.text, filter.focused);
 
     // プラグインリスト
     let title = format!(" {} > Plugins ({}) ", marketplace_name, plugins.len());
@@ -421,37 +411,31 @@ fn view_plugin_list(
         // 空リスト表示
         let msg = "  No cached data. Run update to fetch plugins.";
         let content = Paragraph::new(msg)
-            .block(Block::default().title(title).borders(Borders::ALL))
+            .block(bordered_block(&title))
             .style(Style::default().fg(Color::DarkGray));
-        f.render_widget(content, chunks[2]);
+        f.render_widget(content, content_area);
     } else {
         let items: Vec<ListItem> = plugins
             .iter()
             .map(|(name, desc)| {
                 let raw = if let Some(description) = desc {
-                    format!("  {} - {}", name, description)
+                    format!("{}{} - {}", LIST_ITEM_INDENT, name, description)
                 } else {
-                    format!("  {}", name)
+                    format!("{}{}", LIST_ITEM_INDENT, name)
                 };
-                ListItem::new(truncate_for_list(outer.width, raw))
+                let line_text = truncate_for_list(outer.width, raw).into_owned();
+                ListItem::new(vec![Line::from(line_text), Line::raw("")])
             })
             .collect();
 
-        let list = List::new(items)
-            .block(Block::default().title(title).borders(Borders::ALL))
-            .highlight_style(
-                Style::default()
-                    .add_modifier(Modifier::BOLD)
-                    .fg(Color::Green),
-            )
-            .highlight_symbol("> ");
+        let list = selectable_list(items, &title);
 
-        f.render_stateful_widget(list, chunks[2], &mut state);
+        f.render_stateful_widget(list, content_area, &mut state);
     }
 
     // ヘルプ
     let help = Paragraph::new(" ↑↓: move | Esc: back").style(Style::default().fg(Color::DarkGray));
-    f.render_widget(help, chunks[3]);
+    f.render_widget(help, help_area);
 }
 
 /// 追加フォーム画面を描画
@@ -463,24 +447,16 @@ fn view_plugin_list(
 /// * `filter_text` - Current filter input text.
 /// * `filter_focused` - Whether the filter bar currently has focus.
 fn view_add_form(f: &mut Frame, form: &AddFormModel, filter_text: &str, filter_focused: bool) {
-    let outer = content_rect(f.area(), HORIZONTAL_PADDING);
+    let outer = outer_rect(f.area());
     f.render_widget(Clear, outer);
 
-    let chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Length(1), // タブバー
-            Constraint::Length(3), // フィルタバー
-            Constraint::Min(1),    // コンテンツ
-            Constraint::Length(1), // ヘルプ
-        ])
-        .split(outer);
+    let [tabs_area, filter_area, content_area, help_area] = framed_layout(outer);
 
     // タブバー
-    render_tab_bar(f, chunks[0]);
+    render_tab_bar(f, tabs_area);
 
     // フィルタバー（read-only）
-    render_filter_bar(f, chunks[1], filter_text, filter_focused);
+    render_filter_bar(f, filter_area, filter_text, filter_focused);
 
     // フォームコンテンツ
     match form {
@@ -507,12 +483,8 @@ fn view_add_form(f: &mut Frame, form: &AddFormModel, filter_text: &str, filter_f
                     Style::default().fg(Color::Red),
                 )));
             }
-            let content = Paragraph::new(lines).block(
-                Block::default()
-                    .title(" Add Marketplace ")
-                    .borders(Borders::ALL),
-            );
-            f.render_widget(content, chunks[2]);
+            let content = Paragraph::new(lines).block(bordered_block(" Add Marketplace "));
+            f.render_widget(content, content_area);
         }
         AddFormModel::Name {
             source,
@@ -547,12 +519,8 @@ fn view_add_form(f: &mut Frame, form: &AddFormModel, filter_text: &str, filter_f
                     Style::default().fg(Color::Red),
                 )));
             }
-            let content = Paragraph::new(lines).block(
-                Block::default()
-                    .title(" Add Marketplace ")
-                    .borders(Borders::ALL),
-            );
-            f.render_widget(content, chunks[2]);
+            let content = Paragraph::new(lines).block(bordered_block(" Add Marketplace "));
+            f.render_widget(content, content_area);
         }
         AddFormModel::Confirm {
             source,
@@ -584,19 +552,15 @@ fn view_add_form(f: &mut Frame, form: &AddFormModel, filter_text: &str, filter_f
                     Style::default().fg(Color::Red),
                 )));
             }
-            let content = Paragraph::new(lines).block(
-                Block::default()
-                    .title(" Add Marketplace ")
-                    .borders(Borders::ALL),
-            );
-            f.render_widget(content, chunks[2]);
+            let content = Paragraph::new(lines).block(bordered_block(" Add Marketplace "));
+            f.render_widget(content, content_area);
         }
     }
 
     // ヘルプ
     let help = Paragraph::new(" Type to input | Enter: next | Esc: cancel")
         .style(Style::default().fg(Color::DarkGray));
-    f.render_widget(help, chunks[3]);
+    f.render_widget(help, help_area);
 }
 
 /// プラグインブラウズ画面を描画
@@ -615,66 +579,48 @@ fn view_plugin_browse(
     mut state: ListState,
     filter: &FilterCtx<'_>,
 ) {
-    let outer = content_rect(f.area(), HORIZONTAL_PADDING);
+    let outer = outer_rect(f.area());
     f.render_widget(Clear, outer);
 
-    let chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Length(1), // タブバー
-            Constraint::Length(3), // フィルタバー
-            Constraint::Min(1),    // コンテンツ
-            Constraint::Length(1), // ヘルプ
-        ])
-        .split(outer);
+    let [tabs_area, filter_area, content_area, help_area] = framed_layout(outer);
 
     // タブバー
-    render_tab_bar(f, chunks[0]);
+    render_tab_bar(f, tabs_area);
 
     // フィルタバー
-    render_filter_bar(f, chunks[1], filter.text, filter.focused);
+    render_filter_bar(f, filter_area, filter.text, filter.focused);
 
     // コンテンツ領域
     let title = format!(" {} > Browse ({}) ", marketplace_name, browse.plugins.len());
-    let content_area = chunks[2];
 
     if browse.plugins.is_empty() {
         let msg = Paragraph::new("  No plugins available.")
-            .block(Block::default().title(title).borders(Borders::ALL))
+            .block(bordered_block(&title))
             .style(Style::default().fg(Color::DarkGray));
         f.render_widget(msg, content_area);
     } else if !should_split_layout(content_area.width) {
         // 狭い端末: リストのみ描画
         let items = build_browse_list_items(browse.plugins, browse.selected_plugins);
-        let list = List::new(items)
-            .block(Block::default().title(title).borders(Borders::ALL))
-            .highlight_style(Style::default().add_modifier(Modifier::BOLD | Modifier::REVERSED))
-            .highlight_symbol("> ");
+        let list = selectable_list(items, &title);
         f.render_stateful_widget(list, content_area, &mut state);
     } else {
         // 水平分割レイアウト（40% リスト / 60% 詳細）
-        let h_chunks = Layout::default()
-            .direction(Direction::Horizontal)
-            .constraints([Constraint::Percentage(40), Constraint::Percentage(60)])
-            .split(content_area);
+        let [list_area, detail_area] = split_horizontal(content_area, (40, 60));
 
         // 左パネル: プラグインリスト
         let items = build_browse_list_items(browse.plugins, browse.selected_plugins);
-        let list = List::new(items)
-            .block(Block::default().title(title).borders(Borders::ALL))
-            .highlight_style(Style::default().add_modifier(Modifier::BOLD | Modifier::REVERSED))
-            .highlight_symbol("> ");
-        f.render_stateful_widget(list, h_chunks[0], &mut state);
+        let list = selectable_list(items, &title);
+        f.render_stateful_widget(list, list_area, &mut state);
 
         // 右パネル: プラグイン詳細（state.selected() から導出して一貫性を保つ）
         let detail_idx = state.selected().unwrap_or(browse.highlighted_idx);
-        render_plugin_detail(f, browse.plugins, detail_idx, h_chunks[1]);
+        render_plugin_detail(f, browse.plugins, detail_idx, detail_area);
     }
 
     // ヘルプ
     let help = Paragraph::new(" Space: select | Enter/i: install | Esc: back | q: quit")
         .style(Style::default().fg(Color::DarkGray));
-    f.render_widget(help, chunks[3]);
+    f.render_widget(help, help_area);
 }
 
 /// ターゲット選択画面を描画
@@ -691,14 +637,8 @@ fn view_target_select(
     _highlighted_idx: usize,
     mut state: ListState,
 ) {
-    let outer = content_rect(f.area(), HORIZONTAL_PADDING);
-    let dialog_height = (targets.len() as u16 + 5).min(16);
-    let modal_area = Rect::new(
-        outer.x,
-        outer.y,
-        outer.width,
-        dialog_height.min(outer.height),
-    );
+    let outer = outer_rect(f.area());
+    let modal_area = modal_layout(outer, 60, 60);
     f.render_widget(Clear, modal_area);
 
     let chunks = Layout::default()
@@ -711,14 +651,7 @@ fn view_target_select(
 
     let items = build_target_list_items(targets);
 
-    let list = List::new(items)
-        .block(
-            Block::default()
-                .title(" Select targets ")
-                .borders(Borders::ALL),
-        )
-        .highlight_style(Style::default().add_modifier(Modifier::BOLD))
-        .highlight_symbol("> ");
+    let list = selectable_list(items, " Select targets ");
 
     f.render_stateful_widget(list, chunks[0], &mut state);
 
@@ -735,14 +668,8 @@ fn view_target_select(
 /// * `highlighted_idx` - Currently highlighted scope index.
 /// * `state` - List state used for scope highlight.
 fn view_scope_select(f: &mut Frame, highlighted_idx: usize, mut state: ListState) {
-    let outer = content_rect(f.area(), HORIZONTAL_PADDING);
-    let dialog_height = 8u16;
-    let modal_area = Rect::new(
-        outer.x,
-        outer.y,
-        outer.width,
-        dialog_height.min(outer.height),
-    );
+    let outer = outer_rect(f.area());
+    let modal_area = modal_layout(outer, 60, 50);
     f.render_widget(Clear, modal_area);
 
     let chunks = Layout::default()
@@ -755,14 +682,7 @@ fn view_scope_select(f: &mut Frame, highlighted_idx: usize, mut state: ListState
 
     let items = build_scope_list_items(highlighted_idx);
 
-    let list = List::new(items)
-        .block(
-            Block::default()
-                .title(" Select scope ")
-                .borders(Borders::ALL),
-        )
-        .highlight_style(Style::default().add_modifier(Modifier::BOLD))
-        .highlight_symbol("> ");
+    let list = selectable_list(items, " Select scope ");
 
     f.render_stateful_widget(list, chunks[0], &mut state);
 
@@ -780,14 +700,8 @@ fn view_scope_select(f: &mut Frame, highlighted_idx: usize, mut state: ListState
 /// * `current_idx` - Index of the plugin currently being processed.
 /// * `total` - Total number of plugins in this install batch.
 fn view_installing(f: &mut Frame, plugin_names: &[String], current_idx: usize, total: usize) {
-    let outer = content_rect(f.area(), HORIZONTAL_PADDING);
-    let dialog_height = 7u16;
-    let modal_area = Rect::new(
-        outer.x,
-        outer.y,
-        outer.width,
-        dialog_height.min(outer.height),
-    );
+    let outer = outer_rect(f.area());
+    let modal_area = modal_layout(outer, 70, 40);
     f.render_widget(Clear, modal_area);
 
     let chunks = Layout::default()
@@ -857,16 +771,8 @@ fn format_install_result_line(result: &PluginInstallResult) -> (String, Color) {
 /// * `f` - Ratatui frame to draw into.
 /// * `summary` - Aggregated install summary to display.
 fn view_install_result(f: &mut Frame, summary: &InstallSummary) {
-    let content_height = (summary.results.len() as u16 + 5).min(20);
-    let dialog_height = content_height + 3;
-
-    let outer = content_rect(f.area(), HORIZONTAL_PADDING);
-    let modal_area = Rect::new(
-        outer.x,
-        outer.y,
-        outer.width,
-        dialog_height.min(outer.height),
-    );
+    let outer = outer_rect(f.area());
+    let modal_area = modal_layout(outer, 80, 70);
     f.render_widget(Clear, modal_area);
 
     let chunks = Layout::default()
@@ -896,11 +802,7 @@ fn view_install_result(f: &mut Frame, summary: &InstallSummary) {
 
     lines.push(Line::raw(""));
 
-    let content = Paragraph::new(lines).block(
-        Block::default()
-            .title(" Install Result ")
-            .borders(Borders::ALL),
-    );
+    let content = Paragraph::new(lines).block(bordered_block(" Install Result "));
     f.render_widget(content, chunks[0]);
 
     let help =
@@ -922,7 +824,7 @@ fn render_plugin_detail(
     highlighted_idx: usize,
     area: Rect,
 ) {
-    let detail_block = Block::default().title(" Detail ").borders(Borders::ALL);
+    let detail_block = bordered_block(" Detail ");
 
     if let Some(plugin) = plugins.get(highlighted_idx) {
         let source_text = match &plugin.source {
@@ -991,9 +893,9 @@ fn should_split_layout(width: u16) -> bool {
 /// * `selected` - Whether the target is currently selected.
 fn target_checkbox(selected: bool) -> (&'static str, Style) {
     if selected {
-        ("[x] ", Style::default().fg(Color::Yellow))
+        (CHECKBOX_SELECTED, Style::default().fg(Color::Yellow))
     } else {
-        ("[ ] ", Style::default())
+        (CHECKBOX_UNSELECTED, Style::default())
     }
 }
 
@@ -1007,7 +909,8 @@ fn build_target_list_items(targets: &[(String, String, bool)]) -> Vec<ListItem<'
         .iter()
         .map(|(_name, display_name, selected)| {
             let (mark, style) = target_checkbox(*selected);
-            ListItem::new(format!("  {}{}", mark, display_name)).style(style)
+            let line_text = format!("{}{} {}", LIST_ITEM_INDENT, mark, display_name);
+            ListItem::new(vec![Line::from(line_text), Line::raw("")]).style(style)
         })
         .collect()
 }
@@ -1019,9 +922,9 @@ fn build_target_list_items(targets: &[(String, String, bool)]) -> Vec<ListItem<'
 /// * `is_current` - Whether this scope is the currently highlighted one.
 fn scope_radio(is_current: bool) -> (&'static str, Style) {
     if is_current {
-        ("(x) ", Style::default().fg(Color::Yellow))
+        (RADIO_SELECTED, Style::default().fg(Color::Yellow))
     } else {
-        ("( ) ", Style::default())
+        (RADIO_UNSELECTED, Style::default())
     }
 }
 
@@ -1039,24 +942,33 @@ fn build_scope_list_items(highlighted_idx: usize) -> Vec<ListItem<'static>> {
         .map(|(idx, (scope, path))| {
             let is_current = idx == clamped;
             let (mark, style) = scope_radio(is_current);
-            ListItem::new(format!("  {}{} {}", mark, scope.display_name(), path)).style(style)
+            let line_text = format!(
+                "{}{} {} {}",
+                LIST_ITEM_INDENT,
+                mark,
+                scope.display_name(),
+                path
+            );
+            ListItem::new(vec![Line::from(line_text), Line::raw("")]).style(style)
         })
         .collect()
 }
 
-/// チェックボックスのマークとスタイルを決定
+/// Browse 行の状態ブロックとスタイルを決定（installed / selected / idle の 3 状態）。
+///
+/// 判定優先度: `installed` > `selected` > `idle`。
 ///
 /// # Arguments
 ///
 /// * `installed` - Whether the plugin is already installed.
 /// * `selected` - Whether the plugin is currently selected for install.
-fn browse_checkbox(installed: bool, selected: bool) -> (&'static str, Style) {
+fn browse_state_block(installed: bool, selected: bool) -> (&'static str, Style) {
     if installed {
-        ("[x] ", Style::default().fg(Color::DarkGray))
+        (MARK_MARKED, Style::default().fg(Color::DarkGray))
     } else if selected {
-        ("[x] ", Style::default().fg(Color::Yellow))
+        (CHECKBOX_SELECTED, Style::default().fg(Color::Yellow))
     } else {
-        ("[ ] ", Style::default())
+        (CHECKBOX_UNSELECTED, Style::default())
     }
 }
 
@@ -1074,12 +986,12 @@ fn build_browse_list_items<'a>(
         .iter()
         .map(|p| {
             let selected = selected_plugins.contains(&p.name);
-            let (mark, style) = browse_checkbox(p.installed, selected);
+            let (mark, style) = browse_state_block(p.installed, selected);
             let spans = vec![
-                Span::styled(format!("  {}", mark), style),
+                Span::styled(format!("{}{} ", LIST_ITEM_INDENT, mark), style),
                 Span::styled(&*p.name, style),
             ];
-            ListItem::new(Line::from(spans))
+            ListItem::new(vec![Line::from(spans), Line::raw("")])
         })
         .collect()
 }

--- a/src/tui/manager/screens/marketplaces/view.rs
+++ b/src/tui/manager/screens/marketplaces/view.rs
@@ -952,7 +952,9 @@ fn build_scope_list_items(highlighted_idx: usize) -> Vec<ListItem<'static>> {
 }
 
 /// `view_market_detail` の action メニュー項目を 2 行 ListItem として構築する。
-fn build_market_action_item<'a>(action: &DetailAction) -> ListItem<'a> {
+///
+/// 返される `ListItem` は所有データのみで構成されるため `'static`。
+fn build_market_action_item(action: &DetailAction) -> ListItem<'static> {
     let line_text = format!("{}{}", LIST_ITEM_INDENT, action.label());
     ListItem::new(vec![Line::from(line_text), Line::raw("")]).style(action.style())
 }
@@ -960,8 +962,8 @@ fn build_market_action_item<'a>(action: &DetailAction) -> ListItem<'a> {
 /// `view_market_detail` の action メニュー全体を組み立て、`(items, action_menu_rows)` を返す。
 ///
 /// `action_menu_rows` は描画行数（`items.iter().map(ListItem::height).sum()`）。
-fn build_market_action_menu<'a>(actions: &[DetailAction]) -> (Vec<ListItem<'a>>, u16) {
-    let items: Vec<ListItem> = actions.iter().map(build_market_action_item).collect();
+fn build_market_action_menu(actions: &[DetailAction]) -> (Vec<ListItem<'static>>, u16) {
+    let items: Vec<ListItem<'static>> = actions.iter().map(build_market_action_item).collect();
     let rows: u16 = items.iter().map(|i| i.height() as u16).sum();
     (items, rows)
 }

--- a/src/tui/manager/screens/marketplaces/view.rs
+++ b/src/tui/manager/screens/marketplaces/view.rs
@@ -300,8 +300,7 @@ fn view_market_detail(
 
     // アクションメニュー（先に組み立て、描画行数を算出して area を確保する）
     let actions = DetailAction::all();
-    let items: Vec<ListItem> = actions.iter().map(build_market_action_item).collect();
-    let action_menu_rows: u16 = items.iter().map(|i| i.height() as u16).sum();
+    let (items, action_menu_rows) = build_market_action_menu(&actions);
 
     // コンテンツ領域を画面固有に再分割（info / action_menu / error）
     let content_chunks = Layout::default()
@@ -956,6 +955,15 @@ fn build_scope_list_items(highlighted_idx: usize) -> Vec<ListItem<'static>> {
 fn build_market_action_item<'a>(action: &DetailAction) -> ListItem<'a> {
     let line_text = format!("{}{}", LIST_ITEM_INDENT, action.label());
     ListItem::new(vec![Line::from(line_text), Line::raw("")]).style(action.style())
+}
+
+/// `view_market_detail` の action メニュー全体を組み立て、`(items, action_menu_rows)` を返す。
+///
+/// `action_menu_rows` は描画行数（`items.iter().map(ListItem::height).sum()`）。
+fn build_market_action_menu<'a>(actions: &[DetailAction]) -> (Vec<ListItem<'a>>, u16) {
+    let items: Vec<ListItem> = actions.iter().map(build_market_action_item).collect();
+    let rows: u16 = items.iter().map(|i| i.height() as u16).sum();
+    (items, rows)
 }
 
 /// Browse 行の状態ブロックとスタイルを決定（installed / selected / idle の 3 状態）。

--- a/src/tui/manager/screens/marketplaces/view.rs
+++ b/src/tui/manager/screens/marketplaces/view.rs
@@ -177,7 +177,7 @@ fn view_market_list(
     let extra_lines = if has_status { 1 } else { 0 } + if has_error { 1 } else { 0 };
 
     let outer = outer_rect(f.area());
-    f.render_widget(Clear, outer);
+    f.render_widget(Clear, f.area());
 
     let [tabs_area, filter_area, content_area, help_area] = framed_layout(outer);
 
@@ -286,7 +286,7 @@ fn view_market_detail(
     error_message: &Option<String>,
 ) {
     let outer = outer_rect(f.area());
-    f.render_widget(Clear, outer);
+    f.render_widget(Clear, f.area());
 
     let has_error = error_message.is_some();
     let error_height = if has_error { 1 } else { 0 };
@@ -389,7 +389,7 @@ fn view_plugin_list(
     filter: &FilterCtx<'_>,
 ) {
     let outer = outer_rect(f.area());
-    f.render_widget(Clear, outer);
+    f.render_widget(Clear, f.area());
 
     let [tabs_area, filter_area, content_area, help_area] = framed_layout(outer);
 
@@ -443,7 +443,7 @@ fn view_plugin_list(
 /// * `filter_focused` - Whether the filter bar currently has focus.
 fn view_add_form(f: &mut Frame, form: &AddFormModel, filter_text: &str, filter_focused: bool) {
     let outer = outer_rect(f.area());
-    f.render_widget(Clear, outer);
+    f.render_widget(Clear, f.area());
 
     let [tabs_area, filter_area, content_area, help_area] = framed_layout(outer);
 
@@ -575,7 +575,7 @@ fn view_plugin_browse(
     filter: &FilterCtx<'_>,
 ) {
     let outer = outer_rect(f.area());
-    f.render_widget(Clear, outer);
+    f.render_widget(Clear, f.area());
 
     let [tabs_area, filter_area, content_area, help_area] = framed_layout(outer);
 

--- a/src/tui/manager/screens/marketplaces/view.rs
+++ b/src/tui/manager/screens/marketplaces/view.rs
@@ -793,7 +793,7 @@ fn view_install_result(f: &mut Frame, summary: &InstallSummary) {
     for result in &summary.results {
         let (raw, color) = format_install_result_line(result);
         lines.push(Line::from(Span::styled(
-            truncate_for_paragraph(outer.width, raw),
+            truncate_for_paragraph(modal_area.width, raw),
             Style::default().fg(color),
         )));
     }
@@ -1003,9 +1003,12 @@ fn build_browse_list_items<'a>(
         .map(|p| {
             let selected = selected_plugins.contains(&p.name);
             let (mark, style) = browse_state_block(p.installed, selected);
-            let body = match p.description.as_deref() {
-                Some(desc) if !desc.is_empty() => format!("{} — {}", p.name, desc),
-                _ => p.name.clone(),
+            // description が空でない場合のみ "name — desc" を確保。それ以外は p.name を借用。
+            let body: std::borrow::Cow<'a, str> = match p.description.as_deref() {
+                Some(desc) if !desc.is_empty() => {
+                    std::borrow::Cow::Owned(format!("{} — {}", p.name, desc))
+                }
+                _ => std::borrow::Cow::Borrowed(p.name.as_str()),
             };
             let spans = vec![
                 Span::styled(format!("{}{} ", LIST_ITEM_INDENT, mark), style),

--- a/src/tui/manager/screens/marketplaces/view.rs
+++ b/src/tui/manager/screens/marketplaces/view.rs
@@ -219,14 +219,13 @@ fn view_market_list(
                 LIST_ITEM_INDENT, m.name, m.source, source_path_info, plugin_info, updated_info
             );
             let line_text = truncate_for_list(outer.width, raw).into_owned();
-            ListItem::new(vec![Line::raw(""), Line::from(line_text), Line::raw("")])
+            ListItem::new(vec![Line::from(line_text), Line::raw("")])
         })
         .collect();
 
     // "+ Add new marketplace" 項目を末尾に追加
     items.push(
         ListItem::new(vec![
-            Line::raw(""),
             Line::from(format!("{}+ Add new marketplace", LIST_ITEM_INDENT)),
             Line::raw(""),
         ])
@@ -419,7 +418,7 @@ fn view_plugin_list(
                     format!("{}{}", LIST_ITEM_INDENT, name)
                 };
                 let line_text = truncate_for_list(outer.width, raw).into_owned();
-                ListItem::new(vec![Line::raw(""), Line::from(line_text), Line::raw("")])
+                ListItem::new(vec![Line::from(line_text), Line::raw("")])
             })
             .collect();
 
@@ -908,7 +907,7 @@ fn build_target_list_items(targets: &[(String, String, bool)]) -> Vec<ListItem<'
         .map(|(_name, display_name, selected)| {
             let (mark, style) = target_checkbox(*selected);
             let line_text = format!("{}{} {}", LIST_ITEM_INDENT, mark, display_name);
-            ListItem::new(vec![Line::raw(""), Line::from(line_text), Line::raw("")]).style(style)
+            ListItem::new(vec![Line::from(line_text), Line::raw("")]).style(style)
         })
         .collect()
 }
@@ -947,18 +946,19 @@ fn build_scope_list_items(highlighted_idx: usize) -> Vec<ListItem<'static>> {
                 scope.display_name(),
                 path
             );
-            ListItem::new(vec![Line::raw(""), Line::from(line_text), Line::raw("")]).style(style)
+            ListItem::new(vec![Line::from(line_text), Line::raw("")]).style(style)
         })
         .collect()
 }
 
-/// `view_market_detail` の action メニュー項目を 3 行 ListItem (上下空行 + 内容) として構築する。
+/// `view_market_detail` の action メニュー項目を 2 行 ListItem (内容 + 空行) として構築する。
 ///
-/// 内容行を上下空行で挟むことで、強調表示時に文字が縦中央に来る。
+/// 1 行目に内容、2 行目に空行を持たせて、`highlight_symbol("> ")` を内容行に
+/// 整列させつつ行間に視覚的な余白を確保する。
 /// 返される `ListItem` は所有データのみで構成されるため `'static`。
 fn build_market_action_item(action: &DetailAction) -> ListItem<'static> {
     let line_text = format!("{}{}", LIST_ITEM_INDENT, action.label());
-    ListItem::new(vec![Line::raw(""), Line::from(line_text), Line::raw("")]).style(action.style())
+    ListItem::new(vec![Line::from(line_text), Line::raw("")]).style(action.style())
 }
 
 /// `view_market_detail` の action メニュー全体を組み立て、`(items, action_menu_rows)` を返す。
@@ -1014,7 +1014,7 @@ fn build_browse_list_items<'a>(
                 Span::styled(format!("{}{} ", LIST_ITEM_INDENT, mark), style),
                 Span::styled(body, style),
             ];
-            ListItem::new(vec![Line::raw(""), Line::from(spans), Line::raw("")])
+            ListItem::new(vec![Line::from(spans), Line::raw("")])
         })
         .collect()
 }

--- a/src/tui/manager/screens/marketplaces/view.rs
+++ b/src/tui/manager/screens/marketplaces/view.rs
@@ -10,7 +10,7 @@ use crate::tui::manager::core::layout::{
     framed_layout, modal_layout, outer_rect, split_horizontal,
 };
 use crate::tui::manager::core::style::{
-    bordered_block, highlight_spans, menu_list, selectable_list, CHECKBOX_SELECTED,
+    bordered_block, highlight_line, menu_list, selectable_list, CHECKBOX_SELECTED,
     CHECKBOX_UNSELECTED, LIST_ITEM_INDENT, MARK_MARKED, RADIO_SELECTED, RADIO_UNSELECTED,
 };
 use crate::tui::manager::core::{
@@ -222,21 +222,21 @@ fn view_market_list(
                 LIST_ITEM_INDENT, m.name, m.source, source_path_info, plugin_info, updated_info
             );
             let line_text = truncate_for_list(outer.width, raw).into_owned();
-            let spans = highlight_spans(vec![Span::raw(line_text)], Some(i) == selected_idx);
-            ListItem::new(vec![Line::from(spans), Line::raw("")])
+            let line = highlight_line(vec![Span::raw(line_text)], Some(i) == selected_idx);
+            ListItem::new(vec![line, Line::raw("")])
         })
         .collect();
 
     // "+ Add new marketplace" 項目を末尾に追加
     let add_idx = total_items - 1;
-    let add_spans = highlight_spans(
+    let add_line = highlight_line(
         vec![Span::styled(
             format!("{}+ Add new marketplace", LIST_ITEM_INDENT),
             Style::default().fg(Color::Cyan),
         )],
         Some(add_idx) == selected_idx,
     );
-    items.push(ListItem::new(vec![Line::from(add_spans), Line::raw("")]));
+    items.push(ListItem::new(vec![add_line, Line::raw("")]));
 
     let list = selectable_list(items, &title);
 
@@ -426,8 +426,8 @@ fn view_plugin_list(
                     format!("{}{}", LIST_ITEM_INDENT, name)
                 };
                 let line_text = truncate_for_list(outer.width, raw).into_owned();
-                let spans = highlight_spans(vec![Span::raw(line_text)], Some(i) == selected_idx);
-                ListItem::new(vec![Line::from(spans), Line::raw("")])
+                let line = highlight_line(vec![Span::raw(line_text)], Some(i) == selected_idx);
+                ListItem::new(vec![line, Line::raw("")])
             })
             .collect();
 
@@ -930,9 +930,8 @@ fn build_target_list_items(
         .map(|(i, (_name, display_name, selected))| {
             let (mark, style) = target_checkbox(*selected);
             let line_text = format!("{}{} {}", LIST_ITEM_INDENT, mark, display_name);
-            let spans =
-                highlight_spans(vec![Span::styled(line_text, style)], Some(i) == highlighted);
-            ListItem::new(vec![Line::from(spans), Line::raw("")])
+            let line = highlight_line(vec![Span::styled(line_text, style)], Some(i) == highlighted);
+            ListItem::new(vec![line, Line::raw("")])
         })
         .collect()
 }
@@ -974,24 +973,23 @@ fn build_scope_list_items(
                 scope.display_name(),
                 path
             );
-            let spans = highlight_spans(
+            let line = highlight_line(
                 vec![Span::styled(line_text, style)],
                 Some(idx) == highlighted,
             );
-            ListItem::new(vec![Line::from(spans), Line::raw("")])
+            ListItem::new(vec![line, Line::raw("")])
         })
         .collect()
 }
 
 /// `view_market_detail` の action メニュー項目を 2 行 ListItem (内容 + 空行) として構築する。
 ///
-/// `is_selected = true` のとき内容行の Span に `highlight_style()` を patch する
+/// `is_selected = true` のとき内容行に `highlight_style()` を適用する
 /// （空行には適用しない）。返される `ListItem` は所有データのみで構成されるため `'static`。
 fn build_market_action_item(action: &DetailAction, is_selected: bool) -> ListItem<'static> {
     let line_text = format!("{}{}", LIST_ITEM_INDENT, action.label());
     let spans = vec![Span::styled(line_text, action.style())];
-    let spans = highlight_spans(spans, is_selected);
-    ListItem::new(vec![Line::from(spans), Line::raw("")])
+    ListItem::new(vec![highlight_line(spans, is_selected), Line::raw("")])
 }
 
 /// `view_market_detail` の action メニュー全体を組み立て、`(items, action_menu_rows)` を返す。
@@ -1054,9 +1052,8 @@ fn build_browse_list_items(
                 _ => format!("{}{} {}", LIST_ITEM_INDENT, mark, p.name),
             };
             let line_text = truncate_for_list(content_width, raw).into_owned();
-            let spans =
-                highlight_spans(vec![Span::styled(line_text, style)], Some(i) == highlighted);
-            ListItem::new(vec![Line::from(spans), Line::raw("")])
+            let line = highlight_line(vec![Span::styled(line_text, style)], Some(i) == highlighted);
+            ListItem::new(vec![line, Line::raw("")])
         })
         .collect()
 }

--- a/src/tui/manager/screens/marketplaces/view.rs
+++ b/src/tui/manager/screens/marketplaces/view.rs
@@ -594,7 +594,8 @@ fn view_plugin_browse(
         f.render_widget(msg, content_area);
     } else if !should_split_layout(content_area.width) {
         // 狭い端末: リストのみ描画
-        let items = build_browse_list_items(browse.plugins, browse.selected_plugins);
+        let items =
+            build_browse_list_items(browse.plugins, browse.selected_plugins, content_area.width);
         let list = selectable_list(items, &title);
         f.render_stateful_widget(list, content_area, &mut state);
     } else {
@@ -602,7 +603,8 @@ fn view_plugin_browse(
         let [list_area, detail_area] = split_horizontal(content_area, (40, 60));
 
         // 左パネル: プラグインリスト
-        let items = build_browse_list_items(browse.plugins, browse.selected_plugins);
+        let items =
+            build_browse_list_items(browse.plugins, browse.selected_plugins, list_area.width);
         let list = selectable_list(items, &title);
         f.render_stateful_widget(list, list_area, &mut state);
 
@@ -994,27 +996,27 @@ fn browse_state_block(installed: bool, selected: bool) -> (&'static str, Style) 
 ///
 /// * `plugins` - Browse plugin list to render.
 /// * `selected_plugins` - Plugin names currently selected for install.
-fn build_browse_list_items<'a>(
-    plugins: &'a [BrowsePlugin],
+fn build_browse_list_items(
+    plugins: &[BrowsePlugin],
     selected_plugins: &HashSet<String>,
-) -> Vec<ListItem<'a>> {
+    content_width: u16,
+) -> Vec<ListItem<'static>> {
     plugins
         .iter()
         .map(|p| {
             let selected = selected_plugins.contains(&p.name);
             let (mark, style) = browse_state_block(p.installed, selected);
-            // description が空でない場合のみ "name — desc" を確保。それ以外は p.name を借用。
-            let body: std::borrow::Cow<'a, str> = match p.description.as_deref() {
+            let raw = match p.description.as_deref() {
                 Some(desc) if !desc.is_empty() => {
-                    std::borrow::Cow::Owned(format!("{} — {}", p.name, desc))
+                    format!("{}{} {} — {}", LIST_ITEM_INDENT, mark, p.name, desc)
                 }
-                _ => std::borrow::Cow::Borrowed(p.name.as_str()),
+                _ => format!("{}{} {}", LIST_ITEM_INDENT, mark, p.name),
             };
-            let spans = vec![
-                Span::styled(format!("{}{} ", LIST_ITEM_INDENT, mark), style),
-                Span::styled(body, style),
-            ];
-            ListItem::new(vec![Line::from(spans), Line::raw("")])
+            let line_text = truncate_for_list(content_width, raw).into_owned();
+            ListItem::new(vec![
+                Line::from(Span::styled(line_text, style)),
+                Line::raw(""),
+            ])
         })
         .collect()
 }

--- a/src/tui/manager/screens/marketplaces/view.rs
+++ b/src/tui/manager/screens/marketplaces/view.rs
@@ -735,7 +735,10 @@ fn view_installing(f: &mut Frame, plugin_names: &[String], current_idx: usize, t
 
     let text = Paragraph::new(lines).block(
         Block::default()
-            .title(" Installing ")
+            .title(Span::styled(
+                " Installing ",
+                Style::default().add_modifier(Modifier::BOLD),
+            ))
             .borders(Borders::TOP | Borders::LEFT | Borders::RIGHT),
     );
     f.render_widget(text, inner_chunks[0]);

--- a/src/tui/manager/screens/marketplaces/view.rs
+++ b/src/tui/manager/screens/marketplaces/view.rs
@@ -300,7 +300,7 @@ fn view_market_detail(
 
     // アクションメニュー（先に組み立て、描画行数を算出して area を確保する）
     let actions = DetailAction::all();
-    let (items, action_menu_rows) = build_market_action_menu(&actions);
+    let (items, action_menu_rows) = build_market_action_menu(actions);
 
     // コンテンツ領域を画面固有に再分割（info / action_menu / error）
     let content_chunks = Layout::default()

--- a/src/tui/manager/screens/marketplaces/view_test.rs
+++ b/src/tui/manager/screens/marketplaces/view_test.rs
@@ -82,7 +82,7 @@ fn make_plugin(name: &str, installed: bool) -> BrowsePlugin {
 fn build_browse_list_items_empty() {
     let plugins: Vec<BrowsePlugin> = vec![];
     let selected = HashSet::new();
-    let items = build_browse_list_items(&plugins, &selected, 80);
+    let items = build_browse_list_items(&plugins, &selected, 80, None);
     assert!(items.is_empty());
 }
 
@@ -95,7 +95,7 @@ fn build_browse_list_items_returns_correct_count() {
     ];
     let mut selected = HashSet::new();
     selected.insert("b".to_string());
-    let items = build_browse_list_items(&plugins, &selected, 80);
+    let items = build_browse_list_items(&plugins, &selected, 80, None);
     assert_eq!(items.len(), 3);
 }
 
@@ -105,8 +105,8 @@ fn build_browse_list_items_respects_selected_plugins() {
     let mut selected = HashSet::new();
     selected.insert("alpha".to_string());
 
-    let items_with_selection = build_browse_list_items(&plugins, &selected, 80);
-    let items_without_selection = build_browse_list_items(&plugins, &HashSet::new(), 80);
+    let items_with_selection = build_browse_list_items(&plugins, &selected, 80, None);
+    let items_without_selection = build_browse_list_items(&plugins, &HashSet::new(), 80, None);
 
     assert_eq!(items_with_selection.len(), 2);
     assert_eq!(items_without_selection.len(), 2);
@@ -117,7 +117,7 @@ fn build_browse_list_items_respects_selected_plugins() {
 #[test]
 fn build_browse_list_items_have_height_2() {
     let plugins = vec![make_plugin("a", false), make_plugin("b", true)];
-    let items = build_browse_list_items(&plugins, &HashSet::new(), 80);
+    let items = build_browse_list_items(&plugins, &HashSet::new(), 80, None);
     for item in &items {
         assert_eq!(item.height(), 2);
     }
@@ -164,14 +164,18 @@ fn scope_radio_not_current() {
 // =============================================================================
 
 fn target_item(mark: &str, label: &str, style: Style) -> ListItem<'static> {
+    use ratatui::text::Span;
     let line_text = format!("{}{} {}", LIST_ITEM_INDENT, mark, label);
-    ListItem::new(vec![Line::from(line_text), Line::raw("")]).style(style)
+    ListItem::new(vec![
+        Line::from(Span::styled(line_text, style)),
+        Line::raw(""),
+    ])
 }
 
 #[test]
 fn build_target_list_items_empty() {
     let targets: Vec<(String, String, bool)> = vec![];
-    let items = build_target_list_items(&targets);
+    let items = build_target_list_items(&targets, None);
     assert!(items.is_empty());
 }
 
@@ -181,7 +185,7 @@ fn build_target_list_items_all_selected() {
         ("codex".to_string(), "Codex".to_string(), true),
         ("copilot".to_string(), "Copilot".to_string(), true),
     ];
-    let items = build_target_list_items(&targets);
+    let items = build_target_list_items(&targets, None);
     assert_eq!(items.len(), 2);
     let yellow = Style::default().fg(Color::Yellow);
     assert_eq!(items[0], target_item(CHECKBOX_SELECTED, "Codex", yellow));
@@ -194,7 +198,7 @@ fn build_target_list_items_none_selected() {
         ("codex".to_string(), "Codex".to_string(), false),
         ("copilot".to_string(), "Copilot".to_string(), false),
     ];
-    let items = build_target_list_items(&targets);
+    let items = build_target_list_items(&targets, None);
     assert_eq!(items.len(), 2);
     let default = Style::default();
     assert_eq!(items[0], target_item(CHECKBOX_UNSELECTED, "Codex", default));
@@ -210,7 +214,7 @@ fn build_target_list_items_mixed() {
         ("codex".to_string(), "Codex".to_string(), true),
         ("copilot".to_string(), "Copilot".to_string(), false),
     ];
-    let items = build_target_list_items(&targets);
+    let items = build_target_list_items(&targets, None);
     assert_eq!(items.len(), 2);
     assert_ne!(items[0], items[1]);
     assert_eq!(
@@ -230,7 +234,7 @@ fn build_target_list_items_mixed() {
 #[test]
 fn build_target_list_items_have_height_2() {
     let targets = vec![("codex".to_string(), "Codex".to_string(), true)];
-    let items = build_target_list_items(&targets);
+    let items = build_target_list_items(&targets, None);
     for item in &items {
         assert_eq!(item.height(), 2);
     }
@@ -241,6 +245,7 @@ fn build_target_list_items_have_height_2() {
 // =============================================================================
 
 fn scope_item(mark: &str, scope: Scope, path: &str, style: Style) -> ListItem<'static> {
+    use ratatui::text::Span;
     let line_text = format!(
         "{}{} {} {}",
         LIST_ITEM_INDENT,
@@ -248,12 +253,15 @@ fn scope_item(mark: &str, scope: Scope, path: &str, style: Style) -> ListItem<'s
         scope.display_name(),
         path
     );
-    ListItem::new(vec![Line::from(line_text), Line::raw("")]).style(style)
+    ListItem::new(vec![
+        Line::from(Span::styled(line_text, style)),
+        Line::raw(""),
+    ])
 }
 
 #[test]
 fn build_scope_list_items_personal_selected() {
-    let items = build_scope_list_items(0);
+    let items = build_scope_list_items(0, None);
     assert_eq!(items.len(), 2);
     let yellow = Style::default().fg(Color::Yellow);
     assert_eq!(
@@ -268,7 +276,7 @@ fn build_scope_list_items_personal_selected() {
 
 #[test]
 fn build_scope_list_items_project_selected() {
-    let items = build_scope_list_items(1);
+    let items = build_scope_list_items(1, None);
     assert_eq!(items.len(), 2);
     let yellow = Style::default().fg(Color::Yellow);
     assert_eq!(
@@ -288,7 +296,7 @@ fn build_scope_list_items_project_selected() {
 
 #[test]
 fn build_scope_list_items_out_of_range_clamps_to_last() {
-    let items = build_scope_list_items(99);
+    let items = build_scope_list_items(99, None);
     assert_eq!(items.len(), 2);
     let yellow = Style::default().fg(Color::Yellow);
     assert_eq!(
@@ -308,7 +316,7 @@ fn build_scope_list_items_out_of_range_clamps_to_last() {
 
 #[test]
 fn build_scope_list_items_have_height_2() {
-    let items = build_scope_list_items(0);
+    let items = build_scope_list_items(0, None);
     for item in &items {
         assert_eq!(item.height(), 2);
     }
@@ -321,7 +329,7 @@ fn build_scope_list_items_have_height_2() {
 #[test]
 fn build_market_action_item_returns_height_2() {
     for action in super::DetailAction::all().iter() {
-        let item = build_market_action_item(action);
+        let item = build_market_action_item(action, false);
         assert_eq!(item.height(), 2);
     }
 }
@@ -329,7 +337,7 @@ fn build_market_action_item_returns_height_2() {
 #[test]
 fn build_market_action_menu_reserves_full_height() {
     let actions = super::DetailAction::all();
-    let (items, rows) = build_market_action_menu(actions);
+    let (items, rows) = build_market_action_menu(actions, None);
     assert_eq!(items.len(), actions.len());
     assert_eq!(rows, actions.len() as u16 * 2);
     for item in &items {

--- a/src/tui/manager/screens/marketplaces/view_test.rs
+++ b/src/tui/manager/screens/marketplaces/view_test.rs
@@ -327,11 +327,12 @@ fn build_market_action_item_returns_height_2() {
 }
 
 #[test]
-fn view_market_detail_action_menu_renders_all_actions_with_2line_items() {
+fn build_market_action_menu_reserves_full_height() {
     let actions = super::DetailAction::all();
-    let total: u16 = actions
-        .iter()
-        .map(|a| build_market_action_item(a).height() as u16)
-        .sum();
-    assert_eq!(total, actions.len() as u16 * 2);
+    let (items, rows) = build_market_action_menu(&actions);
+    assert_eq!(items.len(), actions.len());
+    assert_eq!(rows, actions.len() as u16 * 2);
+    for item in &items {
+        assert_eq!(item.height(), 2);
+    }
 }

--- a/src/tui/manager/screens/marketplaces/view_test.rs
+++ b/src/tui/manager/screens/marketplaces/view_test.rs
@@ -82,7 +82,7 @@ fn make_plugin(name: &str, installed: bool) -> BrowsePlugin {
 fn build_browse_list_items_empty() {
     let plugins: Vec<BrowsePlugin> = vec![];
     let selected = HashSet::new();
-    let items = build_browse_list_items(&plugins, &selected);
+    let items = build_browse_list_items(&plugins, &selected, 80);
     assert!(items.is_empty());
 }
 
@@ -95,7 +95,7 @@ fn build_browse_list_items_returns_correct_count() {
     ];
     let mut selected = HashSet::new();
     selected.insert("b".to_string());
-    let items = build_browse_list_items(&plugins, &selected);
+    let items = build_browse_list_items(&plugins, &selected, 80);
     assert_eq!(items.len(), 3);
 }
 
@@ -105,8 +105,8 @@ fn build_browse_list_items_respects_selected_plugins() {
     let mut selected = HashSet::new();
     selected.insert("alpha".to_string());
 
-    let items_with_selection = build_browse_list_items(&plugins, &selected);
-    let items_without_selection = build_browse_list_items(&plugins, &HashSet::new());
+    let items_with_selection = build_browse_list_items(&plugins, &selected, 80);
+    let items_without_selection = build_browse_list_items(&plugins, &HashSet::new(), 80);
 
     assert_eq!(items_with_selection.len(), 2);
     assert_eq!(items_without_selection.len(), 2);
@@ -117,7 +117,7 @@ fn build_browse_list_items_respects_selected_plugins() {
 #[test]
 fn build_browse_list_items_have_height_2() {
     let plugins = vec![make_plugin("a", false), make_plugin("b", true)];
-    let items = build_browse_list_items(&plugins, &HashSet::new());
+    let items = build_browse_list_items(&plugins, &HashSet::new(), 80);
     for item in &items {
         assert_eq!(item.height(), 2);
     }

--- a/src/tui/manager/screens/marketplaces/view_test.rs
+++ b/src/tui/manager/screens/marketplaces/view_test.rs
@@ -115,7 +115,7 @@ fn build_browse_list_items_respects_selected_plugins() {
 }
 
 #[test]
-fn build_browse_list_items_have_height_2() {
+fn build_browse_list_items_have_height_3() {
     let plugins = vec![make_plugin("a", false), make_plugin("b", true)];
     let items = build_browse_list_items(&plugins, &HashSet::new());
     for item in &items {
@@ -228,7 +228,7 @@ fn build_target_list_items_mixed() {
 }
 
 #[test]
-fn build_target_list_items_have_height_2() {
+fn build_target_list_items_have_height_3() {
     let targets = vec![("codex".to_string(), "Codex".to_string(), true)];
     let items = build_target_list_items(&targets);
     for item in &items {
@@ -307,7 +307,7 @@ fn build_scope_list_items_out_of_range_clamps_to_last() {
 }
 
 #[test]
-fn build_scope_list_items_have_height_2() {
+fn build_scope_list_items_have_height_3() {
     let items = build_scope_list_items(0);
     for item in &items {
         assert_eq!(item.height(), 3);
@@ -319,7 +319,7 @@ fn build_scope_list_items_have_height_2() {
 // =============================================================================
 
 #[test]
-fn build_market_action_item_returns_height_2() {
+fn build_market_action_item_returns_height_3() {
     for action in super::DetailAction::all().iter() {
         let item = build_market_action_item(action);
         assert_eq!(item.height(), 3);

--- a/src/tui/manager/screens/marketplaces/view_test.rs
+++ b/src/tui/manager/screens/marketplaces/view_test.rs
@@ -115,11 +115,11 @@ fn build_browse_list_items_respects_selected_plugins() {
 }
 
 #[test]
-fn build_browse_list_items_have_height_3() {
+fn build_browse_list_items_have_height_2() {
     let plugins = vec![make_plugin("a", false), make_plugin("b", true)];
     let items = build_browse_list_items(&plugins, &HashSet::new());
     for item in &items {
-        assert_eq!(item.height(), 3);
+        assert_eq!(item.height(), 2);
     }
 }
 
@@ -165,7 +165,7 @@ fn scope_radio_not_current() {
 
 fn target_item(mark: &str, label: &str, style: Style) -> ListItem<'static> {
     let line_text = format!("{}{} {}", LIST_ITEM_INDENT, mark, label);
-    ListItem::new(vec![Line::raw(""), Line::from(line_text), Line::raw("")]).style(style)
+    ListItem::new(vec![Line::from(line_text), Line::raw("")]).style(style)
 }
 
 #[test]
@@ -228,11 +228,11 @@ fn build_target_list_items_mixed() {
 }
 
 #[test]
-fn build_target_list_items_have_height_3() {
+fn build_target_list_items_have_height_2() {
     let targets = vec![("codex".to_string(), "Codex".to_string(), true)];
     let items = build_target_list_items(&targets);
     for item in &items {
-        assert_eq!(item.height(), 3);
+        assert_eq!(item.height(), 2);
     }
 }
 
@@ -248,7 +248,7 @@ fn scope_item(mark: &str, scope: Scope, path: &str, style: Style) -> ListItem<'s
         scope.display_name(),
         path
     );
-    ListItem::new(vec![Line::raw(""), Line::from(line_text), Line::raw("")]).style(style)
+    ListItem::new(vec![Line::from(line_text), Line::raw("")]).style(style)
 }
 
 #[test]
@@ -307,10 +307,10 @@ fn build_scope_list_items_out_of_range_clamps_to_last() {
 }
 
 #[test]
-fn build_scope_list_items_have_height_3() {
+fn build_scope_list_items_have_height_2() {
     let items = build_scope_list_items(0);
     for item in &items {
-        assert_eq!(item.height(), 3);
+        assert_eq!(item.height(), 2);
     }
 }
 
@@ -319,10 +319,10 @@ fn build_scope_list_items_have_height_3() {
 // =============================================================================
 
 #[test]
-fn build_market_action_item_returns_height_3() {
+fn build_market_action_item_returns_height_2() {
     for action in super::DetailAction::all().iter() {
         let item = build_market_action_item(action);
-        assert_eq!(item.height(), 3);
+        assert_eq!(item.height(), 2);
     }
 }
 
@@ -331,8 +331,8 @@ fn build_market_action_menu_reserves_full_height() {
     let actions = super::DetailAction::all();
     let (items, rows) = build_market_action_menu(actions);
     assert_eq!(items.len(), actions.len());
-    assert_eq!(rows, actions.len() as u16 * 3);
+    assert_eq!(rows, actions.len() as u16 * 2);
     for item in &items {
-        assert_eq!(item.height(), 3);
+        assert_eq!(item.height(), 2);
     }
 }

--- a/src/tui/manager/screens/marketplaces/view_test.rs
+++ b/src/tui/manager/screens/marketplaces/view_test.rs
@@ -329,7 +329,7 @@ fn build_market_action_item_returns_height_2() {
 #[test]
 fn build_market_action_menu_reserves_full_height() {
     let actions = super::DetailAction::all();
-    let (items, rows) = build_market_action_menu(&actions);
+    let (items, rows) = build_market_action_menu(actions);
     assert_eq!(items.len(), actions.len());
     assert_eq!(rows, actions.len() as u16 * 2);
     for item in &items {

--- a/src/tui/manager/screens/marketplaces/view_test.rs
+++ b/src/tui/manager/screens/marketplaces/view_test.rs
@@ -119,7 +119,7 @@ fn build_browse_list_items_have_height_2() {
     let plugins = vec![make_plugin("a", false), make_plugin("b", true)];
     let items = build_browse_list_items(&plugins, &HashSet::new());
     for item in &items {
-        assert_eq!(item.height(), 2);
+        assert_eq!(item.height(), 3);
     }
 }
 
@@ -165,7 +165,7 @@ fn scope_radio_not_current() {
 
 fn target_item(mark: &str, label: &str, style: Style) -> ListItem<'static> {
     let line_text = format!("{}{} {}", LIST_ITEM_INDENT, mark, label);
-    ListItem::new(vec![Line::from(line_text), Line::raw("")]).style(style)
+    ListItem::new(vec![Line::raw(""), Line::from(line_text), Line::raw("")]).style(style)
 }
 
 #[test]
@@ -232,7 +232,7 @@ fn build_target_list_items_have_height_2() {
     let targets = vec![("codex".to_string(), "Codex".to_string(), true)];
     let items = build_target_list_items(&targets);
     for item in &items {
-        assert_eq!(item.height(), 2);
+        assert_eq!(item.height(), 3);
     }
 }
 
@@ -248,7 +248,7 @@ fn scope_item(mark: &str, scope: Scope, path: &str, style: Style) -> ListItem<'s
         scope.display_name(),
         path
     );
-    ListItem::new(vec![Line::from(line_text), Line::raw("")]).style(style)
+    ListItem::new(vec![Line::raw(""), Line::from(line_text), Line::raw("")]).style(style)
 }
 
 #[test]
@@ -310,7 +310,7 @@ fn build_scope_list_items_out_of_range_clamps_to_last() {
 fn build_scope_list_items_have_height_2() {
     let items = build_scope_list_items(0);
     for item in &items {
-        assert_eq!(item.height(), 2);
+        assert_eq!(item.height(), 3);
     }
 }
 
@@ -322,7 +322,7 @@ fn build_scope_list_items_have_height_2() {
 fn build_market_action_item_returns_height_2() {
     for action in super::DetailAction::all().iter() {
         let item = build_market_action_item(action);
-        assert_eq!(item.height(), 2);
+        assert_eq!(item.height(), 3);
     }
 }
 
@@ -331,8 +331,8 @@ fn build_market_action_menu_reserves_full_height() {
     let actions = super::DetailAction::all();
     let (items, rows) = build_market_action_menu(actions);
     assert_eq!(items.len(), actions.len());
-    assert_eq!(rows, actions.len() as u16 * 2);
+    assert_eq!(rows, actions.len() as u16 * 3);
     for item in &items {
-        assert_eq!(item.height(), 2);
+        assert_eq!(item.height(), 3);
     }
 }

--- a/src/tui/manager/screens/marketplaces/view_test.rs
+++ b/src/tui/manager/screens/marketplaces/view_test.rs
@@ -1,7 +1,11 @@
 use super::*;
 use crate::component::Scope;
 use crate::marketplace::PluginSource;
-use ratatui::prelude::{Color, Style};
+use crate::tui::manager::core::style::{
+    CHECKBOX_SELECTED, CHECKBOX_UNSELECTED, LIST_ITEM_INDENT, MARK_MARKED, RADIO_SELECTED,
+    RADIO_UNSELECTED,
+};
+use ratatui::prelude::{Color, Line, Style};
 use std::collections::HashSet;
 
 // =============================================================================
@@ -29,35 +33,34 @@ fn should_split_layout_returns_true_above_threshold() {
 }
 
 // =============================================================================
-// browse_checkbox
+// browse_state_block
 // =============================================================================
 
 #[test]
-fn browse_checkbox_installed() {
-    let (mark, style) = browse_checkbox(true, false);
-    assert_eq!(mark, "[x] ");
+fn browse_state_block_installed() {
+    let (mark, style) = browse_state_block(true, false);
+    assert_eq!(mark, MARK_MARKED);
     assert_eq!(style, Style::default().fg(Color::DarkGray));
 }
 
 #[test]
-fn browse_checkbox_installed_and_selected() {
-    // installed が優先される
-    let (mark, style) = browse_checkbox(true, true);
-    assert_eq!(mark, "[x] ");
+fn browse_state_block_installed_takes_precedence_over_selected() {
+    let (mark, style) = browse_state_block(true, true);
+    assert_eq!(mark, MARK_MARKED);
     assert_eq!(style, Style::default().fg(Color::DarkGray));
 }
 
 #[test]
-fn browse_checkbox_selected() {
-    let (mark, style) = browse_checkbox(false, true);
-    assert_eq!(mark, "[x] ");
+fn browse_state_block_selected() {
+    let (mark, style) = browse_state_block(false, true);
+    assert_eq!(mark, CHECKBOX_SELECTED);
     assert_eq!(style, Style::default().fg(Color::Yellow));
 }
 
 #[test]
-fn browse_checkbox_unselected() {
-    let (mark, style) = browse_checkbox(false, false);
-    assert_eq!(mark, "[ ] ");
+fn browse_state_block_idle() {
+    let (mark, style) = browse_state_block(false, false);
+    assert_eq!(mark, CHECKBOX_UNSELECTED);
     assert_eq!(style, Style::default());
 }
 
@@ -102,16 +105,22 @@ fn build_browse_list_items_respects_selected_plugins() {
     let mut selected = HashSet::new();
     selected.insert("alpha".to_string());
 
-    // selected に含まれるプラグインと含まれないプラグインで異なるアイテムが生成される
     let items_with_selection = build_browse_list_items(&plugins, &selected);
     let items_without_selection = build_browse_list_items(&plugins, &HashSet::new());
 
-    // 選択状態が異なるため、生成されるアイテムも異なるはず
     assert_eq!(items_with_selection.len(), 2);
     assert_eq!(items_without_selection.len(), 2);
 
-    // "alpha" は selected に含まれるため、選択あり/なしでアイテムが異なることを確認する
     assert_ne!(items_with_selection[0], items_without_selection[0]);
+}
+
+#[test]
+fn build_browse_list_items_have_height_2() {
+    let plugins = vec![make_plugin("a", false), make_plugin("b", true)];
+    let items = build_browse_list_items(&plugins, &HashSet::new());
+    for item in &items {
+        assert_eq!(item.height(), 2);
+    }
 }
 
 // =============================================================================
@@ -121,14 +130,14 @@ fn build_browse_list_items_respects_selected_plugins() {
 #[test]
 fn target_checkbox_selected() {
     let (mark, style) = target_checkbox(true);
-    assert_eq!(mark, "[x] ");
+    assert_eq!(mark, CHECKBOX_SELECTED);
     assert_eq!(style, Style::default().fg(Color::Yellow));
 }
 
 #[test]
 fn target_checkbox_unselected() {
     let (mark, style) = target_checkbox(false);
-    assert_eq!(mark, "[ ] ");
+    assert_eq!(mark, CHECKBOX_UNSELECTED);
     assert_eq!(style, Style::default());
 }
 
@@ -139,20 +148,25 @@ fn target_checkbox_unselected() {
 #[test]
 fn scope_radio_current() {
     let (mark, style) = scope_radio(true);
-    assert_eq!(mark, "(x) ");
+    assert_eq!(mark, RADIO_SELECTED);
     assert_eq!(style, Style::default().fg(Color::Yellow));
 }
 
 #[test]
 fn scope_radio_not_current() {
     let (mark, style) = scope_radio(false);
-    assert_eq!(mark, "( ) ");
+    assert_eq!(mark, RADIO_UNSELECTED);
     assert_eq!(style, Style::default());
 }
 
 // =============================================================================
 // build_target_list_items
 // =============================================================================
+
+fn target_item(mark: &str, label: &str, style: Style) -> ListItem<'static> {
+    let line_text = format!("{}{} {}", LIST_ITEM_INDENT, mark, label);
+    ListItem::new(vec![Line::from(line_text), Line::raw("")]).style(style)
+}
 
 #[test]
 fn build_target_list_items_empty() {
@@ -169,13 +183,9 @@ fn build_target_list_items_all_selected() {
     ];
     let items = build_target_list_items(&targets);
     assert_eq!(items.len(), 2);
-    // All items should match Yellow-styled selected items
-    let expected_0 =
-        ListItem::new("  [x] Codex".to_string()).style(Style::default().fg(Color::Yellow));
-    let expected_1 =
-        ListItem::new("  [x] Copilot".to_string()).style(Style::default().fg(Color::Yellow));
-    assert_eq!(items[0], expected_0);
-    assert_eq!(items[1], expected_1);
+    let yellow = Style::default().fg(Color::Yellow);
+    assert_eq!(items[0], target_item(CHECKBOX_SELECTED, "Codex", yellow));
+    assert_eq!(items[1], target_item(CHECKBOX_SELECTED, "Copilot", yellow));
 }
 
 #[test]
@@ -186,11 +196,12 @@ fn build_target_list_items_none_selected() {
     ];
     let items = build_target_list_items(&targets);
     assert_eq!(items.len(), 2);
-    // All items should match default-styled unselected items
-    let expected_0 = ListItem::new("  [ ] Codex".to_string()).style(Style::default());
-    let expected_1 = ListItem::new("  [ ] Copilot".to_string()).style(Style::default());
-    assert_eq!(items[0], expected_0);
-    assert_eq!(items[1], expected_1);
+    let default = Style::default();
+    assert_eq!(items[0], target_item(CHECKBOX_UNSELECTED, "Codex", default));
+    assert_eq!(
+        items[1],
+        target_item(CHECKBOX_UNSELECTED, "Copilot", default)
+    );
 }
 
 #[test]
@@ -201,61 +212,104 @@ fn build_target_list_items_mixed() {
     ];
     let items = build_target_list_items(&targets);
     assert_eq!(items.len(), 2);
-    // Selected and unselected items should differ
     assert_ne!(items[0], items[1]);
-    let expected_selected =
-        ListItem::new("  [x] Codex".to_string()).style(Style::default().fg(Color::Yellow));
-    let expected_unselected = ListItem::new("  [ ] Copilot".to_string()).style(Style::default());
-    assert_eq!(items[0], expected_selected);
-    assert_eq!(items[1], expected_unselected);
+    assert_eq!(
+        items[0],
+        target_item(
+            CHECKBOX_SELECTED,
+            "Codex",
+            Style::default().fg(Color::Yellow)
+        )
+    );
+    assert_eq!(
+        items[1],
+        target_item(CHECKBOX_UNSELECTED, "Copilot", Style::default())
+    );
+}
+
+#[test]
+fn build_target_list_items_have_height_2() {
+    let targets = vec![("codex".to_string(), "Codex".to_string(), true)];
+    let items = build_target_list_items(&targets);
+    for item in &items {
+        assert_eq!(item.height(), 2);
+    }
 }
 
 // =============================================================================
 // build_scope_list_items
 // =============================================================================
 
+fn scope_item(mark: &str, scope: Scope, path: &str, style: Style) -> ListItem<'static> {
+    let line_text = format!(
+        "{}{} {} {}",
+        LIST_ITEM_INDENT,
+        mark,
+        scope.display_name(),
+        path
+    );
+    ListItem::new(vec![Line::from(line_text), Line::raw("")]).style(style)
+}
+
 #[test]
 fn build_scope_list_items_personal_selected() {
     let items = build_scope_list_items(0);
     assert_eq!(items.len(), 2);
-    let expected_personal = ListItem::new(format!(
-        "  (x) {} (~/.plm/)",
-        Scope::Personal.display_name()
-    ))
-    .style(Style::default().fg(Color::Yellow));
-    let expected_project = ListItem::new(format!("  ( ) {} (./)", Scope::Project.display_name()))
-        .style(Style::default());
-    assert_eq!(items[0], expected_personal);
-    assert_eq!(items[1], expected_project);
+    let yellow = Style::default().fg(Color::Yellow);
+    assert_eq!(
+        items[0],
+        scope_item(RADIO_SELECTED, Scope::Personal, "(~/.plm/)", yellow)
+    );
+    assert_eq!(
+        items[1],
+        scope_item(RADIO_UNSELECTED, Scope::Project, "(./)", Style::default())
+    );
 }
 
 #[test]
 fn build_scope_list_items_project_selected() {
     let items = build_scope_list_items(1);
     assert_eq!(items.len(), 2);
-    let expected_personal = ListItem::new(format!(
-        "  ( ) {} (~/.plm/)",
-        Scope::Personal.display_name()
-    ))
-    .style(Style::default());
-    let expected_project = ListItem::new(format!("  (x) {} (./)", Scope::Project.display_name()))
-        .style(Style::default().fg(Color::Yellow));
-    assert_eq!(items[0], expected_personal);
-    assert_eq!(items[1], expected_project);
+    let yellow = Style::default().fg(Color::Yellow);
+    assert_eq!(
+        items[0],
+        scope_item(
+            RADIO_UNSELECTED,
+            Scope::Personal,
+            "(~/.plm/)",
+            Style::default()
+        )
+    );
+    assert_eq!(
+        items[1],
+        scope_item(RADIO_SELECTED, Scope::Project, "(./)", yellow)
+    );
 }
 
 #[test]
 fn build_scope_list_items_out_of_range_clamps_to_last() {
     let items = build_scope_list_items(99);
     assert_eq!(items.len(), 2);
-    // Out-of-range clamps to last valid index (Project selected)
-    let expected_personal = ListItem::new(format!(
-        "  ( ) {} (~/.plm/)",
-        Scope::Personal.display_name()
-    ))
-    .style(Style::default());
-    let expected_project = ListItem::new(format!("  (x) {} (./)", Scope::Project.display_name()))
-        .style(Style::default().fg(Color::Yellow));
-    assert_eq!(items[0], expected_personal);
-    assert_eq!(items[1], expected_project);
+    let yellow = Style::default().fg(Color::Yellow);
+    assert_eq!(
+        items[0],
+        scope_item(
+            RADIO_UNSELECTED,
+            Scope::Personal,
+            "(~/.plm/)",
+            Style::default()
+        )
+    );
+    assert_eq!(
+        items[1],
+        scope_item(RADIO_SELECTED, Scope::Project, "(./)", yellow)
+    );
+}
+
+#[test]
+fn build_scope_list_items_have_height_2() {
+    let items = build_scope_list_items(0);
+    for item in &items {
+        assert_eq!(item.height(), 2);
+    }
 }

--- a/src/tui/manager/screens/marketplaces/view_test.rs
+++ b/src/tui/manager/screens/marketplaces/view_test.rs
@@ -313,3 +313,25 @@ fn build_scope_list_items_have_height_2() {
         assert_eq!(item.height(), 2);
     }
 }
+
+// =============================================================================
+// build_market_action_item
+// =============================================================================
+
+#[test]
+fn build_market_action_item_returns_height_2() {
+    for action in super::DetailAction::all().iter() {
+        let item = build_market_action_item(action);
+        assert_eq!(item.height(), 2);
+    }
+}
+
+#[test]
+fn view_market_detail_action_menu_renders_all_actions_with_2line_items() {
+    let actions = super::DetailAction::all();
+    let total: u16 = actions
+        .iter()
+        .map(|a| build_market_action_item(a).height() as u16)
+        .sum();
+    assert_eq!(total, actions.len() as u16 * 2);
+}


### PR DESCRIPTION
## 概要

TUI 管理画面 (`src/tui/manager`) の視認性課題を解消するため、共通 `core/layout` / `core/style` API を新設し、4 タブ全画面 (Installed / Discover / Marketplaces / Errors) を移行。リスト各行を **2 行 ListItem (`[content, empty]`)** に統一し、`highlight_symbol("> ")` を内容行に整列させつつ行間に視覚的余白を確保。外周マージン 1 セル、タイトル BOLD 化、状態アイコンの導入を統一適用。

## 変更の種類

- [x] ✨ 新機能 — 共通 `core/layout` / `core/style` モジュールと状態アイコン定数の新設
- [x] ♻️ リファクタリング — 4 タブ全画面の Layout/Block/List 構築を共通 API 経由に移行
- [x] 💄 UI/UX — 外周マージン 1 セル / 行間空行 / 選択行 `fg=Black bg=Green BOLD` / タイトル BOLD / 状態アイコン
- [x] 🧪 テスト — 各 view ビルダの 2 行 ListItem 高さ契約と action menu 高さ契約のテスト追加

## 詳細な変更内容

### 共通 API 新設
- `src/tui/manager/core/layout.rs` (NEW): `frame_rect` / `outer_rect` / `framed_layout` / `detail_layout` (`[info, menu]` の 2 区画) / `modal_layout` / `split_horizontal` と定数群 (`OUTER_PADDING_H/V`, `MIN_TERMINAL_HEIGHT/WIDTH`)
- `src/tui/manager/core/style.rs` (NEW): `bordered_block` (BOLD タイトル) / `highlight_style` (`fg=Black bg=Green BOLD`) / `selectable_list` / `menu_list` / 状態アイコン定数 (`ICON_ENABLED ●` / `ICON_DISABLED ○` / `ICON_CHECK ✓` / `MARK_MARKED [✓]` / `MARK_UNMARKED [ ]` / `CHECKBOX_SELECTED [x]` / `CHECKBOX_UNSELECTED [ ]` / `RADIO_SELECTED (●)` / `RADIO_UNSELECTED ( )`)
- 専用 `*_test.rs` 追加 (`core/layout_test.rs`, `core/style_test.rs`)
- `core.rs` で `pub mod layout` / `pub mod style` を公開
- 未使用となった `content_rect` / `HORIZONTAL_PADDING` の re-export を `core.rs` から削除

### 2 行 ListItem (`[content, empty]`)

すべてのリスト項目を `[content, empty]` の 2 行構成に統一。`ListItem::height() == 2` で `selectable_list` / `menu_list` の `repeat_highlight_symbol(false)` と組み合わせ、選択時の "> " シンボルを内容行に整列させつつ各項目間に 1 行の視覚的余白を確保。`detail_layout` の `action_menu_rows` 引数は呼び出し側で `items.iter().map(ListItem::height).sum()` を渡し、2 行化後も全 action が描画欠けなく収まる契約。

### Installed タブ
- `installed/view.rs`: 全 4 サブ画面で `outer_rect` + `framed_layout` (もしくは画面固有 split) + `selectable_list` / `menu_list` 経由
- `plugin_row_prefix(is_marked, enabled)` を `MARK_*` + `ICON_*` 経由に変更し、行を `"  [✓] ● my-plugin v1.2.3 (Codex/Personal)"` 形式に
- `build_plugin_row` を 2 行 ListItem 化
- 詳細画面 action menu 用に `build_detail_action_item` / `build_detail_action_menu` を抽出
- `view_component_types` / `view_component_list` 用に `build_component_types_item` / `build_component_list_item` を抽出
- info pane を 2 行 (Scope+Version / Author+Status) に圧縮し、24 行端末で 6 actions × 2 行 menu と共存可能に

### Marketplaces タブ
- 8 サブ画面を `outer_rect` + `framed_layout` (top-level) / `modal_layout` (modal) / `split_horizontal` (Browse 左右) に統一
- `target_checkbox` / `scope_radio` を `CHECKBOX_*` / `RADIO_*` 定数経由に変更
- Browse 行は `browse_state_block(installed, selected)` で installed (`[✓]` DarkGray) / selected (`[x]` Yellow) / idle (`[ ]` default) の 3 状態
- description が存在する場合は `"name — desc"` 形式 + `truncate_for_list` で狭幅対応
- Market detail action menu は `Constraint::Length(action_menu_rows)` で全 actions 描画分の高さを予約
- `build_market_action_item` / `build_market_action_menu` を抽出
- Installing modal は partial border 維持のため `Span::styled` で BOLD タイトルのみ手動付与
- `modal_layout` は cell 単位で計算し、`pct > 0 && area > 0` のとき最低 1 セル確保 (極小ターミナル対応)

### Discover / Errors タブ
- `outer_rect` + `framed_layout` + `bordered_block` 経由に置換
- 各画面で `Clear` を `f.area()` に対して呼び、外周マージンに前フレームの残骸を残さない

### テスト
- `core/layout_test.rs`: 22 件 (frame_rect / outer_rect / framed_layout / detail_layout / modal_layout / split_horizontal の境界値・極小入力)
- `core/style_test.rs`: 11 件 (定数値 / 単一 char / highlight_style / smoke)
- `installed/view_test.rs`: build_plugin_row / build_detail_action_menu / build_component_types_item / build_component_list_item の 2 行契約 + enabled/disabled 両分岐
- `marketplaces/view_test.rs`: 既存 20 件を `LIST_ITEM_INDENT` + 状態定数経由に書き換え + height==2 / action menu 高さ契約テスト

### Lifetime / 性能微改善
- `bordered_block(title)` を `Block<'a>` 化して `title.to_string()` 確保を排除
- action menu / component item builder の戻り値を `ListItem<'static>` に固定 (借用なし)

## 関連Issue

なし (spec `008-tui-spacing-and-font` ベースの変更で、対応 Issue は起票されていない)。
実装計画: `.plugin-workspace/.specs/008-tui-spacing-and-font/implementation-plan.md`

## テスト

- `cargo fmt`: 適用済み (サブエージェント経由)
- `cargo check` (rust-workflow-plugin:type-check): エラー / 警告なし
- `cargo test --bin plm`: 1478 passed / 0 failed
- `cargo test --bin plm tui::manager`: 283 passed / 0 failed
- 手動: 24 行端末で Installed detail (enabled = 6 actions / disabled = 5 actions) と Marketplaces detail (5 actions) の menu / info pane が共存することを確認
- 手動: 文字が menu_list / selectable_list で内容行に揃い、"> " シンボルもズレないことを確認

## レビューポイント

- **2 行 ListItem (`[content, empty]`)**: `repeat_highlight_symbol(false)` + 内容行先頭で "> " シンボルを内容に整列。空行は次行への視覚的余白
- **detail_layout は `[info, menu]` の 2 区画**: framed_layout の help_area が既に help テキストを担うため、detail_layout から重複する help 行を排除
- **Installed plugin detail の info 圧縮**: 24 行端末で 6 actions × 2 行 = 12 行の menu と共存できるよう Scope+Version / Author+Status の 2 行構成に
- **Browse 行 3 状態**: installed 優先判定。`installed=true && selected=true` でも installed (DarkGray + `[✓]`) として扱う
- **Installing modal タイトル**: partial border のため `bordered_block` を使えず、`Span::styled` で BOLD のみ手動付与
- **modal_layout は cell 単位 + 最低 1 セル**: 極小ターミナル (1xN / Nx1) でもモーダルが消えないよう設計

## チェックリスト

- [x] セルフレビュー実施 (Codex 5 ラウンド + Copilot 数ラウンドで指摘解消)
- [x] `cargo fmt` 適用済み (サブエージェント経由)
- [x] `cargo check` (rust-workflow-plugin:type-check) でエラーなし
- [x] `cargo test` (rust-workflow-plugin:test) で全件 GREEN
- [x] コミットメッセージが絵文字 + タイプ形式
- [ ] 関連 Issue Linked (該当 Issue なし)
- [x] 破壊的変更なし
- [x] 実装計画 `.plugin-workspace/.specs/008-tui-spacing-and-font/implementation-plan.md` と差分に齟齬なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)