### PR TITLE
✨ [New Feature]: #187 add resolve_script_path pure function for hook script paths

### DIFF
--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -9,6 +9,7 @@ pub(crate) mod copilot;
 pub(crate) mod event;
 pub(crate) mod hook_definition;
 pub(crate) mod name;
+pub(crate) mod script_path;
 pub(crate) mod tool;
 
 #[cfg(test)]

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -20,3 +20,5 @@ mod converter_test;
 mod copilot_test;
 #[cfg(test)]
 mod name_test;
+#[cfg(test)]
+mod script_path_test;

--- a/src/hooks/script_path.rs
+++ b/src/hooks/script_path.rs
@@ -1,0 +1,64 @@
+//! Hook スクリプトのパス解決を行う純粋関数モジュール。
+//!
+//! 上位仕様 BL-006 (`docs/hooks-conversion/install-integration-spec.md`) に基づき、
+//! - 絶対パス       → そのまま使用
+//! - 相対パス       → `cache_root` 配下に解決
+//! - コマンド名のみ → そのまま使用 (PATH から探索される想定)
+//!
+//! の 3 種別を判定する。
+//!
+//! # 入力契約
+//! - IN-1: 入力は **実行ファイル部分のみ (program トークン)** とする。引数を含めてはならない。
+//!   `./script.sh --flag` や `npm test` のようなコマンドライン全体、`~/bin/hook` や
+//!   `$HOME/bin/hook` のようなシェル展開トークンを含む文字列は契約違反である。
+//!   resolver を呼ぶ場合は program 部のみを渡すこと。シェル構文を含む command 文字列を
+//!   どう扱うか (変換対象外として警告するか、shell-aware に分離するか等) は本関数の責務外で、
+//!   後続 Issue (#173 / #189) で決定する。
+//! - IN-1a: 判定セパレータは `'/'` のみ。`'\\'` は POSIX では通常のファイル名構成文字として
+//!   扱う。`'/'` を含まない裸のファイル名 (`hook.sh`, `dir\\sub.sh` 等) はコマンド名として
+//!   素通しされ PATH 検索扱いになる。プラグイン同梱スクリプトを `cache_root` 配下から
+//!   実行したい場合は `./hook.sh` のように相対パス記法に正規化すること。
+//! - IN-2: `@@PLUGIN_ROOT@@/...` のようなプレースホルダ未解決文字列を渡してはならない。
+//!   `'/'` を含む相対パスとして誤変換される。プレースホルダ解決は別経路で行う。
+//! - IN-3: `cache_root` は UTF-8 で表現可能であること。
+//!   `Path::display()` は非 UTF-8 バイト列を `U+FFFD` で置換する lossy 変換を行う。
+//!
+//! # 意図的に行わないこと
+//! - `../` を含む相対パスのフォルダトラバーサル防御
+//!   (`cache_root.join(input)` でそのまま返す。防御は呼び出し側の責務)
+//! - `./scripts/x.sh` の `./` 正規化
+//!   (例: `/cache/./scripts/x.sh` をそのまま返す)
+//! - 空白を含む入力のトークン分割やシェルエスケープ
+//!   (シェルエスケープは呼び出し側 `shell_escape` / `escape_for_bash_double_quote`)
+
+use std::path::Path;
+
+/// スクリプト指定文字列をプラグインキャッシュ基準で解決する。
+///
+/// 判定順序 (上から評価):
+/// 1. 空文字列 → 空文字列を返す
+/// 2. `Path::is_absolute()` が true → そのまま返す
+/// 3. `'/'` を含む → `cache_root.join(input).display().to_string()`
+/// 4. それ以外 → そのまま返す (コマンド名扱い)
+///
+/// POSIX 前提のため `'\\'` は通常のファイル名構成文字として扱い、
+/// セパレータ判定には用いない (`dir\\sub.sh` はコマンド名分岐に流れる)。
+///
+/// # Arguments
+/// * `input` - 呼び出し側で分離済みの program トークンのみ。
+///   コマンドライン全体・シェル展開・プレースホルダ未解決文字列を含めないこと
+///   (詳細はモジュール冒頭の「入力契約」を参照、IN-1 / IN-2)。
+/// * `cache_root` - プラグインキャッシュルート
+///   (例: `~/.plm/cache/<marketplace>/<plugin>`、UTF-8 表現可能であること、IN-3)。
+pub(crate) fn resolve_script_path(input: &str, cache_root: &Path) -> String {
+    if input.is_empty() {
+        return String::new();
+    }
+    if Path::new(input).is_absolute() {
+        return input.to_string();
+    }
+    if input.contains('/') {
+        return cache_root.join(input).display().to_string();
+    }
+    input.to_string()
+}

--- a/src/hooks/script_path.rs
+++ b/src/hooks/script_path.rs
@@ -29,7 +29,10 @@
 //! - `./scripts/x.sh` の `./` 正規化
 //!   (例: `/cache/./scripts/x.sh` をそのまま返す)
 //! - 空白を含む入力のトークン分割やシェルエスケープ
-//!   (シェルエスケープは呼び出し側 `shell_escape` / `escape_for_bash_double_quote`)
+//!   (シェルエスケープは呼び出し側責務。`hooks` 配下からは crate 公開の
+//!   `crate::hooks::converter::shell_escape` を利用する。
+//!   `component::deployment::bash::escape_for_bash_double_quote` は
+//!   `pub(super)` で `component::deployment` 配下からのみ参照可能)
 
 use std::path::Path;
 

--- a/src/hooks/script_path_test.rs
+++ b/src/hooks/script_path_test.rs
@@ -1,0 +1,182 @@
+//! Tests for `resolve_script_path` (BL-006).
+//!
+//! 前提: POSIX 環境 (Linux CI)。判定セパレータは `'/'` のみ。
+//! Windows ドライブレター付きパス (`C:\\foo\\bar`) は `Path::is_absolute()` が false を返し、
+//! `'/'` も含まないため、本テストでは「コマンド名分岐」に流れて素通しされる挙動を固定する。
+//! Windows 対応は将来 Issue。
+
+use std::path::Path;
+
+use super::script_path::resolve_script_path;
+
+// --- 絶対パス分岐 -------------------------------------------------
+
+#[test]
+fn absolute_posix_path_returned_as_is() {
+    let cache = Path::new("/cache");
+    assert_eq!(
+        resolve_script_path("/usr/local/bin/hook", cache),
+        "/usr/local/bin/hook"
+    );
+}
+
+#[test]
+fn absolute_path_with_spaces_returned_as_is() {
+    let cache = Path::new("/cache");
+    assert_eq!(
+        resolve_script_path("/abs/with spaces/file.sh", cache),
+        "/abs/with spaces/file.sh"
+    );
+}
+
+// --- 相対パス分岐 (セパレータ '/' を含む) ------------------------
+
+#[test]
+fn relative_with_dot_slash_is_joined_without_normalization() {
+    // `./` は正規化しない (ヒアリング 6.2)
+    let cache = Path::new("/cache");
+    assert_eq!(
+        resolve_script_path("./scripts/validate.sh", cache),
+        "/cache/./scripts/validate.sh"
+    );
+}
+
+#[test]
+fn relative_without_dot_slash_is_joined() {
+    let cache = Path::new("/cache");
+    assert_eq!(
+        resolve_script_path("scripts/validate.sh", cache),
+        "/cache/scripts/validate.sh"
+    );
+}
+
+#[test]
+fn relative_path_with_spaces_is_joined_without_escape() {
+    // 相対パス + ファイル名に空白 (シェルエスケープは呼び出し側責務)
+    let cache = Path::new("/cache");
+    assert_eq!(
+        resolve_script_path("scripts/with space.sh", cache),
+        "/cache/scripts/with space.sh"
+    );
+}
+
+#[test]
+fn relative_with_parent_traversal_is_joined_without_guard() {
+    // `../` ガードは行わない (ヒアリング 4.6 / 探索 3-3)
+    let cache = Path::new("/cache");
+    assert_eq!(resolve_script_path("../foo", cache), "/cache/../foo");
+}
+
+// --- コマンド名分岐 (セパレータなし) -----------------------------
+
+#[test]
+fn bare_command_name_returned_as_is() {
+    let cache = Path::new("/cache");
+    assert_eq!(resolve_script_path("npm", cache), "npm");
+}
+
+#[test]
+fn bare_filename_with_extension_treated_as_command() {
+    // 契約 IN-1a: セパレータを含まない裸のファイル名はコマンド名として扱う。
+    // プラグイン同梱スクリプトを cache_root 配下から実行したい場合は、
+    // 呼び出し側で `./hook.sh` のように相対パス記法に正規化すること。
+    let cache = Path::new("/cache");
+    assert_eq!(resolve_script_path("hook.sh", cache), "hook.sh");
+}
+
+// --- 観察的固定テスト (契約違反入力・POSIX 専用挙動の凍結) -----------
+// 以下は契約違反入力および POSIX 専用挙動に対する不定義動作を観察的に凍結したリグレッション
+// 検知用テスト。仕様化された挙動ではないため、後続 Issue (#173 / #189) で入力検証を導入する場合は
+// 方針変更に応じて更新・削除する。呼び出し側がこの挙動に依存することは禁止。
+
+#[test]
+fn contract_violation_empty_input_returns_empty() {
+    // 契約違反: 空文字列はスクリプト指定子として意味を持たない。
+    // 防御的に空文字列を返す現挙動を凍結。
+    // 本来は呼び出し側 (`hook_definition.rs` 等) のバリデーション層で排除すべき。
+    let cache = Path::new("/cache");
+    assert_eq!(resolve_script_path("", cache), "");
+}
+
+#[test]
+fn contract_violation_command_with_arguments_passed_through() {
+    // IN-1 違反: 空白で区切られた引数付きコマンドラインを直接渡されると、
+    // セパレータ未含有のためコマンド名分岐に流れて素通しされる。
+    // 呼び出し側 (#173 / #189) で program と args を分離する責務がある。
+    let cache = Path::new("/cache");
+    assert_eq!(resolve_script_path("npm test", cache), "npm test");
+}
+
+#[test]
+fn contract_violation_relative_with_arguments_misjoined() {
+    // IN-1 違反: '/' を含む引数付き入力 `./script.sh --flag` は相対パス分岐に流れて、
+    // `--flag` まで含めた文字列が cache_root.join される現挙動を凍結。
+    // 呼び出し側 (#173 / #189) で program と args を分離する責務がある。
+    let cache = Path::new("/cache");
+    assert_eq!(
+        resolve_script_path("./script.sh --flag", cache),
+        "/cache/./script.sh --flag"
+    );
+}
+
+#[test]
+fn contract_violation_tilde_shell_expansion_misresolved() {
+    // `~/bin/hook` はシェル展開を含むため契約 IN-1 違反。
+    // 本関数は `~` を解釈せず、'/' 含有として相対分岐で誤解決する現挙動を観察的に固定。
+    let cache = Path::new("/cache");
+    assert_eq!(
+        resolve_script_path("~/bin/hook", cache),
+        "/cache/~/bin/hook"
+    );
+}
+
+#[test]
+fn posix_only_backslash_path_treated_as_command_name() {
+    // POSIX 前提のため `'\\'` はセパレータ判定に用いない。
+    // `dir\\sub\\x.sh` はコマンド名分岐に流れて素通しされる現挙動を凍結。
+    // Windows 対応は将来 Issue。
+    let cache = Path::new("/cache");
+    assert_eq!(
+        resolve_script_path("dir\\sub\\x.sh", cache),
+        "dir\\sub\\x.sh"
+    );
+}
+
+#[test]
+fn posix_only_windows_drive_letter_treated_as_command_name() {
+    // POSIX 上では `Path::new("C:\\foo\\bar").is_absolute()` は false。
+    // セパレータ判定も `'/'` のみのため、コマンド名分岐に流れる現挙動を凍結。
+    // Windows 対応は将来 Issue。
+    let cache = Path::new("/cache");
+    assert_eq!(resolve_script_path("C:\\foo\\bar", cache), "C:\\foo\\bar");
+}
+
+#[test]
+fn contract_violation_unresolved_plugin_root_placeholder_misjoined() {
+    // `@@PLUGIN_ROOT@@/scripts/x.sh` はプレースホルダ未解決のため契約 IN-2 違反。
+    // 本関数はプレースホルダを認識せず、'/' 含有として相対分岐で誤解決する現挙動を凍結。
+    // プレースホルダ解決は別経路 (`hook_deploy.rs:143` の `replace("@@PLUGIN_ROOT@@", ...)`) で行われる。
+    let cache = Path::new("/cache");
+    assert_eq!(
+        resolve_script_path("@@PLUGIN_ROOT@@/scripts/x.sh", cache),
+        "/cache/@@PLUGIN_ROOT@@/scripts/x.sh"
+    );
+}
+
+#[test]
+fn contract_violation_lone_dot_treated_as_command_name() {
+    // IN-1a: 単独の `.` は POSIX ではカレントディレクトリだが、本関数では '/' を含まないため
+    // コマンド名分岐に流れて素通しされる現挙動を凍結。スクリプト指定子としては意味を持たないため
+    // 呼び出し側で排除すべき。
+    let cache = Path::new("/cache");
+    assert_eq!(resolve_script_path(".", cache), ".");
+}
+
+#[test]
+fn contract_violation_lone_dotdot_treated_as_command_name() {
+    // IN-1a: 単独の `..` は POSIX では親ディレクトリだが、本関数では '/' を含まないため
+    // コマンド名分岐に流れて素通しされる現挙動を凍結。スクリプト指定子としては意味を持たないため
+    // 呼び出し側で排除すべき。
+    let cache = Path::new("/cache");
+    assert_eq!(resolve_script_path("..", cache), "..");
+}


### PR DESCRIPTION
## 概要

ラッパースクリプト生成・配置時に必要となる「絶対パス / 相対パス / コマンド名」3 種別の判定を行う純粋関数 `resolve_script_path` を `src/hooks/script_path.rs` に新規追加。`hooks` モジュール直下に閉じた pure logic で、`deployment.rs` 等への配線は本 PR スコープ外（後続 #186 / #189）。BL-006 (`docs/hooks-conversion/install-integration-spec.md`) を実装。

## 変更の種類

- [x] ✨ 新機能 (新規 `pub(crate) fn resolve_script_path`)
- [x] 🧪 テスト (必須 8 件 + 観察的固定 9 件 = 17 件)
- [ ] 💥 破壊的変更（なし — 既存 Hook デプロイ経路 `hook_deploy.rs::@@PLUGIN_ROOT@@` には触らない）

## 詳細な変更内容

### Phase 1: 関数本体追加（`16fbb0e`）

- 新規: `src/hooks/script_path.rs:53` — `pub(crate) fn resolve_script_path(input: &str, cache_root: &Path) -> String`
  - 判定順序: 空文字列 → `Path::is_absolute()` → `'/'` 含有 → コマンド名（フォールバック）
  - POSIX 前提: 判定セパレータは `'/'` のみ。`'\\'` は通常文字としてコマンド名分岐に流れる
  - 副作用なし: IO・正規化・サニタイズ・トークン分割いずれも行わない（呼び出し側責務）
  - ファイル冒頭 doc コメントに入力契約 IN-1 / IN-1a / IN-2 / IN-3 を明記
- 変更: `src/hooks.rs:12` — `pub(crate) mod script_path;` 追加（アルファベット順を維持）

### Phase 2: テスト追加（`96bcc7d`）

- 新規: `src/hooks/script_path_test.rs` — 17 ケース
  - 必須 8 件（DoD カバー対象）: 絶対 POSIX / 絶対 + 空白 / 相対 + 4 種 / コマンド名 / 裸ファイル名
  - 観察的固定 9 件: `contract_violation_*` / `posix_only_*` のプレフィックスで契約違反入力と POSIX 専用挙動の現挙動を凍結
- 変更: `src/hooks.rs:24` — `#[cfg(test)] mod script_path_test;` 追加

## システム図

```mermaid
flowchart TD
    Input["input: &str<br/>cache_root: &Path"] --> Empty{"input.is_empty()?"}
    Empty -- yes --> RetEmpty["return String::new()"]
    Empty -- no --> Abs{"Path::new input<br/>.is_absolute()?"}
    Abs -- yes --> RetAbs["return input.to_string()<br/>(POSIX absolute)"]
    Abs -- no --> Sep{"input.contains '/'<br/>?"}
    Sep -- yes --> RetRel["return cache_root<br/>.join input<br/>.display.to_string<br/>(no normalization)"]
    Sep -- no --> RetCmd["return input.to_string()<br/>(command name / PATH lookup)"]

    style Input fill:#e1f5ff,stroke:#0288d1
    style RetEmpty fill:#fff9c4,stroke:#f9a825
    style RetAbs fill:#c8e6c9,stroke:#388e3c
    style RetRel fill:#c8e6c9,stroke:#388e3c
    style RetCmd fill:#c8e6c9,stroke:#388e3c
```

注: 仮にセパレータ判定を絶対パス判定より先に置いても `cache_root.join(\"/abs\")` は `PathBuf::join` のセマンティクスにより `/abs` を返すが、「絶対パスはキャッシュ基準で解決しない」という意図を判定段階で明示するため絶対判定を先に置いている。

## 関連Issue

Refs #187（親 #183、Epic #161）

呼び出し配線は後続 #186 / #189 で別 PR とする。

## テスト

すべてサブエージェント経由で実行・確認済み。

| ステップ | コマンド | 結果 |
|---|---|---|
| フォーマット | `cargo fmt` (Bash agent) | 差分なし |
| 型チェック | `rust-workflow-plugin:type-check` | エラー 0、新規コードに警告なし |
| 局所テスト | `cargo test hooks::script_path_test` | 17 / 17 pass |
| モジュール回帰 | `cargo test hooks` | 167 / 167 pass |
| 全体回帰 | `cargo test` | 1513 / 1513 pass |

Codex CLI による一括コードレビュー（`.plugin-workspace/.specs/010-hook-script-path-resolution/code-review/review-001.md`）は **問題なし** で 1 ラウンド完結。判定順序・公開範囲・mod 宣言順・テスト分離・サニタイズ非実施方針すべて確認済み。

## レビューポイント

1. **入力契約のドキュメント** — `src/hooks/script_path.rs:10-31` に IN-1 / IN-1a / IN-2 / IN-3 を明記。本関数はサニタイズ・正規化・トークン分割を行わず、これらは呼び出し側 (#173 / #189) の責務。観察的固定テスト群（`contract_violation_*` / `posix_only_*`）は仕様化された挙動ではない旨をテストファイル冒頭にも記載済み。
2. **公開範囲** — `pub(crate)` 限定。`hooks::script_path::resolve_script_path` 経由で参照させ、再エクスポートはしない（後続で必要になれば昇格）。
3. **POSIX 前提** — Windows ドライブレター・バックスラッシュ区切りパスはコマンド名分岐に素通しされる。Windows 対応は将来 Issue。
4. **scope 限定** — `git diff --name-only` は `src/hooks.rs` + 新規 `src/hooks/script_path*.rs` の 3 ファイルのみ。`deployment.rs` 配線・`copilot.rs::generate_command_script` 改修・WrapperGenerator 接続は本 PR に含まない。

## チェックリスト

- [x] セルフレビュー実施
- [x] `cargo fmt` 適用済み（サブエージェント経由）
- [x] `cargo check` でエラーなし（rust-workflow-plugin:type-check）
- [x] `cargo test` で全件 GREEN（rust-workflow-plugin:test, 1513 件）
- [x] コミットメッセージが絵文字 + タイプ形式
- [x] 関連 Issue (#187) を Refs で記載
- [x] 破壊的変更なし
- [x] 実装計画（`.plugin-workspace/.specs/010-hook-script-path-resolution/implementation-plan.md`）と差分に齟齬なし