### PR TITLE
📝 [Doc]: add Copilot Hooks Personal scope path to targets.md

### DIFF
--- a/docs/concepts/targets.md
+++ b/docs/concepts/targets.md
@@ -97,7 +97,7 @@ PLMがサポートするAI開発環境（ターゲット）について説明し
 | Prompts | `*.prompt.md` | - | `.github/prompts/<marketplace>/<plugin>/` |
 | Instructions | `AGENTS.md` | - | `AGENTS.md` |
 | Instructions | `copilot-instructions.md` | - | `.github/copilot-instructions.md` |
-| Hooks | `*.json` | - | `.github/hooks/<marketplace>/<plugin>/` |
+| Hooks | `*.json` | `~/.copilot/hooks/<marketplace>/<plugin>/` | `.github/hooks/<marketplace>/<plugin>/` |
 
 ### Hooks（Preview）
 


### PR DESCRIPTION
## Summary

- `docs/concepts/targets.md` の Hooks 行 Personal 列に `~/.copilot/hooks/<marketplace>/<plugin>/` を追記
- 実装 (`CopilotTarget::placement_location` / `can_place` / `list_placed`) は既に Personal / Project 両スコープに対応済みで、ドキュメントだけが追従していなかったため整合させる

## 背景

- `src/target/copilot.rs:43-48` の `can_place` で Hook は両スコープ可
- `src/target/copilot.rs:131-133` の `placement_location` で Hook の配置パスを返却
- `src/target/copilot.rs:161` の `list_placed` で `hooks/` ディレクトリを走査

## Closes

- Closes #121

## Test plan

- [x] `docs/concepts/targets.md` の Hooks 行 Personal 列が `~/.copilot/hooks/<marketplace>/<plugin>/` になっていること
- [x] Project 列の値が変更されていないこと