### PR TITLE
✨ [New Feature]: #190 surface hook conversion results in install output

### DIFF
--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -9,12 +9,50 @@
 //! 3. 配置
 
 use crate::component::ComponentKind;
-use crate::install::{self, PlaceRequest};
+use crate::install::format::render_hook_success;
+use crate::install::{self, PlaceRequest, PlaceSuccess};
 use crate::output::CommandSummary;
 use crate::target::{all_targets, parse_target, Scope, TargetKind};
 use crate::tui;
 use clap::Parser;
 use std::env;
+
+/// `PlaceSuccess` を表示用の `(stdout 行, stderr ブロック群)` に変換する pure function。
+///
+/// stdout 1 行は `+ {target} {kind}: {name} -> {path}{suffix}` の形式。
+/// suffix は次の優先順で決定する：
+/// 1. Hook の場合: `render_hook_success` の `stdout_suffix`（cyan）
+/// 2. それ以外で `source_format` / `dest_format` が両方 `Some`: ` (Converted: src → dst)`
+/// 3. その他: 空
+///
+/// stderr ブロック群は Hook のみ `render_hook_success` の `stderr_blocks` を返す。
+pub fn render_place_success_to_strings(success: &PlaceSuccess) -> (String, Vec<String>) {
+    let rendered = render_hook_success(
+        success.component_kind,
+        success.hook_source_format,
+        &success.hook_warnings,
+        success.script_count,
+    );
+
+    let suffix = match rendered.stdout_suffix {
+        Some(s) => s,
+        None => match (&success.source_format, &success.dest_format) {
+            (Some(src), Some(dst)) => format!(" (Converted: {} → {})", src, dst),
+            _ => String::new(),
+        },
+    };
+
+    let stdout_line = format!(
+        "  + {} {}: {} -> {}{}",
+        success.target,
+        success.component_kind,
+        success.component_name,
+        success.target_path.display(),
+        suffix
+    );
+
+    (stdout_line, rendered.stderr_blocks)
+}
 
 #[derive(Debug, Parser)]
 pub struct Args {
@@ -127,21 +165,10 @@ pub async fn run(args: Args) -> std::result::Result<(), String> {
         let mut target_success = true;
 
         for success in result.successes.iter().filter(|s| &s.target == target_name) {
-            let suffix = match (&success.source_format, &success.dest_format) {
-                (Some(src), Some(dst)) => format!(" (Converted: {} → {})", src, dst),
-                _ => String::new(),
-            };
-            println!(
-                "  + {} {}: {} -> {}{}",
-                success.target,
-                success.component_kind,
-                success.component_name,
-                success.target_path.display(),
-                suffix
-            );
-
-            for warning in &success.hook_warnings {
-                eprintln!("Warning: {}", warning);
+            let (stdout_line, stderr_blocks) = render_place_success_to_strings(success);
+            println!("{}", stdout_line);
+            for block in &stderr_blocks {
+                eprintln!("{}", block);
             }
         }
 
@@ -163,3 +190,7 @@ pub async fn run(args: Args) -> std::result::Result<(), String> {
 
     Ok(())
 }
+
+#[cfg(test)]
+#[path = "install_test.rs"]
+mod tests;

--- a/src/commands/install_test.rs
+++ b/src/commands/install_test.rs
@@ -1,0 +1,179 @@
+use super::*;
+use crate::component::ComponentKind;
+use crate::hooks::converter::{ConversionWarning, SourceFormat};
+use crate::install::PlaceSuccess;
+use std::path::PathBuf;
+
+fn make_success(
+    component_kind: ComponentKind,
+    component_name: &str,
+    target: &str,
+    target_path: &str,
+    source_format: Option<&str>,
+    dest_format: Option<&str>,
+    hook_warnings: Vec<ConversionWarning>,
+    script_count: usize,
+    hook_source_format: Option<SourceFormat>,
+) -> PlaceSuccess {
+    PlaceSuccess {
+        target: target.to_string(),
+        component_name: component_name.to_string(),
+        component_kind,
+        target_path: PathBuf::from(target_path),
+        source_format: source_format.map(|s| s.to_string()),
+        dest_format: dest_format.map(|s| s.to_string()),
+        hook_warnings,
+        script_count,
+        hook_source_format,
+    }
+}
+
+#[test]
+fn render_place_success_hook_claude_code_with_unsupported_events() {
+    let success = make_success(
+        ComponentKind::Hook,
+        "my-hook",
+        "copilot",
+        "/dest/copilot/hooks/my-hook.json",
+        None,
+        None,
+        vec![
+            ConversionWarning::UnsupportedEvent {
+                event: "Notification".to_string(),
+            },
+            ConversionWarning::UnsupportedEvent {
+                event: "PreCompact".to_string(),
+            },
+            ConversionWarning::UnsupportedEvent {
+                event: "SubagentStart".to_string(),
+            },
+        ],
+        1,
+        Some(SourceFormat::ClaudeCode),
+    );
+    let (stdout, stderr) = render_place_success_to_strings(&success);
+    assert!(stdout.contains("(converted from Claude Code format)"));
+    assert!(stdout.starts_with("  + copilot Hook: my-hook -> "));
+    assert_eq!(stderr.len(), 1);
+    assert!(stderr[0].contains("3 events skipped"));
+}
+
+#[test]
+fn render_place_success_hook_target_format_with_missing_version() {
+    let success = make_success(
+        ComponentKind::Hook,
+        "copilot-hook",
+        "copilot",
+        "/dest/copilot/hooks/copilot-hook.json",
+        None,
+        None,
+        vec![ConversionWarning::MissingVersion],
+        0,
+        Some(SourceFormat::TargetFormat),
+    );
+    let (stdout, stderr) = render_place_success_to_strings(&success);
+    // Copilot 形式 passthrough なので suffix なし、source/dest_format も None で空 suffix
+    assert!(!stdout.contains("(converted from Claude Code format)"));
+    assert!(!stdout.contains("(Converted:"));
+    assert_eq!(stderr.len(), 1);
+    assert!(stderr[0].contains("Warning:"));
+    assert!(stderr[0].contains("missing required 'version'"));
+}
+
+#[test]
+fn render_place_success_hook_passthrough_copied_no_warnings() {
+    // version 付き Copilot 形式 Hook → DeploymentOutput::Copied 経路
+    // → hook_source_format == None, warnings 0 件
+    let success = make_success(
+        ComponentKind::Hook,
+        "copilot-hook",
+        "copilot",
+        "/dest/copilot/hooks/copilot-hook.json",
+        None,
+        None,
+        vec![],
+        0,
+        None,
+    );
+    let (stdout, stderr) = render_place_success_to_strings(&success);
+    assert!(!stdout.contains("(converted from Claude Code format)"));
+    assert!(!stdout.contains("(Converted:"));
+    assert!(stderr.is_empty());
+}
+
+#[test]
+fn render_place_success_command_keeps_legacy_converted_suffix() {
+    let success = make_success(
+        ComponentKind::Command,
+        "test-plugin_my-cmd",
+        "copilot",
+        "/dest/copilot/commands/my-cmd.prompt.md",
+        Some("ClaudeCode"),
+        Some("Copilot"),
+        vec![],
+        0,
+        None,
+    );
+    let (stdout, stderr) = render_place_success_to_strings(&success);
+    assert!(stdout.contains("(Converted: ClaudeCode → Copilot)"));
+    assert!(!stdout.contains("(converted from Claude Code format)"));
+    assert!(stderr.is_empty());
+}
+
+#[test]
+fn render_place_success_agent_keeps_legacy_converted_suffix() {
+    let success = make_success(
+        ComponentKind::Agent,
+        "test-plugin_my-agent",
+        "copilot",
+        "/dest/copilot/agents/my-agent.agent.md",
+        Some("ClaudeCode"),
+        Some("Copilot"),
+        vec![],
+        0,
+        None,
+    );
+    let (stdout, stderr) = render_place_success_to_strings(&success);
+    assert!(stdout.contains("(Converted: ClaudeCode → Copilot)"));
+    assert!(!stdout.contains("(converted from Claude Code format)"));
+    assert!(stderr.is_empty());
+}
+
+#[test]
+fn render_place_success_skill_no_suffix_no_stderr() {
+    let success = make_success(
+        ComponentKind::Skill,
+        "test-plugin_my-skill",
+        "codex",
+        "/dest/codex/skills/my-skill",
+        None,
+        None,
+        vec![],
+        0,
+        None,
+    );
+    let (stdout, stderr) = render_place_success_to_strings(&success);
+    assert!(!stdout.contains("(Converted:"));
+    assert!(!stdout.contains("(converted from Claude Code format)"));
+    assert!(stderr.is_empty());
+}
+
+#[test]
+fn render_place_success_instruction_no_suffix_no_stderr() {
+    // 受入基準 4 (issue #190): Instruction の既存出力に変更がないことを固定する
+    let success = make_success(
+        ComponentKind::Instruction,
+        "test-plugin_AGENTS",
+        "codex",
+        "/dest/codex/AGENTS.md",
+        None,
+        None,
+        vec![],
+        0,
+        None,
+    );
+    let (stdout, stderr) = render_place_success_to_strings(&success);
+    assert!(!stdout.contains("(Converted:"));
+    assert!(!stdout.contains("(converted from Claude Code format)"));
+    assert!(stderr.is_empty());
+}

--- a/src/component/deployment/hook_deploy.rs
+++ b/src/component/deployment/hook_deploy.rs
@@ -111,6 +111,7 @@ impl ComponentDeployment {
             return Ok(DeploymentOutput::HookConverted(HookConvertOutput {
                 warnings: convert_result.warnings,
                 script_count: 0,
+                source_format: convert_result.source_format,
             }));
         }
 
@@ -148,6 +149,7 @@ impl ComponentDeployment {
         Ok(DeploymentOutput::HookConverted(HookConvertOutput {
             warnings: convert_result.warnings,
             script_count,
+            source_format: convert_result.source_format,
         }))
     }
 }

--- a/src/component/deployment/hook_deploy_test.rs
+++ b/src/component/deployment/hook_deploy_test.rs
@@ -1,7 +1,7 @@
 use crate::component::{
     Component, ComponentDeployment, ComponentKind, ConversionConfig, DeploymentOutput, Scope,
 };
-use crate::hooks::converter::ConversionWarning;
+use crate::hooks::converter::{ConversionWarning, SourceFormat};
 use crate::hooks::name::HookName;
 use crate::target::TargetKind;
 use std::fs;
@@ -80,6 +80,8 @@ fn test_hook_convert_without_plugin_root_ok_for_warnings_only() {
         DeploymentOutput::HookConverted(hr) => {
             assert!(!hr.warnings.is_empty());
             assert_eq!(hr.script_count, 0);
+            // Copilot 形式（version 欠落）入力では source_format は TargetFormat になる。
+            assert_eq!(hr.source_format, SourceFormat::TargetFormat);
         }
         _ => panic!("Expected HookConverted with warnings only"),
     }
@@ -129,6 +131,8 @@ fn test_hook_convert_true_deploys_converted() {
     match result {
         DeploymentOutput::HookConverted(hr) => {
             assert!(hr.script_count > 0);
+            // Claude Code 形式入力 → source_format は ClaudeCode
+            assert_eq!(hr.source_format, SourceFormat::ClaudeCode);
         }
         _ => panic!("Expected HookConverted"),
     }

--- a/src/component/deployment/output.rs
+++ b/src/component/deployment/output.rs
@@ -5,7 +5,7 @@
 //! `~Output` 命名を採用している（`std::process::Output` などの慣用に倣う）。
 
 use crate::component::convert::{AgentConversionResult, ConversionResult};
-use crate::hooks::converter::ConversionWarning;
+use crate::hooks::converter::{ConversionWarning, SourceFormat};
 
 /// デプロイ結果
 #[derive(Debug)]
@@ -25,6 +25,9 @@ pub enum DeploymentOutput {
 pub struct HookConvertOutput {
     pub warnings: Vec<ConversionWarning>,
     pub script_count: usize,
+    /// 入力 JSON が Claude Code 形式だったか Copilot 形式（passthrough）だったか。
+    /// `(converted from Claude Code format)` サフィックスの判定に使う。
+    pub source_format: SourceFormat,
 }
 
 impl std::fmt::Display for DeploymentOutput {

--- a/src/component/deployment/output_test.rs
+++ b/src/component/deployment/output_test.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::component::convert::{AgentConversionResult, AgentFormat, ConversionResult};
 use crate::component::CommandFormat;
-use crate::hooks::converter::ConversionWarning;
+use crate::hooks::converter::{ConversionWarning, SourceFormat};
 
 // ========================================
 // HookConvertOutput tests
@@ -12,10 +12,12 @@ fn test_hook_convert_result_has_expected_fields() {
     let result = HookConvertOutput {
         warnings: vec![ConversionWarning::MissingVersion],
         script_count: 2,
+        source_format: SourceFormat::ClaudeCode,
     };
 
     assert_eq!(result.warnings.len(), 1);
     assert_eq!(result.script_count, 2);
+    assert_eq!(result.source_format, SourceFormat::ClaudeCode);
 }
 
 #[test]
@@ -23,6 +25,7 @@ fn test_deployment_result_hook_converted_variant() {
     let hook_result = HookConvertOutput {
         warnings: vec![],
         script_count: 0,
+        source_format: SourceFormat::ClaudeCode,
     };
     let result = DeploymentOutput::HookConverted(hook_result);
 
@@ -90,6 +93,7 @@ fn test_display_hook_converted() {
     let result = DeploymentOutput::HookConverted(HookConvertOutput {
         warnings: vec![ConversionWarning::MissingVersion],
         script_count: 3,
+        source_format: SourceFormat::ClaudeCode,
     });
     assert_eq!(result.to_string(), "Hook converted (3 scripts, 1 warning)");
 }

--- a/src/install.rs
+++ b/src/install.rs
@@ -83,9 +83,14 @@ pub struct PlaceSuccess {
     /// `HookConverted` 時に生成されたスクリプト数（それ以外は 0）。
     /// 「全イベント除外」判定（`script_count == 0 && skipped_count > 0`）に使う。
     pub script_count: usize,
-    /// Hook 変換時の入力形式（`HookConverted` 以外は `None`）。
-    /// `Some(SourceFormat::ClaudeCode)` のときのみ
+    /// Hook 変換時の入力形式。`Some(SourceFormat::ClaudeCode)` のときのみ
     /// `(converted from Claude Code format)` サフィックスを表示する。
+    ///
+    /// `None` になるケース:
+    /// - **Hook 以外**（Skill / Agent / Command / Instruction）
+    /// - **Hook だが `DeploymentOutput::Copied` 経路**を通った場合（version 付き
+    ///   Copilot 形式の完全 passthrough。`HookConvertOutput` を経由しないため
+    ///   `source_format` を保持しない）
     pub hook_source_format: Option<SourceFormat>,
 }
 

--- a/src/install.rs
+++ b/src/install.rs
@@ -9,6 +9,9 @@ use crate::plugin::{
 use crate::source::parse_source;
 use crate::target::{PluginOrigin, Target, TargetKind};
 
+pub mod format;
+pub use crate::hooks::converter::{ConversionWarning, SourceFormat};
+
 /// スキャン済みプラグイン
 ///
 /// ダウンロード済みプラグインからコンポーネントをスキャンした結果。
@@ -75,7 +78,15 @@ pub struct PlaceSuccess {
     pub target_path: PathBuf,
     pub source_format: Option<String>,
     pub dest_format: Option<String>,
-    pub hook_warnings: Vec<String>,
+    /// Hook 変換時の警告（`HookConverted` 以外は空）。
+    pub hook_warnings: Vec<ConversionWarning>,
+    /// `HookConverted` 時に生成されたスクリプト数（それ以外は 0）。
+    /// 「全イベント除外」判定（`script_count == 0 && skipped_count > 0`）に使う。
+    pub script_count: usize,
+    /// Hook 変換時の入力形式（`HookConverted` 以外は `None`）。
+    /// `Some(SourceFormat::ClaudeCode)` のときのみ
+    /// `(converted from Claude Code format)` サフィックスを表示する。
+    pub hook_source_format: Option<SourceFormat>,
 }
 
 /// 配置失敗の段階
@@ -239,11 +250,11 @@ pub fn place_plugin(request: &PlaceRequest) -> PlaceResult {
                         _ => (None, None),
                     };
 
-                    let hook_warnings = match &result {
+                    let (hook_warnings, script_count, hook_source_format) = match &result {
                         DeploymentOutput::HookConverted(hr) => {
-                            hr.warnings.iter().map(|w| w.to_string()).collect()
+                            (hr.warnings.clone(), hr.script_count, Some(hr.source_format))
                         }
-                        _ => vec![],
+                        _ => (Vec::new(), 0, None),
                     };
 
                     successes.push(PlaceSuccess {
@@ -254,6 +265,8 @@ pub fn place_plugin(request: &PlaceRequest) -> PlaceResult {
                         source_format,
                         dest_format,
                         hook_warnings,
+                        script_count,
+                        hook_source_format,
                     });
                 }
                 Err(e) => {

--- a/src/install.rs
+++ b/src/install.rs
@@ -81,7 +81,13 @@ pub struct PlaceSuccess {
     /// Hook 変換時の警告（`HookConverted` 以外は空）。
     pub hook_warnings: Vec<ConversionWarning>,
     /// `HookConverted` 時に生成されたスクリプト数（それ以外は 0）。
-    /// 「全イベント除外」判定（`script_count == 0 && skipped_count > 0`）に使う。
+    ///
+    /// ClaudeCode 入力では各 hook が必ず 1 つのスクリプト（command / http / stub）を
+    /// 生成するため、`script_count == 0` ⇔ 変換後の `hooks.json` が空、という
+    /// 不変条件が成立する。`format::format_empty_hooks_warning` はこの不変条件と
+    /// `hook_source_format == Some(SourceFormat::ClaudeCode)` の組み合わせで
+    /// 「空 `hooks.json` 配置警告」を出す。除外の主因が `UnsupportedEvent` /
+    /// `UnsupportedHookType` / `RemovedField` のいずれかは問わない。
     pub script_count: usize,
     /// Hook 変換時の入力形式。`Some(SourceFormat::ClaudeCode)` のときのみ
     /// `(converted from Claude Code format)` サフィックスを表示する。

--- a/src/install/format.rs
+++ b/src/install/format.rs
@@ -126,7 +126,8 @@ pub fn format_manual_rewrite_section(stubs: &[(String, String)]) -> Option<Strin
         return None;
     }
     let count = stubs.len();
-    let header = format!("Manual rewrite required ({} hooks):", count);
+    let noun = if count == 1 { "hook" } else { "hooks" };
+    let header = format!("Manual rewrite required ({} {}):", count, noun);
     let mut lines: Vec<String> = Vec::with_capacity(stubs.len() + 2);
     lines.push(format!("  {}", header.magenta().bold()));
     for (hook_type, event) in stubs {

--- a/src/install/format.rs
+++ b/src/install/format.rs
@@ -30,11 +30,17 @@ pub fn should_show_converted_suffix(source: Option<SourceFormat>) -> bool {
 /// 将来 `ConversionWarning` に新 variant が追加されても、既知の集約対象に
 /// 該当しないものは全て `others` に流れる（`match` 末尾の `_ =>` で網羅）。
 pub struct ClassifiedWarnings<'a> {
-    /// `UnsupportedEvent` / `UnsupportedHookType` から抽出した event 名（一意化・整列済み）
+    /// `UnsupportedEvent` から抽出した event 名（一意化・整列済み）。
+    ///
+    /// **注意**: ここに入るのは「イベント全体が除外された」ケースのみ。
+    /// `UnsupportedHookType` は同じイベント内の他のフックが残ることがあるため
+    /// `others` 側へ流し、個別の Warning として `Display` の正確な文言で表示する。
     pub skipped: BTreeSet<String>,
     /// `PromptAgentHookStub` の `(hook_type, event)` ペア（入力順保持）
     pub stubs: Vec<(String, String)>,
-    /// 上記カテゴリ以外の warning（`RemovedField` / `MissingVersion` / 将来 variant）
+    /// 上記カテゴリ以外の warning（`UnsupportedHookType` / `RemovedField` /
+    /// `MissingVersion` / 将来 variant）。CLI では `format_individual_warning`
+    /// 経由で 1 件ずつ出力する。
     pub others: Vec<&'a ConversionWarning>,
 }
 
@@ -49,13 +55,13 @@ pub fn classify_hook_warnings(warnings: &[ConversionWarning]) -> ClassifiedWarni
             ConversionWarning::UnsupportedEvent { event } => {
                 skipped.insert(event.clone());
             }
-            ConversionWarning::UnsupportedHookType { event, .. } => {
-                skipped.insert(event.clone());
-            }
             ConversionWarning::PromptAgentHookStub { hook_type, event } => {
                 stubs.push((hook_type.clone(), event.clone()));
             }
-            // `RemovedField` / `MissingVersion` / 将来追加 variant はすべて others へ。
+            // `UnsupportedHookType` は「イベント内の特定フックのみ除外」を意味するため
+            // 「イベント全体がスキップされた」を示す skipped バケットには入れない。
+            // `RemovedField` / `MissingVersion` / 将来追加 variant も含めて others へ流し、
+            // `Display` の正確な文言を保ったまま 1 件ずつ出力する。
             _ => {
                 others.push(w);
             }

--- a/src/install/format.rs
+++ b/src/install/format.rs
@@ -1,0 +1,208 @@
+//! install コマンド出力の整形ユーティリティ
+//!
+//! Hook 変換結果を CLI に表示するための副作用なし pure function 群。
+//! `commands/install.rs` の出力ループは本モジュールの戻り値を `println!` /
+//! `eprintln!` に流すだけのラッパに専念する。
+
+use crate::component::ComponentKind;
+use crate::hooks::converter::{ConversionWarning, SourceFormat};
+use owo_colors::OwoColorize;
+use std::collections::BTreeSet;
+
+/// `(converted from Claude Code format)` サフィックスを表示すべきかを判定する pure function。
+///
+/// 仕様（必須 3 分岐）:
+/// - `Some(SourceFormat::ClaudeCode)` → `true`（Claude Code 形式から変換された Hook のみ）
+/// - `Some(SourceFormat::TargetFormat)` → `false`（Copilot 形式 passthrough、false positive 防止）
+/// - `None` → `false`（Hook 以外）
+///
+/// この関数は **stdout の suffix 表示専用**。stderr の Hook 警告セクション
+/// （skipped events 集約 / Manual rewrite / All events skipped / 個別 Warning）の
+/// 表示条件はこの関数を経由しない。warning 群の表示条件は
+/// `component_kind == ComponentKind::Hook` かつ各カテゴリの非空判定のみで決まり、
+/// `source_format` には依存しない。
+pub fn should_show_converted_suffix(source: Option<SourceFormat>) -> bool {
+    matches!(source, Some(SourceFormat::ClaudeCode))
+}
+
+/// `&[ConversionWarning]` を出力カテゴリへ分類した結果。
+///
+/// 将来 `ConversionWarning` に新 variant が追加されても、既知の集約対象に
+/// 該当しないものは全て `others` に流れる（`match` 末尾の `_ =>` で網羅）。
+pub struct ClassifiedWarnings<'a> {
+    /// `UnsupportedEvent` / `UnsupportedHookType` から抽出した event 名（一意化・整列済み）
+    pub skipped: BTreeSet<String>,
+    /// `PromptAgentHookStub` の `(hook_type, event)` ペア（入力順保持）
+    pub stubs: Vec<(String, String)>,
+    /// 上記カテゴリ以外の warning（`RemovedField` / `MissingVersion` / 将来 variant）
+    pub others: Vec<&'a ConversionWarning>,
+}
+
+/// `&[ConversionWarning]` を `ClassifiedWarnings` に分類する pure function。
+pub fn classify_hook_warnings(warnings: &[ConversionWarning]) -> ClassifiedWarnings<'_> {
+    let mut skipped: BTreeSet<String> = BTreeSet::new();
+    let mut stubs: Vec<(String, String)> = Vec::new();
+    let mut others: Vec<&ConversionWarning> = Vec::new();
+
+    for w in warnings {
+        match w {
+            ConversionWarning::UnsupportedEvent { event } => {
+                skipped.insert(event.clone());
+            }
+            ConversionWarning::UnsupportedHookType { event, .. } => {
+                skipped.insert(event.clone());
+            }
+            ConversionWarning::PromptAgentHookStub { hook_type, event } => {
+                stubs.push((hook_type.clone(), event.clone()));
+            }
+            // `RemovedField` / `MissingVersion` / 将来追加 variant はすべて others へ。
+            _ => {
+                others.push(w);
+            }
+        }
+    }
+
+    ClassifiedWarnings {
+        skipped,
+        stubs,
+        others,
+    }
+}
+
+/// stdout の "+" 行末に付与する変換済みサフィックス（cyan）。
+///
+/// 例: ` (converted from Claude Code format)`
+///
+/// 呼び出し側は `should_show_converted_suffix(success.hook_source_format)` が
+/// `true` のときのみ呼ぶこと。
+pub fn format_converted_hook_suffix() -> String {
+    format!(" {}", "(converted from Claude Code format)".cyan())
+}
+
+/// 除外イベントの集約警告（stderr / yellow）。
+///
+/// 集約済み event 集合（`BTreeSet` で一意化・整列済み）を受け取る。
+/// 0 件のときは `None`。
+///
+/// 文言仕様: 件数によらず常に複数形 `events skipped` を使う（1 件でも
+/// `1 events skipped`）。issue #190 受入基準例文と整合する単純化（hearing-notes
+/// 論点 5 採択）。
+pub fn format_skipped_events_warning(events: &BTreeSet<String>) -> Option<String> {
+    if events.is_empty() {
+        return None;
+    }
+    let count = events.len();
+    let list = events.iter().cloned().collect::<Vec<_>>().join(", ");
+    Some(format!(
+        "  {} {} events skipped (not supported in Copilot CLI): {}",
+        "Warning:".yellow(),
+        count,
+        list
+    ))
+}
+
+/// prompt/agent フックの手動書き換え案内（stderr / magenta + bold 見出し）。
+///
+/// `(hook_type, event)` のリストを受け取る。0 件のときは `None`。
+/// 出力は見出し + 各 stub 行 + Note 行を `\n` で結合した 1 個の `String`。
+pub fn format_manual_rewrite_section(stubs: &[(String, String)]) -> Option<String> {
+    if stubs.is_empty() {
+        return None;
+    }
+    let count = stubs.len();
+    let header = format!("Manual rewrite required ({} hooks):", count);
+    let mut lines: Vec<String> = Vec::with_capacity(stubs.len() + 2);
+    lines.push(format!("  {}", header.magenta().bold()));
+    for (hook_type, event) in stubs {
+        lines.push(format!("    - '{}' hook for event '{}'", hook_type, event));
+    }
+    lines.push(
+        "  Note: stub scripts have been generated; please rewrite them manually.".to_string(),
+    );
+    Some(lines.join("\n"))
+}
+
+/// 全イベント除外時の追加警告（stderr / yellow）。
+///
+/// `script_count == 0 && skipped_count > 0` のとき返す。それ以外は `None`。
+pub fn format_empty_hooks_warning(script_count: usize, skipped_count: usize) -> Option<String> {
+    if script_count == 0 && skipped_count > 0 {
+        Some(format!(
+            "  {} All events were skipped; an empty hooks.json was placed.",
+            "Warning:".yellow()
+        ))
+    } else {
+        None
+    }
+}
+
+/// 個別 Warning（others カテゴリ全般）を 1 行にフォーマット。
+///
+/// 既存 `ConversionWarning::Display` をそのまま使い、yellow の `Warning:` を付与。
+pub fn format_individual_warning(warning: &ConversionWarning) -> String {
+    format!("  {} {}", "Warning:".yellow(), warning)
+}
+
+/// Hook ターゲットの success を CLI に表示するための副作用なしレンダリング結果。
+pub struct HookRenderOutput {
+    /// `+` 行末に追加する suffix。`None` なら追加しない（Copilot passthrough や Hook 以外）。
+    pub stdout_suffix: Option<String>,
+    /// stderr に順に出力するブロック群。各要素は `format_*` 関数の戻り値で
+    /// 複数行を含む可能性がある（例: Manual rewrite セクションは見出し + 行 +
+    /// Note を `\n` で結合した 1 個の `String`）。CLI 側は各要素を
+    /// `eprintln!("{}", block)` で出力すればよい。
+    pub stderr_blocks: Vec<String>,
+}
+
+/// Hook の success データから表示用の `HookRenderOutput` を組み立てる pure function。
+///
+/// 分岐仕様:
+/// - `stdout_suffix`: `should_show_converted_suffix(hook_source_format)` が
+///   `true` のときのみ `Some(format_converted_hook_suffix())`、それ以外は `None`
+/// - `stderr_blocks`: `component_kind == Hook` かつ各カテゴリ非空のときのみ追加。
+///   `source_format` 非依存（Copilot 形式 + `MissingVersion` でも warning は出る）
+/// - Hook 以外の `component_kind` では空の `HookRenderOutput` を返す
+pub fn render_hook_success(
+    component_kind: ComponentKind,
+    hook_source_format: Option<SourceFormat>,
+    hook_warnings: &[ConversionWarning],
+    script_count: usize,
+) -> HookRenderOutput {
+    if component_kind != ComponentKind::Hook {
+        return HookRenderOutput {
+            stdout_suffix: None,
+            stderr_blocks: Vec::new(),
+        };
+    }
+
+    let stdout_suffix = if should_show_converted_suffix(hook_source_format) {
+        Some(format_converted_hook_suffix())
+    } else {
+        None
+    };
+
+    let classified = classify_hook_warnings(hook_warnings);
+    let mut stderr_blocks: Vec<String> = Vec::new();
+
+    if let Some(line) = format_skipped_events_warning(&classified.skipped) {
+        stderr_blocks.push(line);
+    }
+    if let Some(section) = format_manual_rewrite_section(&classified.stubs) {
+        stderr_blocks.push(section);
+    }
+    if let Some(line) = format_empty_hooks_warning(script_count, classified.skipped.len()) {
+        stderr_blocks.push(line);
+    }
+    for w in &classified.others {
+        stderr_blocks.push(format_individual_warning(w));
+    }
+
+    HookRenderOutput {
+        stdout_suffix,
+        stderr_blocks,
+    }
+}
+
+#[cfg(test)]
+#[path = "format_test.rs"]
+mod tests;

--- a/src/install/format.rs
+++ b/src/install/format.rs
@@ -13,8 +13,15 @@ use std::collections::BTreeSet;
 ///
 /// 仕様（必須 3 分岐）:
 /// - `Some(SourceFormat::ClaudeCode)` → `true`（Claude Code 形式から変換された Hook のみ）
-/// - `Some(SourceFormat::TargetFormat)` → `false`（Copilot 形式 passthrough、false positive 防止）
-/// - `None` → `false`（Hook 以外）
+/// - `Some(SourceFormat::TargetFormat)` → `false`（Copilot 形式 passthrough の `HookConverted`
+///   ルートで warning を伴うケース。false positive 防止）
+/// - `None` → `false`。`None` は次の 2 ケースで発生する:
+///     1. **Hook 以外**（Skill / Agent / Command / Instruction）。`PlaceSuccess` 構築時に
+///        `hook_source_format` が `None` で初期化される
+///     2. **Hook だが `DeploymentOutput::Copied` 経路**を通ったケース（version 付き
+///        Copilot 形式の完全 passthrough。`HookConvertOutput` を経由しないため
+///        `source_format` を持たない）
+///   どちらのケースでも suffix は表示しない。
 ///
 /// この関数は **stdout の suffix 表示専用**。stderr の Hook 警告セクション
 /// （skipped events 集約 / Manual rewrite / All events skipped / 個別 Warning）の

--- a/src/install/format.rs
+++ b/src/install/format.rs
@@ -140,14 +140,29 @@ pub fn format_manual_rewrite_section(stubs: &[(String, String)]) -> Option<Strin
 /// 変換結果として hook が 1 件も残らなかった場合の追加警告（stderr / yellow）。
 ///
 /// 「空 `hooks.json` を放置したまま気づかれない」状況を防ぐためのセーフティネット。
-/// `script_count == 0 && dropped_count > 0` のとき返す。それ以外は `None`。
+/// `source_format == Some(SourceFormat::ClaudeCode) && script_count == 0` のとき返す。
+/// それ以外は `None`。
 ///
-/// `dropped_count` は **何らかの理由で除外された hook** の総件数（呼び出し側で集計）。
-/// `UnsupportedEvent` で event 単位に除外されたケースだけでなく、
-/// `UnsupportedHookType` で event 内の全 hook が除外され `convert_event_hooks` が
-/// その event ごと落としたケース（`UnsupportedEvent` は出ない）もカバーする。
-pub fn format_empty_hooks_warning(script_count: usize, dropped_count: usize) -> Option<String> {
-    if script_count == 0 && dropped_count > 0 {
+/// **判定方針**: ClaudeCode 入力時は各 hook が必ずスクリプトを生成するため、
+/// `script_count == 0` ⇔「変換後の `hooks.json` が空」という不変条件が成立する。
+/// この単一の条件で、除外の主因が `UnsupportedEvent` / `UnsupportedHookType` /
+/// `RemovedField`（イベント値が配列でない、matcher group の `hooks` 配列欠落 など、
+/// 詳細は `src/hooks/converter.rs::flatten_matchers`）のいずれであっても取りこぼさず
+/// 警告を出せる。
+///
+/// **`source_format == Some(TargetFormat)` の扱い**: passthrough では入力 JSON が
+/// そのまま配置され `script_count == 0` でも `hooks.json` は空ではない（例:
+/// `MissingVersion` 警告つきの Copilot 形式入力）。誤検知を避けるためここでは
+/// 警告を出さない。
+///
+/// **`source_format == None` の扱い**: Hook 以外（Skill / Agent / ...）または
+/// `DeploymentOutput::Copied` 経路の Hook（version 付き Copilot 完全 passthrough）。
+/// どちらも警告対象外。
+pub fn format_empty_hooks_warning(
+    script_count: usize,
+    source_format: Option<SourceFormat>,
+) -> Option<String> {
+    if script_count == 0 && source_format == Some(SourceFormat::ClaudeCode) {
         Some(format!(
             "  {} An empty hooks.json was placed; no hooks remained after conversion.",
             "Warning:".yellow()
@@ -211,17 +226,10 @@ pub fn render_hook_success(
     if let Some(section) = format_manual_rewrite_section(&classified.stubs) {
         stderr_blocks.push(section);
     }
-    // 空 `hooks.json` 警告は「除外が起きたか」で判定する。`UnsupportedEvent`
-    // による event 全体除外だけでなく、`UnsupportedHookType` で event 内の全
-    // hook が除外され `convert_event_hooks` がその event ごと落としたケース
-    // （`UnsupportedEvent` は出ない）も含めてカウントする。
-    let unsupported_hook_type_count = classified
-        .others
-        .iter()
-        .filter(|w| matches!(w, ConversionWarning::UnsupportedHookType { .. }))
-        .count();
-    let dropped_count = classified.skipped.len() + unsupported_hook_type_count;
-    if let Some(line) = format_empty_hooks_warning(script_count, dropped_count) {
+    // 空 `hooks.json` 警告は ClaudeCode 入力時の `script_count == 0` だけで判定する
+    // （除外の主因が `UnsupportedEvent` / `UnsupportedHookType` / `RemovedField` の
+    // どれであっても 1 つの不変条件で取りこぼさない）。
+    if let Some(line) = format_empty_hooks_warning(script_count, hook_source_format) {
         stderr_blocks.push(line);
     }
     for w in &classified.others {

--- a/src/install/format.rs
+++ b/src/install/format.rs
@@ -137,13 +137,19 @@ pub fn format_manual_rewrite_section(stubs: &[(String, String)]) -> Option<Strin
     Some(lines.join("\n"))
 }
 
-/// 全イベント除外時の追加警告（stderr / yellow）。
+/// 変換結果として hook が 1 件も残らなかった場合の追加警告（stderr / yellow）。
 ///
-/// `script_count == 0 && skipped_count > 0` のとき返す。それ以外は `None`。
-pub fn format_empty_hooks_warning(script_count: usize, skipped_count: usize) -> Option<String> {
-    if script_count == 0 && skipped_count > 0 {
+/// 「空 `hooks.json` を放置したまま気づかれない」状況を防ぐためのセーフティネット。
+/// `script_count == 0 && dropped_count > 0` のとき返す。それ以外は `None`。
+///
+/// `dropped_count` は **何らかの理由で除外された hook** の総件数（呼び出し側で集計）。
+/// `UnsupportedEvent` で event 単位に除外されたケースだけでなく、
+/// `UnsupportedHookType` で event 内の全 hook が除外され `convert_event_hooks` が
+/// その event ごと落としたケース（`UnsupportedEvent` は出ない）もカバーする。
+pub fn format_empty_hooks_warning(script_count: usize, dropped_count: usize) -> Option<String> {
+    if script_count == 0 && dropped_count > 0 {
         Some(format!(
-            "  {} All events were skipped; an empty hooks.json was placed.",
+            "  {} An empty hooks.json was placed; no hooks remained after conversion.",
             "Warning:".yellow()
         ))
     } else {
@@ -205,7 +211,17 @@ pub fn render_hook_success(
     if let Some(section) = format_manual_rewrite_section(&classified.stubs) {
         stderr_blocks.push(section);
     }
-    if let Some(line) = format_empty_hooks_warning(script_count, classified.skipped.len()) {
+    // 空 `hooks.json` 警告は「除外が起きたか」で判定する。`UnsupportedEvent`
+    // による event 全体除外だけでなく、`UnsupportedHookType` で event 内の全
+    // hook が除外され `convert_event_hooks` がその event ごと落としたケース
+    // （`UnsupportedEvent` は出ない）も含めてカウントする。
+    let unsupported_hook_type_count = classified
+        .others
+        .iter()
+        .filter(|w| matches!(w, ConversionWarning::UnsupportedHookType { .. }))
+        .count();
+    let dropped_count = classified.skipped.len() + unsupported_hook_type_count;
+    if let Some(line) = format_empty_hooks_warning(script_count, dropped_count) {
         stderr_blocks.push(line);
     }
     for w in &classified.others {

--- a/src/install/format.rs
+++ b/src/install/format.rs
@@ -99,19 +99,20 @@ pub fn format_converted_hook_suffix() -> String {
 /// 集約済み event 集合（`BTreeSet` で一意化・整列済み）を受け取る。
 /// 0 件のときは `None`。
 ///
-/// 文言仕様: 件数によらず常に複数形 `events skipped` を使う（1 件でも
-/// `1 events skipped`）。issue #190 受入基準例文と整合する単純化（hearing-notes
-/// 論点 5 採択）。
+/// 文言: 件数に応じて単数形 `1 event skipped` / 複数形 `N events skipped` を
+/// 切り替える（user-facing CLI なので英語の単複は正確に出す）。
 pub fn format_skipped_events_warning(events: &BTreeSet<String>) -> Option<String> {
     if events.is_empty() {
         return None;
     }
     let count = events.len();
+    let noun = if count == 1 { "event" } else { "events" };
     let list = events.iter().cloned().collect::<Vec<_>>().join(", ");
     Some(format!(
-        "  {} {} events skipped (not supported in Copilot CLI): {}",
+        "  {} {} {} skipped (not supported in Copilot CLI): {}",
         "Warning:".yellow(),
         count,
+        noun,
         list
     ))
 }

--- a/src/install/format.rs
+++ b/src/install/format.rs
@@ -13,15 +13,17 @@ use std::collections::BTreeSet;
 ///
 /// 仕様（必須 3 分岐）:
 /// - `Some(SourceFormat::ClaudeCode)` → `true`（Claude Code 形式から変換された Hook のみ）
-/// - `Some(SourceFormat::TargetFormat)` → `false`（Copilot 形式 passthrough の `HookConverted`
-///   ルートで warning を伴うケース。false positive 防止）
-/// - `None` → `false`。`None` は次の 2 ケースで発生する:
-///     1. **Hook 以外**（Skill / Agent / Command / Instruction）。`PlaceSuccess` 構築時に
-///        `hook_source_format` が `None` で初期化される
-///     2. **Hook だが `DeploymentOutput::Copied` 経路**を通ったケース（version 付き
-///        Copilot 形式の完全 passthrough。`HookConvertOutput` を経由しないため
-///        `source_format` を持たない）
-///   どちらのケースでも suffix は表示しない。
+/// - `Some(SourceFormat::TargetFormat)` → `false`（Copilot 形式 passthrough の
+///   `HookConverted` ルートで warning を伴うケース。false positive 防止）
+/// - `None` → `false`（suffix を表示しない）
+///
+/// `None` は次の 2 ケースで発生する。どちらでも suffix は表示しない:
+///
+/// 1. **Hook 以外**（Skill / Agent / Command / Instruction）。`PlaceSuccess` 構築時に
+///    `hook_source_format` が `None` で初期化される
+/// 2. **Hook だが `DeploymentOutput::Copied` 経路**を通ったケース（version 付き
+///    Copilot 形式の完全 passthrough。`HookConvertOutput` を経由しないため
+///    `source_format` を保持しない）
 ///
 /// この関数は **stdout の suffix 表示専用**。stderr の Hook 警告セクション
 /// （skipped events 集約 / Manual rewrite / All events skipped / 個別 Warning）の

--- a/src/install/format_test.rs
+++ b/src/install/format_test.rs
@@ -1,0 +1,361 @@
+use super::*;
+use crate::component::ComponentKind;
+use crate::hooks::converter::{ConversionWarning, SourceFormat};
+use owo_colors::OwoColorize;
+use std::collections::BTreeSet;
+
+// ============================================================================
+// should_show_converted_suffix（3 分岐網羅）
+// ============================================================================
+
+#[test]
+fn should_show_converted_suffix_returns_true_for_claude_code() {
+    assert!(should_show_converted_suffix(Some(SourceFormat::ClaudeCode)));
+}
+
+#[test]
+fn should_show_converted_suffix_returns_false_for_target_format() {
+    // Copilot 形式 passthrough のときに suffix を出さない（false positive 防止）
+    assert!(!should_show_converted_suffix(Some(
+        SourceFormat::TargetFormat
+    )));
+}
+
+#[test]
+fn should_show_converted_suffix_returns_false_for_none() {
+    // Hook 以外（hook_source_format == None）では suffix を出さない
+    assert!(!should_show_converted_suffix(None));
+}
+
+// ============================================================================
+// format_converted_hook_suffix
+// ============================================================================
+
+#[test]
+fn format_converted_hook_suffix_returns_cyan_decorated_label() {
+    let actual = format_converted_hook_suffix();
+    let expected = format!(" {}", "(converted from Claude Code format)".cyan());
+    assert_eq!(actual, expected);
+    assert!(actual.contains("(converted from Claude Code format)"));
+    // 先頭スペースは `+` 行末に直接連結する想定
+    assert!(actual.starts_with(' '));
+}
+
+// ============================================================================
+// classify_hook_warnings
+// ============================================================================
+
+#[test]
+fn classify_hook_warnings_collects_unsupported_event_into_skipped() {
+    let warnings = vec![ConversionWarning::UnsupportedEvent {
+        event: "Notification".to_string(),
+    }];
+    let classified = classify_hook_warnings(&warnings);
+    assert_eq!(classified.skipped.len(), 1);
+    assert!(classified.skipped.contains("Notification"));
+    assert!(classified.stubs.is_empty());
+    assert!(classified.others.is_empty());
+}
+
+#[test]
+fn classify_hook_warnings_extracts_event_from_unsupported_hook_type() {
+    let warnings = vec![ConversionWarning::UnsupportedHookType {
+        hook_type: "weird".to_string(),
+        event: "PreCompact".to_string(),
+    }];
+    let classified = classify_hook_warnings(&warnings);
+    assert_eq!(classified.skipped.len(), 1);
+    assert!(classified.skipped.contains("PreCompact"));
+    assert!(classified.stubs.is_empty());
+    assert!(classified.others.is_empty());
+}
+
+#[test]
+fn classify_hook_warnings_dedupes_events_via_btreeset() {
+    // 3 件混在（重複あり）→ BTreeSet で 2 件に一意化、アルファベット順
+    let warnings = vec![
+        ConversionWarning::UnsupportedEvent {
+            event: "Foo".to_string(),
+        },
+        ConversionWarning::UnsupportedHookType {
+            hook_type: "weird".to_string(),
+            event: "Foo".to_string(),
+        },
+        ConversionWarning::UnsupportedEvent {
+            event: "Bar".to_string(),
+        },
+    ];
+    let classified = classify_hook_warnings(&warnings);
+    assert_eq!(classified.skipped.len(), 2);
+    let ordered: Vec<&String> = classified.skipped.iter().collect();
+    assert_eq!(ordered[0], "Bar");
+    assert_eq!(ordered[1], "Foo");
+}
+
+#[test]
+fn classify_hook_warnings_collects_prompt_agent_stubs_in_input_order() {
+    let warnings = vec![
+        ConversionWarning::PromptAgentHookStub {
+            hook_type: "prompt".to_string(),
+            event: "preToolUse".to_string(),
+        },
+        ConversionWarning::PromptAgentHookStub {
+            hook_type: "agent".to_string(),
+            event: "postToolUse".to_string(),
+        },
+    ];
+    let classified = classify_hook_warnings(&warnings);
+    assert_eq!(classified.stubs.len(), 2);
+    assert_eq!(classified.stubs[0].0, "prompt");
+    assert_eq!(classified.stubs[0].1, "preToolUse");
+    assert_eq!(classified.stubs[1].0, "agent");
+    assert_eq!(classified.stubs[1].1, "postToolUse");
+    assert!(classified.skipped.is_empty());
+    assert!(classified.others.is_empty());
+}
+
+#[test]
+fn classify_hook_warnings_routes_others_for_removed_field_and_missing_version() {
+    let warnings = vec![
+        ConversionWarning::RemovedField {
+            field: "matcher".to_string(),
+            reason: "Copilot CLI does not support matchers".to_string(),
+        },
+        ConversionWarning::MissingVersion,
+    ];
+    let classified = classify_hook_warnings(&warnings);
+    assert_eq!(classified.others.len(), 2);
+    assert!(classified.skipped.is_empty());
+    assert!(classified.stubs.is_empty());
+}
+
+// ============================================================================
+// format_skipped_events_warning
+// ============================================================================
+
+#[test]
+fn format_skipped_events_warning_returns_none_for_empty() {
+    let events: BTreeSet<String> = BTreeSet::new();
+    assert!(format_skipped_events_warning(&events).is_none());
+}
+
+#[test]
+fn format_skipped_events_warning_uses_plural_even_for_single_event() {
+    // 件数 1 でも複数形 `events` を使う仕様（hearing-notes 論点 5 採択）
+    let mut events = BTreeSet::new();
+    events.insert("Notification".to_string());
+    let actual = format_skipped_events_warning(&events).unwrap();
+    let expected = format!(
+        "  {} 1 events skipped (not supported in Copilot CLI): Notification",
+        "Warning:".yellow()
+    );
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn format_skipped_events_warning_lists_three_events_alphabetically() {
+    let mut events = BTreeSet::new();
+    events.insert("PreCompact".to_string());
+    events.insert("Notification".to_string());
+    events.insert("SubagentStart".to_string());
+    let actual = format_skipped_events_warning(&events).unwrap();
+    let expected = format!(
+        "  {} 3 events skipped (not supported in Copilot CLI): Notification, PreCompact, SubagentStart",
+        "Warning:".yellow()
+    );
+    assert_eq!(actual, expected);
+}
+
+// ============================================================================
+// format_manual_rewrite_section
+// ============================================================================
+
+#[test]
+fn format_manual_rewrite_section_returns_none_for_empty() {
+    assert!(format_manual_rewrite_section(&[]).is_none());
+}
+
+#[test]
+fn format_manual_rewrite_section_renders_header_lines_and_note() {
+    let stubs = vec![
+        ("prompt".to_string(), "preToolUse".to_string()),
+        ("agent".to_string(), "postToolUse".to_string()),
+    ];
+    let actual = format_manual_rewrite_section(&stubs).unwrap();
+    let header = "Manual rewrite required (2 hooks):";
+    assert!(actual.contains(&header.magenta().bold().to_string()));
+    assert!(actual.contains("    - 'prompt' hook for event 'preToolUse'"));
+    assert!(actual.contains("    - 'agent' hook for event 'postToolUse'"));
+    assert!(
+        actual.contains("  Note: stub scripts have been generated; please rewrite them manually.")
+    );
+    // 行構成: 見出し + 2 stub 行 + Note 行 = 4 行
+    assert_eq!(actual.lines().count(), 4);
+}
+
+// ============================================================================
+// format_empty_hooks_warning
+// ============================================================================
+
+#[test]
+fn format_empty_hooks_warning_some_when_zero_scripts_with_skipped() {
+    let actual = format_empty_hooks_warning(0, 3).unwrap();
+    let expected = format!(
+        "  {} All events were skipped; an empty hooks.json was placed.",
+        "Warning:".yellow()
+    );
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn format_empty_hooks_warning_none_when_scripts_present() {
+    assert!(format_empty_hooks_warning(2, 3).is_none());
+}
+
+#[test]
+fn format_empty_hooks_warning_none_when_no_skipped() {
+    assert!(format_empty_hooks_warning(0, 0).is_none());
+}
+
+// ============================================================================
+// format_individual_warning
+// ============================================================================
+
+#[test]
+fn format_individual_warning_decorates_removed_field() {
+    let warning = ConversionWarning::RemovedField {
+        field: "matcher".to_string(),
+        reason: "Copilot CLI does not support matchers".to_string(),
+    };
+    let actual = format_individual_warning(&warning);
+    let expected = format!("  {} {}", "Warning:".yellow(), warning);
+    assert_eq!(actual, expected);
+    assert!(actual.contains("matcher"));
+}
+
+#[test]
+fn format_individual_warning_decorates_missing_version() {
+    let warning = ConversionWarning::MissingVersion;
+    let actual = format_individual_warning(&warning);
+    let expected = format!("  {} {}", "Warning:".yellow(), warning);
+    assert_eq!(actual, expected);
+}
+
+// ============================================================================
+// render_hook_success（副作用なしレンダラ）
+// ============================================================================
+
+#[test]
+fn render_hook_success_claude_code_with_unsupported_events_emits_suffix_and_one_block() {
+    let warnings = vec![
+        ConversionWarning::UnsupportedEvent {
+            event: "Notification".to_string(),
+        },
+        ConversionWarning::UnsupportedEvent {
+            event: "PreCompact".to_string(),
+        },
+        ConversionWarning::UnsupportedEvent {
+            event: "SubagentStart".to_string(),
+        },
+    ];
+    let rendered = render_hook_success(
+        ComponentKind::Hook,
+        Some(SourceFormat::ClaudeCode),
+        &warnings,
+        1,
+    );
+    assert!(rendered.stdout_suffix.is_some());
+    assert_eq!(rendered.stderr_blocks.len(), 1);
+    assert!(rendered.stderr_blocks[0].contains("3 events skipped"));
+}
+
+#[test]
+fn render_hook_success_copilot_format_with_missing_version_no_suffix_only_individual_warning() {
+    // Copilot 形式 + MissingVersion 1 件 → suffix なし、stderr_blocks に individual warning のみ
+    let warnings = vec![ConversionWarning::MissingVersion];
+    let rendered = render_hook_success(
+        ComponentKind::Hook,
+        Some(SourceFormat::TargetFormat),
+        &warnings,
+        0,
+    );
+    assert!(rendered.stdout_suffix.is_none());
+    assert_eq!(rendered.stderr_blocks.len(), 1);
+    assert_eq!(
+        rendered.stderr_blocks[0],
+        format_individual_warning(&ConversionWarning::MissingVersion)
+    );
+}
+
+#[test]
+fn render_hook_success_skill_returns_empty_output() {
+    let rendered = render_hook_success(
+        ComponentKind::Skill,
+        Some(SourceFormat::ClaudeCode),
+        &[ConversionWarning::MissingVersion],
+        1,
+    );
+    assert!(rendered.stdout_suffix.is_none());
+    assert!(rendered.stderr_blocks.is_empty());
+}
+
+#[test]
+fn render_hook_success_all_events_skipped_includes_empty_hooks_warning() {
+    let warnings = vec![
+        ConversionWarning::UnsupportedEvent {
+            event: "Notification".to_string(),
+        },
+        ConversionWarning::UnsupportedEvent {
+            event: "PreCompact".to_string(),
+        },
+    ];
+    let rendered = render_hook_success(
+        ComponentKind::Hook,
+        Some(SourceFormat::ClaudeCode),
+        &warnings,
+        0,
+    );
+    assert!(rendered.stdout_suffix.is_some());
+    // skipped events warning + empty hooks warning の 2 ブロック
+    assert_eq!(rendered.stderr_blocks.len(), 2);
+    assert!(rendered.stderr_blocks[0].contains("2 events skipped"));
+    assert!(rendered.stderr_blocks[1].contains("All events were skipped"));
+}
+
+#[test]
+fn render_hook_success_hook_with_none_source_format_and_no_warnings_returns_empty() {
+    // version 付き Copilot 形式 Hook は DeploymentOutput::Copied 経路で
+    // hook_source_format == None / warnings 0 になる。既存挙動の固定。
+    let rendered = render_hook_success(ComponentKind::Hook, None, &[], 0);
+    assert!(rendered.stdout_suffix.is_none());
+    assert!(rendered.stderr_blocks.is_empty());
+}
+
+#[test]
+fn render_hook_success_prompt_agent_stub_emits_manual_rewrite_section() {
+    // PromptAgentHookStub → classify_hook_warnings → render_hook_success の配線回帰を固定。
+    // 受入基準 3 (issue #190): "Manual rewrite required (N hooks):" セクションが
+    // stderr ブロックに 1 件入ることを確認する。
+    let warnings = vec![
+        ConversionWarning::PromptAgentHookStub {
+            hook_type: "prompt".to_string(),
+            event: "preToolUse".to_string(),
+        },
+        ConversionWarning::PromptAgentHookStub {
+            hook_type: "agent".to_string(),
+            event: "postToolUse".to_string(),
+        },
+    ];
+    let rendered = render_hook_success(
+        ComponentKind::Hook,
+        Some(SourceFormat::ClaudeCode),
+        &warnings,
+        2,
+    );
+    assert!(rendered.stdout_suffix.is_some());
+    assert_eq!(rendered.stderr_blocks.len(), 1);
+    assert!(rendered.stderr_blocks[0].contains("Manual rewrite required (2 hooks):"));
+    assert!(rendered.stderr_blocks[0].contains("'prompt' hook for event 'preToolUse'"));
+    assert!(rendered.stderr_blocks[0].contains("'agent' hook for event 'postToolUse'"));
+    assert!(rendered.stderr_blocks[0].contains("Note: stub scripts have been generated"));
+}

--- a/src/install/format_test.rs
+++ b/src/install/format_test.rs
@@ -58,27 +58,33 @@ fn classify_hook_warnings_collects_unsupported_event_into_skipped() {
 }
 
 #[test]
-fn classify_hook_warnings_extracts_event_from_unsupported_hook_type() {
+fn classify_hook_warnings_routes_unsupported_hook_type_to_others() {
+    // `UnsupportedHookType` は「イベント内の特定フックのみ除外」されたケースで発生する。
+    // イベント全体がスキップされたかのような誤解を防ぐため、`skipped` には入れず
+    // `others` に流して個別 Warning として `Display` の正確な文言で出す。
     let warnings = vec![ConversionWarning::UnsupportedHookType {
         hook_type: "weird".to_string(),
         event: "PreCompact".to_string(),
     }];
     let classified = classify_hook_warnings(&warnings);
-    assert_eq!(classified.skipped.len(), 1);
-    assert!(classified.skipped.contains("PreCompact"));
+    assert!(classified.skipped.is_empty());
     assert!(classified.stubs.is_empty());
-    assert!(classified.others.is_empty());
+    assert_eq!(classified.others.len(), 1);
+    assert!(matches!(
+        classified.others[0],
+        ConversionWarning::UnsupportedHookType { .. }
+    ));
 }
 
 #[test]
-fn classify_hook_warnings_dedupes_events_via_btreeset() {
-    // 3 件混在（重複あり）→ BTreeSet で 2 件に一意化、アルファベット順
+fn classify_hook_warnings_dedupes_unsupported_events_via_btreeset() {
+    // `UnsupportedEvent` のみ 3 件（重複あり）→ BTreeSet で 2 件に一意化、アルファベット順。
+    // `UnsupportedHookType` は別ルートに行くため、ここでは混ぜない。
     let warnings = vec![
         ConversionWarning::UnsupportedEvent {
             event: "Foo".to_string(),
         },
-        ConversionWarning::UnsupportedHookType {
-            hook_type: "weird".to_string(),
+        ConversionWarning::UnsupportedEvent {
             event: "Foo".to_string(),
         },
         ConversionWarning::UnsupportedEvent {
@@ -90,6 +96,30 @@ fn classify_hook_warnings_dedupes_events_via_btreeset() {
     let ordered: Vec<&String> = classified.skipped.iter().collect();
     assert_eq!(ordered[0], "Bar");
     assert_eq!(ordered[1], "Foo");
+}
+
+#[test]
+fn classify_hook_warnings_separates_unsupported_event_from_unsupported_hook_type() {
+    // 同じ event 名でも、`UnsupportedEvent` は skipped、`UnsupportedHookType` は others に
+    // 分かれることを固定する。これにより「イベント全体除外」と「イベント内の一部除外」が
+    // 出力上も明確に区別される。
+    let warnings = vec![
+        ConversionWarning::UnsupportedEvent {
+            event: "PreToolUse".to_string(),
+        },
+        ConversionWarning::UnsupportedHookType {
+            hook_type: "weird".to_string(),
+            event: "PreToolUse".to_string(),
+        },
+    ];
+    let classified = classify_hook_warnings(&warnings);
+    assert_eq!(classified.skipped.len(), 1);
+    assert!(classified.skipped.contains("PreToolUse"));
+    assert_eq!(classified.others.len(), 1);
+    assert!(matches!(
+        classified.others[0],
+        ConversionWarning::UnsupportedHookType { .. }
+    ));
 }
 
 #[test]

--- a/src/install/format_test.rs
+++ b/src/install/format_test.rs
@@ -170,13 +170,13 @@ fn format_skipped_events_warning_returns_none_for_empty() {
 }
 
 #[test]
-fn format_skipped_events_warning_uses_plural_even_for_single_event() {
-    // 件数 1 でも複数形 `events` を使う仕様（hearing-notes 論点 5 採択）
+fn format_skipped_events_warning_uses_singular_for_one_event() {
+    // user-facing CLI の英文として「1 events」は誤りなので、件数 1 のとき "event" を使う。
     let mut events = BTreeSet::new();
     events.insert("Notification".to_string());
     let actual = format_skipped_events_warning(&events).unwrap();
     let expected = format!(
-        "  {} 1 events skipped (not supported in Copilot CLI): Notification",
+        "  {} 1 event skipped (not supported in Copilot CLI): Notification",
         "Warning:".yellow()
     );
     assert_eq!(actual, expected);

--- a/src/install/format_test.rs
+++ b/src/install/format_test.rs
@@ -228,8 +228,8 @@ fn format_manual_rewrite_section_renders_header_lines_and_note() {
 // ============================================================================
 
 #[test]
-fn format_empty_hooks_warning_some_when_zero_scripts_with_drops() {
-    let actual = format_empty_hooks_warning(0, 3).unwrap();
+fn format_empty_hooks_warning_some_for_claude_code_with_zero_scripts() {
+    let actual = format_empty_hooks_warning(0, Some(SourceFormat::ClaudeCode)).unwrap();
     let expected = format!(
         "  {} An empty hooks.json was placed; no hooks remained after conversion.",
         "Warning:".yellow()
@@ -239,12 +239,20 @@ fn format_empty_hooks_warning_some_when_zero_scripts_with_drops() {
 
 #[test]
 fn format_empty_hooks_warning_none_when_scripts_present() {
-    assert!(format_empty_hooks_warning(2, 3).is_none());
+    // 明示的な hook が 1 件以上残っているケース
+    assert!(format_empty_hooks_warning(2, Some(SourceFormat::ClaudeCode)).is_none());
 }
 
 #[test]
-fn format_empty_hooks_warning_none_when_no_drops() {
-    assert!(format_empty_hooks_warning(0, 0).is_none());
+fn format_empty_hooks_warning_none_for_target_format_passthrough() {
+    // TargetFormat passthrough は入力 JSON が保持されるので空配置警告対象外（false positive 防止）
+    assert!(format_empty_hooks_warning(0, Some(SourceFormat::TargetFormat)).is_none());
+}
+
+#[test]
+fn format_empty_hooks_warning_none_when_source_format_is_none() {
+    // Hook 以外、または Copied 経路の Hook（version 付き Copilot passthrough）はこの警告対象外
+    assert!(format_empty_hooks_warning(0, None).is_none());
 }
 
 // ============================================================================
@@ -390,6 +398,64 @@ fn render_hook_success_all_unsupported_hook_types_emits_empty_hooks_warning() {
         .filter(|b| b.contains("Hook type 'weird' for event"))
         .count();
     assert_eq!(individual_count, 2);
+}
+
+#[test]
+fn render_hook_success_only_removed_field_warnings_still_emits_empty_hooks_warning() {
+    // `RemovedField` 経路でも空 `hooks.json` が配置され得る:
+    // `flatten_matchers` がイベント値を配列として読めなかった、または matcher group の
+    // `hooks` 配列が欠落していた場合（`src/hooks/converter.rs::flatten_matchers`）に
+    // `RemovedField` のみが出力され、`UnsupportedEvent` / `UnsupportedHookType` は出ない。
+    // ClaudeCode 入力の `script_count == 0` という不変条件で取りこぼさないことを固定する。
+    let warnings = vec![
+        ConversionWarning::RemovedField {
+            field: "PreToolUse".to_string(),
+            reason: "Event 'PreToolUse' value is not an array; expected matcher group structure"
+                .to_string(),
+        },
+        ConversionWarning::RemovedField {
+            field: "hooks".to_string(),
+            reason: "Matcher group in event 'PostToolUse' is missing 'hooks' array; skipped"
+                .to_string(),
+        },
+    ];
+    let rendered = render_hook_success(
+        ComponentKind::Hook,
+        Some(SourceFormat::ClaudeCode),
+        &warnings,
+        0,
+    );
+    assert!(rendered.stdout_suffix.is_some());
+    // 空配置警告 + 個別 warning 2 件 = 3 ブロック
+    assert_eq!(rendered.stderr_blocks.len(), 3);
+    assert!(
+        rendered
+            .stderr_blocks
+            .iter()
+            .any(|b| b.contains("no hooks remained after conversion")),
+        "empty hooks warning should appear even when only RemovedField warnings are emitted"
+    );
+}
+
+#[test]
+fn render_hook_success_target_format_with_zero_scripts_does_not_emit_empty_hooks_warning() {
+    // TargetFormat passthrough は入力 JSON がそのまま配置されるので `script_count == 0`
+    // でも空配置警告は出してはいけない（false positive 防止）。
+    let warnings = vec![ConversionWarning::MissingVersion];
+    let rendered = render_hook_success(
+        ComponentKind::Hook,
+        Some(SourceFormat::TargetFormat),
+        &warnings,
+        0,
+    );
+    assert!(rendered.stdout_suffix.is_none());
+    assert!(
+        !rendered
+            .stderr_blocks
+            .iter()
+            .any(|b| b.contains("no hooks remained after conversion")),
+        "empty hooks warning must NOT appear for TargetFormat passthrough"
+    );
 }
 
 #[test]

--- a/src/install/format_test.rs
+++ b/src/install/format_test.rs
@@ -228,10 +228,10 @@ fn format_manual_rewrite_section_renders_header_lines_and_note() {
 // ============================================================================
 
 #[test]
-fn format_empty_hooks_warning_some_when_zero_scripts_with_skipped() {
+fn format_empty_hooks_warning_some_when_zero_scripts_with_drops() {
     let actual = format_empty_hooks_warning(0, 3).unwrap();
     let expected = format!(
-        "  {} All events were skipped; an empty hooks.json was placed.",
+        "  {} An empty hooks.json was placed; no hooks remained after conversion.",
         "Warning:".yellow()
     );
     assert_eq!(actual, expected);
@@ -243,7 +243,7 @@ fn format_empty_hooks_warning_none_when_scripts_present() {
 }
 
 #[test]
-fn format_empty_hooks_warning_none_when_no_skipped() {
+fn format_empty_hooks_warning_none_when_no_drops() {
     assert!(format_empty_hooks_warning(0, 0).is_none());
 }
 
@@ -349,7 +349,47 @@ fn render_hook_success_all_events_skipped_includes_empty_hooks_warning() {
     // skipped events warning + empty hooks warning の 2 ブロック
     assert_eq!(rendered.stderr_blocks.len(), 2);
     assert!(rendered.stderr_blocks[0].contains("2 events skipped"));
-    assert!(rendered.stderr_blocks[1].contains("All events were skipped"));
+    assert!(rendered.stderr_blocks[1].contains("no hooks remained after conversion"));
+}
+
+#[test]
+fn render_hook_success_all_unsupported_hook_types_emits_empty_hooks_warning() {
+    // `UnsupportedHookType` で event 内の全 hook が落ちると、`convert_event_hooks` は
+    // その event ごと JSON から落とす（`UnsupportedEvent` は出ない）。この経路では
+    // `skipped_count == 0` だが `script_count == 0` で空 `hooks.json` が配置されるため、
+    // 空配置警告を出す必要がある。
+    let warnings = vec![
+        ConversionWarning::UnsupportedHookType {
+            hook_type: "weird".to_string(),
+            event: "PreToolUse".to_string(),
+        },
+        ConversionWarning::UnsupportedHookType {
+            hook_type: "weird".to_string(),
+            event: "PostToolUse".to_string(),
+        },
+    ];
+    let rendered = render_hook_success(
+        ComponentKind::Hook,
+        Some(SourceFormat::ClaudeCode),
+        &warnings,
+        0,
+    );
+    assert!(rendered.stdout_suffix.is_some());
+    // 空配置警告 + 個別 warning 2 件 = 3 ブロック
+    assert_eq!(rendered.stderr_blocks.len(), 3);
+    assert!(
+        rendered
+            .stderr_blocks
+            .iter()
+            .any(|b| b.contains("no hooks remained after conversion")),
+        "empty hooks warning should appear when all hooks are filtered as UnsupportedHookType"
+    );
+    let individual_count = rendered
+        .stderr_blocks
+        .iter()
+        .filter(|b| b.contains("Hook type 'weird' for event"))
+        .count();
+    assert_eq!(individual_count, 2);
 }
 
 #[test]

--- a/src/install/format_test.rs
+++ b/src/install/format_test.rs
@@ -206,6 +206,16 @@ fn format_manual_rewrite_section_returns_none_for_empty() {
 }
 
 #[test]
+fn format_manual_rewrite_section_uses_singular_for_one_stub() {
+    // user-facing CLI の英文として「(1 hooks)」は誤りなので、件数 1 のときは "hook"。
+    let stubs = vec![("prompt".to_string(), "preToolUse".to_string())];
+    let actual = format_manual_rewrite_section(&stubs).unwrap();
+    let header = "Manual rewrite required (1 hook):";
+    assert!(actual.contains(&header.magenta().bold().to_string()));
+    assert!(!actual.contains("(1 hooks)"));
+}
+
+#[test]
 fn format_manual_rewrite_section_renders_header_lines_and_note() {
     let stubs = vec![
         ("prompt".to_string(), "preToolUse".to_string()),

--- a/src/install_test.rs
+++ b/src/install_test.rs
@@ -5,6 +5,7 @@ use tempfile::TempDir;
 
 use super::*;
 use crate::component::ComponentKind;
+use crate::hooks::converter::{ConversionWarning, SourceFormat};
 use crate::plugin::{CachedPackage, MarketplaceContent, PluginManifest};
 use crate::target::{CodexTarget, CopilotTarget};
 
@@ -324,4 +325,122 @@ async fn test_download_plugin_with_cache_invalid_source_returns_error() {
     // "/" のような不正なソース文字列は parse_source で確実に失敗し、早期にエラーとなる
     let result = download_plugin_with_cache("/", false, &cache).await;
     assert!(result.is_err());
+}
+
+// =============================================================================
+// Hook 配置時の hook_source_format 伝播テスト
+// =============================================================================
+
+/// `hooks/` 配下に 1 つの hook ファイルを持つ test fixture を作成
+fn create_test_hook_package(base_dir: &Path, hook_name: &str, hook_json: &str) -> CachedPackage {
+    let manifest_content = serde_json::json!({
+        "name": "test-plugin",
+        "version": "1.0.0",
+        "description": "A test plugin"
+    });
+    fs::write(base_dir.join("plugin.json"), manifest_content.to_string()).unwrap();
+
+    let hooks_dir = base_dir.join("hooks");
+    fs::create_dir_all(&hooks_dir).unwrap();
+    fs::write(hooks_dir.join(format!("{}.json", hook_name)), hook_json).unwrap();
+
+    let manifest = PluginManifest::load(&base_dir.join("plugin.json")).unwrap();
+
+    CachedPackage {
+        name: "test-plugin".to_string(),
+        id: None,
+        marketplace: Some("test-marketplace".to_string()),
+        path: base_dir.to_path_buf(),
+        manifest,
+        git_ref: "main".to_string(),
+        commit_sha: "abc123".to_string(),
+        marketplace_manifest: None,
+    }
+}
+
+#[test]
+fn test_place_plugin_claude_code_hook_propagates_source_format() {
+    let temp = TempDir::new().unwrap();
+    let project_dir = TempDir::new().unwrap();
+
+    // Claude Code 形式 Hook（PreToolUse, command 型 → wrapper を生成）
+    let claude_code_hook = r#"{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo 'pre check'"
+          }
+        ]
+      }
+    ]
+  }
+}"#;
+    let cached = create_test_hook_package(temp.path(), "my-hook", claude_code_hook);
+    let package = MarketplaceContent::try_from(cached).unwrap();
+    let scanned = scan_plugin(&package, None).unwrap();
+
+    let targets: Vec<Box<dyn crate::target::Target>> = vec![Box::new(CopilotTarget::new())];
+
+    let result = place_plugin(&PlaceRequest {
+        scanned: &scanned,
+        targets: &targets,
+        scope: crate::component::Scope::Project,
+        project_root: project_dir.path(),
+    });
+
+    assert_eq!(result.successes.len(), 1, "failures: {:?}", result.failures);
+    let success = &result.successes[0];
+    assert_eq!(success.component_kind, ComponentKind::Hook);
+    assert_eq!(
+        success.hook_source_format,
+        Some(SourceFormat::ClaudeCode),
+        "Claude Code 形式 Hook では hook_source_format == Some(ClaudeCode) であるべき"
+    );
+    assert!(
+        success.script_count > 0,
+        "Claude Code 形式の command フックは wrapper を生成するため script_count > 0"
+    );
+}
+
+#[test]
+fn test_place_plugin_copilot_hook_with_missing_version_propagates_target_format() {
+    let temp = TempDir::new().unwrap();
+    let project_dir = TempDir::new().unwrap();
+
+    // Copilot 形式 + version 欠落 → MissingVersion warning が 1 件、wrapper なし。
+    // この経路で `hook_source_format == Some(SourceFormat::TargetFormat)` を担保する
+    // （false positive 防止：suffix を出さないことの根拠）。
+    let copilot_hook = r#"{"hooks":{"preToolUse":[{"type":"command","bash":"echo hi"}]}}"#;
+    let cached = create_test_hook_package(temp.path(), "copilot-hook", copilot_hook);
+    let package = MarketplaceContent::try_from(cached).unwrap();
+    let scanned = scan_plugin(&package, None).unwrap();
+
+    let targets: Vec<Box<dyn crate::target::Target>> = vec![Box::new(CopilotTarget::new())];
+
+    let result = place_plugin(&PlaceRequest {
+        scanned: &scanned,
+        targets: &targets,
+        scope: crate::component::Scope::Project,
+        project_root: project_dir.path(),
+    });
+
+    assert_eq!(result.successes.len(), 1, "failures: {:?}", result.failures);
+    let success = &result.successes[0];
+    assert_eq!(success.component_kind, ComponentKind::Hook);
+    assert_eq!(
+        success.hook_source_format,
+        Some(SourceFormat::TargetFormat),
+        "Copilot 形式 passthrough では hook_source_format == Some(TargetFormat) であるべき"
+    );
+    assert!(
+        success
+            .hook_warnings
+            .iter()
+            .any(|w| matches!(w, ConversionWarning::MissingVersion)),
+        "MissingVersion warning が伝播しているはず"
+    );
+    assert_eq!(success.script_count, 0);
 }


### PR DESCRIPTION
## 概要

`plm install` 実行時の出力を拡張し、Hook が Claude Code 形式から Copilot CLI 形式へ自動変換された場合に stdout で `(converted from Claude Code format)` サフィックスを表示し、stderr に変換時の警告（除外イベント集約 / 手動書き換え案内 / 全イベント除外 / 個別 warning）を装飾フォーマットで出力する。Skill / Agent / Command / Instruction の既存出力と version 付き Copilot Hook の passthrough は不変。

## 変更の種類

- ✨ 新機能（Hook 変換結果の CLI 表示）
- ♻️ リファクタリング（`PlaceSuccess` を `Vec<String>` から `Vec<ConversionWarning>` へ構造化、`HookConvertOutput` に `source_format` を追加）

## 詳細な変更内容

### 新規追加

- **`src/install/format.rs` / `format_test.rs`**: 副作用なし pure function 群を新設
  - `should_show_converted_suffix(Option<SourceFormat>) -> bool`: 3 分岐網羅（`Some(ClaudeCode) → true`、`Some(TargetFormat) → false`、`None → false`）
  - `classify_hook_warnings(&[ConversionWarning]) -> ClassifiedWarnings`: `skipped` (`BTreeSet`) / `stubs` / `others` に分類。`match` 末尾 `_ =>` で将来 variant の取りこぼしを防止
  - `format_skipped_events_warning` / `format_manual_rewrite_section` / `format_empty_hooks_warning` / `format_individual_warning` / `format_converted_hook_suffix`: 装飾済み文字列を組み立てる pure 関数群
  - `render_hook_success(...) -> HookRenderOutput`: stdout suffix と stderr ブロック群を返す副作用なしレンダラ
  - 単体テスト 24 件
- **`src/commands/install_test.rs`**: `render_place_success_to_strings` ラッパの単体テスト 7 件（Hook + ClaudeCode / Hook + TargetFormat + MissingVersion / Hook passthrough / Command / Agent / Skill / Instruction）

### 変更

- **`src/component/deployment/output.rs`**: `HookConvertOutput` に `source_format: SourceFormat` を追加
- **`src/component/deployment/hook_deploy.rs`**: `convert_result.source_format` を `HookConvertOutput` 経由で伝播
- **`src/install.rs`**: 
  - `pub mod format;` と `pub use crate::hooks::converter::{ConversionWarning, SourceFormat};` を追加
  - `PlaceSuccess.hook_warnings: Vec<String>` → `Vec<ConversionWarning>`
  - `PlaceSuccess.script_count: usize` と `hook_source_format: Option<SourceFormat>` を追加
  - `place_plugin` 内の `to_string()` を撤廃し enum を保持
- **`src/commands/install.rs`**: 出力ループから `render_place_success_to_strings(&PlaceSuccess) -> (String, Vec<String>)` を切り出し、CLI 側は `println!`/`eprintln!` に流すだけのラッパに専念
- **テスト追従**:
  - `output_test.rs`: 既存 struct literal 3 箇所に `source_format` を補い、新規 assert を追加
  - `hook_deploy_test.rs`: 既存テストに `source_format == ClaudeCode/TargetFormat` の assert を追加
  - `install_test.rs`: `place_plugin` 経由で `hook_source_format` の伝播（Claude Code / Copilot 形式 + MissingVersion 各 1 件）を担保

## システム図

```
hooks/converter.rs::convert()
        │ ConvertResult { source_format, warnings, scripts, ... }
        ▼
component/deployment/hook_deploy.rs::deploy_hook_converted()
        │ HookConvertOutput { warnings, script_count, source_format }
        ▼
install.rs::place_plugin()
        │ PlaceSuccess {
        │   hook_warnings: Vec<ConversionWarning>,
        │   script_count: usize,
        │   hook_source_format: Option<SourceFormat>,
        │   ...
        │ }
        ▼
commands/install.rs::render_place_success_to_strings()  ← 副作用なしラッパ
        │
        ├─ install/format.rs::render_hook_success()  ← Hook 専用 pure renderer
        │      ├─ should_show_converted_suffix(hook_source_format)
        │      │     true(=Some(ClaudeCode)) → cyan suffix
        │      │     false → suffix なし
        │      └─ classify_hook_warnings(&warnings)
        │            ├─ skipped → format_skipped_events_warning  (yellow, 集約)
        │            ├─ stubs   → format_manual_rewrite_section  (magenta+bold)
        │            ├─ empty?  → format_empty_hooks_warning      (yellow)
        │            └─ others  → format_individual_warning       (yellow)
        │
        └─ Hook 以外 → 既存の `(Converted: src → dst)` 表記を維持
```

## 関連Issue

Closes #190

## テスト

- [x] `cargo fmt` 差分なし
- [x] `cargo check --all-targets` コンパイルエラーなし
- [x] `cargo test` 全件パス（**1547 passed; 0 failed**）
  - `install::format::tests` 24 件（pure function + `render_hook_success` 配線）
  - `commands::install::tests` 7 件（出力ラッパ：Hook 3 系統 + Command/Agent/Skill/Instruction）
  - `install::tests::test_place_plugin_*_hook_propagates_*_format` 2 件（`place_plugin` 経由の伝播）
  - `component::deployment::hook_deploy::tests` の既存テストに `source_format` assert 追加
- [x] Codex 自動レビュー 2 ラウンド実施 → 最終ラウンドで「問題なし」

## レビューポイント

1. **false positive 防止**: `should_show_converted_suffix` の 3 分岐（特に `Some(TargetFormat) → false`）が、Copilot 形式 + `MissingVersion` の passthrough ルートで `(converted from Claude Code format)` を出さないことを担保しているか
2. **stderr / stdout の独立条件**: stderr の Hook warning 群は `component_kind == Hook` のみで判定し `source_format` 非依存にしている（Copilot 形式 + warning でも警告を出す）。stdout suffix だけが `should_show_converted_suffix` で分岐する。この二分仕様が `render_hook_success` で意図どおりに分かれているか
3. **enum 拡張耐性**: `classify_hook_warnings` の `match` 末尾 `_ =>` により、将来 `ConversionWarning` に variant が追加されても出力から取りこぼされない設計になっているか
4. **既存挙動維持**: `(Converted: src → dst)` 表記が Skill / Agent / Command / Instruction でそのまま維持され、`DeploymentOutput::Copied` 経路の version 付き Copilot Hook も既存どおり stdout のみで suffix 無しになっているか（テスト 3, 4, 5, 6 で固定済み）
5. **TUI 経路への影響**: `PlaceSuccess.hook_warnings` の型変更（`Vec<String>` → `Vec<ConversionWarning>`）が `src/tui/manager/screens/marketplaces/actions.rs` の compile に影響するかどうか（参照していないため compile 通過のみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)