### PR TITLE
♻️ [Refactoring]: extract EndpointInner and introduce enum Endpoint

### DIFF
--- a/src/sync/endpoint.rs
+++ b/src/sync/endpoint.rs
@@ -1,12 +1,138 @@
 //! Sync endpoint sub-parent.
 //!
-//! Groups source/destination wrappers around a Target environment used by
-//! the sync orchestrator. The leaves keep test form A
-//! (`#[path = "*_test.rs"] mod tests;` at the bottom of each leaf file), so
-//! no test declarations are needed at this sub-parent.
+//! Hosts the shared `EndpointInner` (common fields/methods of source/destination)
+//! and the crate-internal `Endpoint` enum used for variant-aware dispatch.
+//!
+//! 形式 A（`#[path = "*_test.rs"] mod tests;` を leaf 末尾に置く）に加えて、
+//! 共通テスト集約用の `endpoint_test.rs` を本ファイル末尾でも宣言する。
 
 mod destination;
+mod inner;
 mod source;
 
 pub use self::destination::SyncDestination;
 pub use self::source::SyncSource;
+use self::inner::EndpointInner;
+
+use std::path::{Path, PathBuf};
+
+use crate::component::CommandFormat;
+use crate::error::{PlmError, Result};
+use crate::scan::is_instruction_file;
+use crate::sync::model::{PlacedComponent, SyncOptions};
+use crate::target::PluginOrigin;
+
+/// Crate-internal abstraction over a sync endpoint variant.
+///
+/// External callers must continue to use `SyncSource` / `SyncDestination`.
+/// `Endpoint` exists to deduplicate dispatch logic inside the `sync` feature.
+#[derive(Debug)]
+pub(crate) enum Endpoint {
+    Source(SyncSource),
+    Destination(SyncDestination),
+}
+
+impl Endpoint {
+    /// `Source` variant ならその `&SyncSource` を返す
+    pub(crate) fn as_source(&self) -> Option<&SyncSource> {
+        match self {
+            Self::Source(s) => Some(s),
+            Self::Destination(_) => None,
+        }
+    }
+
+    /// `Destination` variant ならその `&SyncDestination` を返す
+    pub(crate) fn as_destination(&self) -> Option<&SyncDestination> {
+        match self {
+            Self::Source(_) => None,
+            Self::Destination(d) => Some(d),
+        }
+    }
+
+    /// ターゲット名（共通メソッド・variant 別ディスパッチ）
+    pub(crate) fn name(&self) -> &'static str {
+        match self {
+            Self::Source(s) => s.name(),
+            Self::Destination(d) => d.name(),
+        }
+    }
+
+    /// Command フォーマット（共通メソッド・variant 別ディスパッチ）
+    pub(crate) fn command_format(&self) -> CommandFormat {
+        match self {
+            Self::Source(s) => s.command_format(),
+            Self::Destination(d) => d.command_format(),
+        }
+    }
+
+    /// 配置済みコンポーネント一覧（共通メソッド・variant 別ディスパッチ）
+    pub(crate) fn placed_components(&self, options: &SyncOptions) -> Result<Vec<PlacedComponent>> {
+        match self {
+            Self::Source(s) => s.placed_components(options),
+            Self::Destination(d) => d.placed_components(options),
+        }
+    }
+
+    /// 配置済みコンポーネントのパスを解決（共通メソッド・variant 別ディスパッチ）
+    pub(crate) fn path_for(&self, component: &PlacedComponent) -> Result<PathBuf> {
+        match self {
+            Self::Source(s) => s.path_for(component),
+            Self::Destination(d) => d.path_for(component),
+        }
+    }
+}
+
+/// コンポーネント名をパース。
+///
+/// フラット化後の識別子は `flattened_name` 単一セグメントのみ。Instruction
+/// (AGENTS.md / copilot-instructions.md / GEMINI.md) はそのままファイル名で
+/// 受け取る特例とする。空文字・パス区切り (`/` `\`) ・null バイト・`.` / `..` ・
+/// 複合パスを含むレガシー識別子は `InvalidArgument` で拒否する
+/// (`placement_location` が `base.join(name)` を直接行うためベースディレクトリ
+/// 外への書き込みを防ぐ)。
+///
+/// `endpoint` サブ親直下に配置することで、`source` / `destination` 両 leaf から
+/// `super::parse_component_name` で参照できる。
+pub(super) fn parse_component_name(name: &str) -> Result<(PluginOrigin, &str)> {
+    if is_instruction_file(name) {
+        return Ok((PluginOrigin::from_marketplace("", ""), name));
+    }
+
+    validate_flattened_name(name)?;
+
+    Ok((PluginOrigin::placeholder(), name))
+}
+
+/// `flattened_name` が単一の安全なパスセグメントであることを検証する。
+fn validate_flattened_name(name: &str) -> Result<()> {
+    if name.is_empty() {
+        return Err(PlmError::InvalidArgument(
+            "Component name must not be empty".to_string(),
+        ));
+    }
+    if name.contains('/') || name.contains('\\') || name.contains('\0') {
+        return Err(PlmError::InvalidArgument(format!(
+            "Invalid component name '{}': must not contain path separators or null bytes",
+            name
+        )));
+    }
+    if name == "." || name == ".." {
+        return Err(PlmError::InvalidArgument(format!(
+            "Invalid component name '{}': must not be a parent/current directory reference",
+            name
+        )));
+    }
+    let mut components = Path::new(name).components();
+    let first = components.next();
+    if components.next().is_some() || !matches!(first, Some(std::path::Component::Normal(_))) {
+        return Err(PlmError::InvalidArgument(format!(
+            "Invalid component name '{}': must be a single flattened segment",
+            name
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[path = "endpoint/endpoint_test.rs"]
+mod tests;

--- a/src/sync/endpoint.rs
+++ b/src/sync/endpoint.rs
@@ -1,18 +1,18 @@
 //! Sync endpoint sub-parent.
 //!
-//! Hosts the shared `EndpointInner` (common fields/methods of source/destination)
+//! Hosts the shared `TargetBinding` (common fields/methods of source/destination)
 //! and the crate-internal `Endpoint` enum used for variant-aware dispatch.
 //!
 //! 形式 A（`#[path = "*_test.rs"] mod tests;` を leaf 末尾に置く）に加えて、
 //! 共通テスト集約用の `endpoint_test.rs` を本ファイル末尾でも宣言する。
 
+mod binding;
 mod destination;
-mod inner;
 mod source;
 
+use self::binding::TargetBinding;
 pub use self::destination::SyncDestination;
 pub use self::source::SyncSource;
-use self::inner::EndpointInner;
 
 use std::path::{Path, PathBuf};
 

--- a/src/sync/endpoint/binding.rs
+++ b/src/sync/endpoint/binding.rs
@@ -1,7 +1,7 @@
-//! Endpoint の共通本体（共有 inner struct）
+//! Target を project_root に束ねた共通本体（共有 binding struct）
 //!
 //! `SyncSource` / `SyncDestination` の共通フィールド・共通メソッドを集約した
-//! `pub(super)` 構造体。両 newtype が `EndpointInner` を内包し、共通メソッドを
+//! `pub(super)` 構造体。両 newtype が `TargetBinding` を内包し、共通メソッドを
 //! 委譲する形で重複を解消する。
 
 use std::collections::HashSet;
@@ -16,26 +16,28 @@ use crate::component::{
 use crate::error::{PlmError, Result};
 use crate::target::{parse_target, Target, TargetKind};
 
-/// `SyncSource` / `SyncDestination` の共通フィールド・共通メソッドを保持する内部型
+/// `Target` を `project_root` に束ねた共通本体
 ///
-/// `pub(super)` により `endpoint` サブ親配下のみ可視。`endpoint.rs` 側では
-/// 非公開の `use self::inner::EndpointInner;` でサブ親に再導入し、`source` /
-/// `destination` 子モジュールから `super::EndpointInner` で参照できるようにする。
-pub(super) struct EndpointInner {
+/// `SyncSource` / `SyncDestination` がそれぞれ newtype として内包し、共通
+/// メソッドを委譲する。`pub(super)` により `endpoint` サブ親配下のみ可視。
+/// `endpoint.rs` 側で非公開の `use self::binding::TargetBinding;` でサブ親に
+/// 再導入し、`source` / `destination` 子モジュールから `super::TargetBinding`
+/// で参照できるようにする。
+pub(super) struct TargetBinding {
     pub(super) target: Box<dyn Target>,
     pub(super) project_root: PathBuf,
 }
 
-impl std::fmt::Debug for EndpointInner {
+impl std::fmt::Debug for TargetBinding {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("EndpointInner")
+        f.debug_struct("TargetBinding")
             .field("target", &self.target.name())
             .field("project_root", &self.project_root)
             .finish()
     }
 }
 
-impl EndpointInner {
+impl TargetBinding {
     /// 本番用コンストラクタ
     pub(super) fn new(kind: TargetKind, project_root: &Path) -> Result<Self> {
         let target = parse_target(kind.as_str())?;

--- a/src/sync/endpoint/destination.rs
+++ b/src/sync/endpoint/destination.rs
@@ -3,13 +3,13 @@
 use std::path::{Path, PathBuf};
 
 use super::super::model::{PlacedComponent, PlacedRef, SyncOptions};
-use super::EndpointInner;
+use super::TargetBinding;
 use crate::component::CommandFormat;
 use crate::error::Result;
 use crate::target::{Target, TargetKind};
 
 /// 同期先
-pub struct SyncDestination(EndpointInner);
+pub struct SyncDestination(TargetBinding);
 
 impl std::fmt::Debug for SyncDestination {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -28,7 +28,7 @@ impl SyncDestination {
     /// * `kind` - Target environment kind to synchronize into.
     /// * `project_root` - Project root directory used when resolving placement paths.
     pub fn new(kind: TargetKind, project_root: &Path) -> Result<Self> {
-        Ok(Self(EndpointInner::new(kind, project_root)?))
+        Ok(Self(TargetBinding::new(kind, project_root)?))
     }
 
     /// テスト用コンストラクタ（Target を注入）
@@ -38,7 +38,7 @@ impl SyncDestination {
     /// * `target` - Injected target implementation to use in tests.
     /// * `project_root` - Project root directory used when resolving placement paths.
     pub fn with_target(target: Box<dyn Target>, project_root: &Path) -> Self {
-        Self(EndpointInner::with_target(target, project_root))
+        Self(TargetBinding::with_target(target, project_root))
     }
 
     /// ターゲット名を取得

--- a/src/sync/endpoint/destination.rs
+++ b/src/sync/endpoint/destination.rs
@@ -1,27 +1,21 @@
 //! 同期先の定義
 
-use super::super::model::{PlacedComponent, PlacedRef, SyncOptions, SyncableKind};
-use super::source::parse_component_name;
-use crate::component::{
-    CommandFormat, ComponentKind, ComponentRef, PlacementContext, PlacementScope, ProjectContext,
-    Scope,
-};
-use crate::error::{PlmError, Result};
-use crate::target::{parse_target, Target, TargetKind};
-use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
+use super::super::model::{PlacedComponent, PlacedRef, SyncOptions};
+use super::EndpointInner;
+use crate::component::CommandFormat;
+use crate::error::Result;
+use crate::target::{Target, TargetKind};
+
 /// 同期先
-pub struct SyncDestination {
-    target: Box<dyn Target>,
-    project_root: PathBuf,
-}
+pub struct SyncDestination(EndpointInner);
 
 impl std::fmt::Debug for SyncDestination {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SyncDestination")
-            .field("target", &self.target.name())
-            .field("project_root", &self.project_root)
+            .field("target", &self.0.target.name())
+            .field("project_root", &self.0.project_root)
             .finish()
     }
 }
@@ -34,11 +28,7 @@ impl SyncDestination {
     /// * `kind` - Target environment kind to synchronize into.
     /// * `project_root` - Project root directory used when resolving placement paths.
     pub fn new(kind: TargetKind, project_root: &Path) -> Result<Self> {
-        let target = parse_target(kind.as_str())?;
-        Ok(Self {
-            target,
-            project_root: project_root.to_path_buf(),
-        })
+        Ok(Self(EndpointInner::new(kind, project_root)?))
     }
 
     /// テスト用コンストラクタ（Target を注入）
@@ -48,20 +38,17 @@ impl SyncDestination {
     /// * `target` - Injected target implementation to use in tests.
     /// * `project_root` - Project root directory used when resolving placement paths.
     pub fn with_target(target: Box<dyn Target>, project_root: &Path) -> Self {
-        Self {
-            target,
-            project_root: project_root.to_path_buf(),
-        }
+        Self(EndpointInner::with_target(target, project_root))
     }
 
     /// ターゲット名を取得
     pub fn name(&self) -> &'static str {
-        self.target.name()
+        self.0.name()
     }
 
     /// Command フォーマットを取得
     pub fn command_format(&self) -> CommandFormat {
-        self.target.command_format()
+        self.0.command_format()
     }
 
     /// 配置済みコンポーネントを取得
@@ -72,35 +59,7 @@ impl SyncDestination {
     ///
     /// * `options` - Options selecting which kinds and scopes to include.
     pub fn placed_components(&self, options: &SyncOptions) -> Result<Vec<PlacedComponent>> {
-        let mut components = Vec::new();
-        let mut seen_refs = HashSet::new();
-
-        let kinds = self.target_kinds(options);
-        let scopes = self.target_scopes(options);
-
-        for syncable_kind in kinds {
-            let kind = syncable_kind.to_component_kind();
-
-            for scope in &scopes {
-                let placed = self.target.list_placed(kind, *scope, &self.project_root)?;
-
-                for name in placed {
-                    let placed_ref = PlacedRef::new(kind, name.clone(), *scope);
-
-                    if !seen_refs.insert(placed_ref.clone()) {
-                        return Err(PlmError::InvalidArgument(format!(
-                            "Duplicate placed component ref: {:?}",
-                            placed_ref
-                        )));
-                    }
-
-                    let path = self.resolve_path(kind, &name, *scope)?;
-                    components.push(PlacedComponent::new(kind, name, *scope, path));
-                }
-            }
-        }
-
-        Ok(components)
+        self.0.placed_components(options)
     }
 
     /// コンポーネントの配置先パスを取得
@@ -109,72 +68,20 @@ impl SyncDestination {
     ///
     /// * `component` - Placed component whose destination path should be resolved.
     pub fn path_for(&self, component: &PlacedComponent) -> Result<PathBuf> {
-        self.resolve_path(component.kind(), component.name(), component.scope())
+        self.0.path_for(component)
     }
 
     /// このコンポーネントをサポートしているか
+    ///
+    /// `Endpoint` enum には生やさず、`SyncDestination` 固有メソッドとして残す
+    /// ことで Source variant からの呼出を型レベルで排除する。
     ///
     /// # Arguments
     ///
     /// * `placed_ref` - Placed component reference whose kind and scope support is checked.
     pub fn supports(&self, placed_ref: &PlacedRef) -> bool {
-        self.target.supports(placed_ref.kind)
-            && self
-                .target
-                .supports_scope(placed_ref.kind, placed_ref.scope)
-    }
-
-    /// 対象の SyncableKind リストを取得
-    ///
-    /// # Arguments
-    ///
-    /// * `options` - Options whose `component_type` filter is applied.
-    fn target_kinds(&self, options: &SyncOptions) -> Vec<SyncableKind> {
-        match options.component_type {
-            Some(kind) => vec![kind],
-            None => SyncableKind::all().to_vec(),
-        }
-    }
-
-    /// 対象の Scope リストを取得
-    ///
-    /// # Arguments
-    ///
-    /// * `options` - Options whose `scope` filter is applied.
-    fn target_scopes(&self, options: &SyncOptions) -> Vec<Scope> {
-        match options.scope {
-            Some(scope) => vec![scope],
-            None => vec![Scope::Personal, Scope::Project],
-        }
-    }
-
-    /// パスを解決
-    ///
-    /// # Arguments
-    ///
-    /// * `kind` - Component kind to resolve.
-    /// * `name` - Fully-qualified component name (e.g. `marketplace/plugin/component`).
-    /// * `scope` - Placement scope (personal or project).
-    fn resolve_path(&self, kind: ComponentKind, name: &str, scope: Scope) -> Result<PathBuf> {
-        let (origin, component_name) = parse_component_name(name)?;
-
-        let ctx = PlacementContext {
-            component: ComponentRef::new(kind, component_name),
-            origin: &origin,
-            scope: PlacementScope::new(scope),
-            project: ProjectContext::new(&self.project_root),
-        };
-
-        self.target
-            .placement_location(&ctx)
-            .map(|l| l.into_path())
-            .ok_or_else(|| {
-                PlmError::InvalidArgument(format!(
-                    "Cannot resolve path for {} on {}",
-                    name,
-                    self.target.name()
-                ))
-            })
+        let target = self.0.target();
+        target.supports(placed_ref.kind) && target.supports_scope(placed_ref.kind, placed_ref.scope)
     }
 }
 

--- a/src/sync/endpoint/endpoint_test.rs
+++ b/src/sync/endpoint/endpoint_test.rs
@@ -1,4 +1,4 @@
-//! 共通テスト集約: `Endpoint` ディスパッチ + `EndpointInner` 経由の共通振る舞い
+//! 共通テスト集約: `Endpoint` ディスパッチ + `TargetBinding` 経由の共通振る舞い
 //!
 //! 実環境（ホームディレクトリ・プロジェクト直下 `AGENTS.md`）に依存しないよう
 //! `FakeTarget` を内部定義し `with_target` 経由で注入する。
@@ -289,7 +289,7 @@ fn test_resolve_path_rejects_invalid_name() {
 
 // --- target_kinds / target_scopes フィルタ ---
 //
-// `target_kinds` / `target_scopes` は `EndpointInner` の private なメソッドだが、
+// `target_kinds` / `target_scopes` は `TargetBinding` の private なメソッドだが、
 // `placed_components` 経由で間接的に観測する。`list_placed` を呼び出すたびに
 // FakeTarget の `placement_calls` 履歴が積まれる動作を利用してフィルタ尊重を検証する。
 

--- a/src/sync/endpoint/endpoint_test.rs
+++ b/src/sync/endpoint/endpoint_test.rs
@@ -1,0 +1,417 @@
+//! 共通テスト集約: `Endpoint` ディスパッチ + `EndpointInner` 経由の共通振る舞い
+//!
+//! 実環境（ホームディレクトリ・プロジェクト直下 `AGENTS.md`）に依存しないよう
+//! `FakeTarget` を内部定義し `with_target` 経由で注入する。
+
+use std::cell::RefCell;
+use std::path::{Path, PathBuf};
+
+use super::{Endpoint, SyncDestination, SyncSource};
+use crate::component::{
+    AgentFormat, CommandFormat, ComponentKind, PlacementContext, PlacementLocation, Scope,
+};
+use crate::error::Result;
+use crate::sync::model::{PlacedRef, SyncOptions, SyncableKind};
+use crate::target::{Target, TargetKind};
+
+/// 実環境非依存の Target 実装。
+///
+/// `list_placed` / `placement_location` / `supports_scope` の戻り値を
+/// フィールドで制御し、テストの再現性を確保する。
+struct FakeTarget {
+    name: &'static str,
+    display_name: &'static str,
+    kind: TargetKind,
+    supported_components: Vec<ComponentKind>,
+    /// (kind, scope) ごとに `list_placed` が返す名前列
+    placed: Vec<(ComponentKind, Scope, Vec<String>)>,
+    /// `placement_location` が返す固定パス（`None` ならサポート外）
+    location: Option<PathBuf>,
+    /// `supports_scope` で対応する (kind, scope) の組
+    supports_scopes: Vec<(ComponentKind, Scope)>,
+    /// `placement_location` の呼出履歴（`name` を観測する）
+    placement_calls: RefCell<Vec<String>>,
+}
+
+// `Target: Send + Sync` を満たすために手動で `Sync` を実装する必要がある。
+// `RefCell` は `!Sync` だが、本テストはシングルスレッドで参照するのみのため
+// `unsafe impl Sync` で許可する。
+unsafe impl Sync for FakeTarget {}
+
+impl Default for FakeTarget {
+    fn default() -> Self {
+        Self {
+            name: "fake",
+            display_name: "Fake",
+            kind: TargetKind::Codex,
+            supported_components: Vec::new(),
+            placed: Vec::new(),
+            location: None,
+            supports_scopes: Vec::new(),
+            placement_calls: RefCell::new(Vec::new()),
+        }
+    }
+}
+
+impl Target for FakeTarget {
+    fn name(&self) -> &'static str {
+        self.name
+    }
+
+    fn display_name(&self) -> &'static str {
+        self.display_name
+    }
+
+    fn kind(&self) -> TargetKind {
+        self.kind
+    }
+
+    fn command_format(&self) -> CommandFormat {
+        CommandFormat::Codex
+    }
+
+    fn agent_format(&self) -> AgentFormat {
+        AgentFormat::Codex
+    }
+
+    fn supported_components(&self) -> &[ComponentKind] {
+        &self.supported_components
+    }
+
+    fn supports_scope(&self, kind: ComponentKind, scope: Scope) -> bool {
+        self.supports_scopes.contains(&(kind, scope))
+    }
+
+    fn placement_location(&self, context: &PlacementContext) -> Option<PlacementLocation> {
+        self.placement_calls
+            .borrow_mut()
+            .push(context.component.name.to_string());
+        self.location.clone().map(PlacementLocation::file)
+    }
+
+    fn list_placed(
+        &self,
+        kind: ComponentKind,
+        scope: Scope,
+        _project_root: &Path,
+    ) -> Result<Vec<String>> {
+        Ok(self
+            .placed
+            .iter()
+            .find(|(k, s, _)| *k == kind && *s == scope)
+            .map(|(_, _, names)| names.clone())
+            .unwrap_or_default())
+    }
+}
+
+fn fake_source(target: FakeTarget, root: &Path) -> SyncSource {
+    SyncSource::with_target(Box::new(target), root)
+}
+
+fn fake_destination(target: FakeTarget, root: &Path) -> SyncDestination {
+    SyncDestination::with_target(Box::new(target), root)
+}
+
+// --- Endpoint dispatch ---
+
+#[test]
+fn test_endpoint_source_dispatch_name() {
+    let src = fake_source(
+        FakeTarget {
+            name: "fake-src",
+            ..Default::default()
+        },
+        Path::new("."),
+    );
+    let ep = Endpoint::Source(src);
+    assert_eq!(ep.name(), "fake-src");
+    assert!(ep.as_source().is_some());
+    assert!(ep.as_destination().is_none());
+}
+
+#[test]
+fn test_endpoint_destination_dispatch_name() {
+    let dst = fake_destination(
+        FakeTarget {
+            name: "fake-dst",
+            ..Default::default()
+        },
+        Path::new("."),
+    );
+    let ep = Endpoint::Destination(dst);
+    assert_eq!(ep.name(), "fake-dst");
+    assert!(ep.as_destination().is_some());
+    assert!(ep.as_source().is_none());
+}
+
+#[test]
+fn test_endpoint_dispatch_command_format() {
+    let src = fake_source(FakeTarget::default(), Path::new("."));
+    let ep = Endpoint::Source(src);
+    assert_eq!(ep.command_format(), CommandFormat::Codex);
+}
+
+// --- placed_components / path_for / resolve_path 経由 ---
+
+#[test]
+fn test_placed_components_empty_returns_empty_vec() {
+    let src = fake_source(FakeTarget::default(), Path::new("/tmp/fake"));
+    let v = src.placed_components(&SyncOptions::default()).unwrap();
+    assert!(v.is_empty());
+}
+
+#[test]
+fn test_placed_components_maps_names_to_placed_components() {
+    let target = FakeTarget {
+        placed: vec![(
+            ComponentKind::Skill,
+            Scope::Project,
+            vec!["alpha".to_string()],
+        )],
+        location: Some(PathBuf::from("/tmp/fake/alpha")),
+        ..Default::default()
+    };
+    let src = fake_source(target, Path::new("/tmp/fake"));
+    let opts = SyncOptions::default()
+        .with_component_type(SyncableKind::Skill)
+        .with_scope(Scope::Project);
+    let comps = src.placed_components(&opts).unwrap();
+    assert_eq!(comps.len(), 1);
+    assert_eq!(comps[0].name(), "alpha");
+    assert_eq!(comps[0].kind(), ComponentKind::Skill);
+    assert_eq!(comps[0].scope(), Scope::Project);
+    assert_eq!(comps[0].path, PathBuf::from("/tmp/fake/alpha"));
+}
+
+#[test]
+fn test_placed_components_duplicate_ref_returns_error() {
+    let target = FakeTarget {
+        placed: vec![(
+            ComponentKind::Skill,
+            Scope::Project,
+            vec!["dup".to_string(), "dup".to_string()],
+        )],
+        location: Some(PathBuf::from("/tmp/fake/dup")),
+        ..Default::default()
+    };
+    let src = fake_source(target, Path::new("/tmp/fake"));
+    let opts = SyncOptions::default()
+        .with_component_type(SyncableKind::Skill)
+        .with_scope(Scope::Project);
+    let err = src.placed_components(&opts).unwrap_err();
+    let msg = format!("{:?}", err);
+    assert!(
+        msg.contains("Duplicate placed component ref"),
+        "expected duplicate error message, got: {msg}"
+    );
+}
+
+#[test]
+fn test_path_for_uses_placement_location() {
+    use crate::sync::model::PlacedComponent;
+
+    let target = FakeTarget {
+        location: Some(PathBuf::from("/tmp/fake/skills/x")),
+        ..Default::default()
+    };
+    let src = fake_source(target, Path::new("/tmp/fake"));
+    let comp = PlacedComponent::new(
+        ComponentKind::Skill,
+        "x",
+        Scope::Project,
+        PathBuf::from("/ignored"),
+    );
+    let path = src.path_for(&comp).unwrap();
+    assert_eq!(path, PathBuf::from("/tmp/fake/skills/x"));
+}
+
+#[test]
+fn test_resolve_path_unsupported_returns_error() {
+    use crate::sync::model::PlacedComponent;
+
+    let target = FakeTarget {
+        location: None, // placement_location が None → サポート外
+        ..Default::default()
+    };
+    let src = fake_source(target, Path::new("/tmp/fake"));
+    let comp = PlacedComponent::new(
+        ComponentKind::Skill,
+        "y",
+        Scope::Project,
+        PathBuf::from("/ignored"),
+    );
+    let err = src.path_for(&comp).unwrap_err();
+    let msg = format!("{:?}", err);
+    assert!(
+        msg.contains("Cannot resolve path"),
+        "expected resolve error, got: {msg}"
+    );
+}
+
+#[test]
+fn test_resolve_path_passes_instruction_name_through() {
+    use crate::sync::model::PlacedComponent;
+
+    let target = FakeTarget {
+        location: Some(PathBuf::from("/tmp/fake/AGENTS.md")),
+        ..Default::default()
+    };
+    let src = fake_source(target, Path::new("/tmp/fake"));
+    let comp = PlacedComponent::new(
+        ComponentKind::Instruction,
+        "AGENTS.md",
+        Scope::Project,
+        PathBuf::from("/ignored"),
+    );
+    // Instruction 名は parse_component_name の特例で素通りする → エラーにならない
+    let path = src.path_for(&comp).unwrap();
+    assert_eq!(path, PathBuf::from("/tmp/fake/AGENTS.md"));
+}
+
+#[test]
+fn test_resolve_path_rejects_invalid_name() {
+    use crate::sync::model::PlacedComponent;
+
+    let target = FakeTarget {
+        location: Some(PathBuf::from("/tmp/fake/x")),
+        ..Default::default()
+    };
+    let src = fake_source(target, Path::new("/tmp/fake"));
+    let comp = PlacedComponent::new(
+        ComponentKind::Skill,
+        "a/b",
+        Scope::Project,
+        PathBuf::from("/ignored"),
+    );
+    // parse_component_name がスラッシュを拒否してエラー
+    assert!(src.path_for(&comp).is_err());
+}
+
+// --- target_kinds / target_scopes フィルタ ---
+//
+// `target_kinds` / `target_scopes` は `EndpointInner` の private なメソッドだが、
+// `placed_components` 経由で間接的に観測する。`list_placed` を呼び出すたびに
+// FakeTarget の `placement_calls` 履歴が積まれる動作を利用してフィルタ尊重を検証する。
+
+#[test]
+fn test_placed_components_respects_component_type_filter() {
+    let target = FakeTarget {
+        placed: vec![
+            (
+                ComponentKind::Skill,
+                Scope::Personal,
+                vec!["s1".to_string()],
+            ),
+            (
+                ComponentKind::Agent,
+                Scope::Personal,
+                vec!["a1".to_string()],
+            ),
+        ],
+        location: Some(PathBuf::from("/tmp/fake/x")),
+        ..Default::default()
+    };
+    let src = fake_source(target, Path::new("/tmp/fake"));
+    let opts = SyncOptions::default()
+        .with_component_type(SyncableKind::Skill)
+        .with_scope(Scope::Personal);
+    let comps = src.placed_components(&opts).unwrap();
+    assert_eq!(comps.len(), 1);
+    assert_eq!(comps[0].kind(), ComponentKind::Skill);
+}
+
+#[test]
+fn test_placed_components_respects_scope_filter() {
+    let target = FakeTarget {
+        placed: vec![
+            (
+                ComponentKind::Skill,
+                Scope::Personal,
+                vec!["s1".to_string()],
+            ),
+            (ComponentKind::Skill, Scope::Project, vec!["s2".to_string()]),
+        ],
+        location: Some(PathBuf::from("/tmp/fake/x")),
+        ..Default::default()
+    };
+    let src = fake_source(target, Path::new("/tmp/fake"));
+    let opts = SyncOptions::default()
+        .with_component_type(SyncableKind::Skill)
+        .with_scope(Scope::Project);
+    let comps = src.placed_components(&opts).unwrap();
+    assert_eq!(comps.len(), 1);
+    assert_eq!(comps[0].name(), "s2");
+    assert_eq!(comps[0].scope(), Scope::Project);
+}
+
+// --- SyncDestination::supports ---
+
+#[test]
+fn test_supports_returns_true_when_kind_and_scope_supported() {
+    let target = FakeTarget {
+        supported_components: vec![ComponentKind::Skill],
+        supports_scopes: vec![(ComponentKind::Skill, Scope::Project)],
+        ..Default::default()
+    };
+    let dst = fake_destination(target, Path::new("/tmp/fake"));
+    let r = PlacedRef::new(ComponentKind::Skill, "x", Scope::Project);
+    assert!(dst.supports(&r));
+}
+
+#[test]
+fn test_supports_returns_false_when_scope_unsupported() {
+    let target = FakeTarget {
+        supported_components: vec![ComponentKind::Skill],
+        supports_scopes: vec![(ComponentKind::Skill, Scope::Personal)],
+        ..Default::default()
+    };
+    let dst = fake_destination(target, Path::new("/tmp/fake"));
+    let r = PlacedRef::new(ComponentKind::Skill, "x", Scope::Project);
+    assert!(!dst.supports(&r));
+}
+
+#[test]
+fn test_supports_returns_false_when_kind_unsupported() {
+    let target = FakeTarget {
+        supported_components: vec![ComponentKind::Agent],
+        supports_scopes: vec![(ComponentKind::Skill, Scope::Project)],
+        ..Default::default()
+    };
+    let dst = fake_destination(target, Path::new("/tmp/fake"));
+    let r = PlacedRef::new(ComponentKind::Skill, "x", Scope::Project);
+    assert!(!dst.supports(&r));
+}
+
+// --- Debug 出力フォーマット完全保存 ---
+
+#[test]
+fn test_sync_source_debug_format_preserved() {
+    let target = FakeTarget {
+        name: "fake-src",
+        ..Default::default()
+    };
+    let src = fake_source(target, Path::new("/tmp/fake"));
+    let dbg = format!("{:?}", src);
+    assert!(
+        dbg.starts_with("SyncSource {"),
+        "expected SyncSource {{ ... }}, got: {dbg}"
+    );
+    assert!(dbg.contains("target: \"fake-src\""), "got: {dbg}");
+    assert!(dbg.contains("project_root:"), "got: {dbg}");
+}
+
+#[test]
+fn test_sync_destination_debug_format_preserved() {
+    let target = FakeTarget {
+        name: "fake-dst",
+        ..Default::default()
+    };
+    let dst = fake_destination(target, Path::new("/tmp/fake"));
+    let dbg = format!("{:?}", dst);
+    assert!(
+        dbg.starts_with("SyncDestination {"),
+        "expected SyncDestination {{ ... }}, got: {dbg}"
+    );
+    assert!(dbg.contains("target: \"fake-dst\""), "got: {dbg}");
+    assert!(dbg.contains("project_root:"), "got: {dbg}");
+}

--- a/src/sync/endpoint/inner.rs
+++ b/src/sync/endpoint/inner.rs
@@ -1,0 +1,158 @@
+//! Endpoint の共通本体（共有 inner struct）
+//!
+//! `SyncSource` / `SyncDestination` の共通フィールド・共通メソッドを集約した
+//! `pub(super)` 構造体。両 newtype が `EndpointInner` を内包し、共通メソッドを
+//! 委譲する形で重複を解消する。
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use super::super::model::{PlacedComponent, PlacedRef, SyncOptions, SyncableKind};
+use super::parse_component_name;
+use crate::component::{
+    CommandFormat, ComponentKind, ComponentRef, PlacementContext, PlacementScope, ProjectContext,
+    Scope,
+};
+use crate::error::{PlmError, Result};
+use crate::target::{parse_target, Target, TargetKind};
+
+/// `SyncSource` / `SyncDestination` の共通フィールド・共通メソッドを保持する内部型
+///
+/// `pub(super)` により `endpoint` サブ親配下のみ可視。`endpoint.rs` 側では
+/// 非公開の `use self::inner::EndpointInner;` でサブ親に再導入し、`source` /
+/// `destination` 子モジュールから `super::EndpointInner` で参照できるようにする。
+pub(super) struct EndpointInner {
+    pub(super) target: Box<dyn Target>,
+    pub(super) project_root: PathBuf,
+}
+
+impl std::fmt::Debug for EndpointInner {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EndpointInner")
+            .field("target", &self.target.name())
+            .field("project_root", &self.project_root)
+            .finish()
+    }
+}
+
+impl EndpointInner {
+    /// 本番用コンストラクタ
+    pub(super) fn new(kind: TargetKind, project_root: &Path) -> Result<Self> {
+        let target = parse_target(kind.as_str())?;
+        Ok(Self {
+            target,
+            project_root: project_root.to_path_buf(),
+        })
+    }
+
+    /// テスト用コンストラクタ（Target を注入）
+    pub(super) fn with_target(target: Box<dyn Target>, project_root: &Path) -> Self {
+        Self {
+            target,
+            project_root: project_root.to_path_buf(),
+        }
+    }
+
+    /// ターゲット名
+    pub(super) fn name(&self) -> &'static str {
+        self.target.name()
+    }
+
+    /// Command フォーマット
+    pub(super) fn command_format(&self) -> CommandFormat {
+        self.target.command_format()
+    }
+
+    /// Target trait オブジェクトへの参照
+    ///
+    /// `SyncDestination::supports` のような固有メソッドが
+    /// `target.supports(kind)` / `target.supports_scope(kind, scope)` を
+    /// 呼ぶために `pub(super)` で公開する。
+    pub(super) fn target(&self) -> &dyn Target {
+        self.target.as_ref()
+    }
+
+    /// 配置済みコンポーネント一覧
+    ///
+    /// 重複した `PlacedRef` がある場合はエラーを返す。
+    pub(super) fn placed_components(&self, options: &SyncOptions) -> Result<Vec<PlacedComponent>> {
+        let mut components = Vec::new();
+        let mut seen_refs = HashSet::new();
+
+        let kinds = self.target_kinds(options);
+        let scopes = self.target_scopes(options);
+
+        for syncable_kind in kinds {
+            let kind = syncable_kind.to_component_kind();
+
+            for scope in &scopes {
+                let placed = self.target.list_placed(kind, *scope, &self.project_root)?;
+
+                for name in placed {
+                    let placed_ref = PlacedRef::new(kind, name.clone(), *scope);
+
+                    if !seen_refs.insert(placed_ref.clone()) {
+                        return Err(PlmError::InvalidArgument(format!(
+                            "Duplicate placed component ref: {:?}",
+                            placed_ref
+                        )));
+                    }
+
+                    let path = self.resolve_path(kind, &name, *scope)?;
+                    components.push(PlacedComponent::new(kind, name, *scope, path));
+                }
+            }
+        }
+
+        Ok(components)
+    }
+
+    /// 配置済みコンポーネントのパスを解決
+    pub(super) fn path_for(&self, component: &PlacedComponent) -> Result<PathBuf> {
+        self.resolve_path(component.kind(), component.name(), component.scope())
+    }
+
+    /// `SyncOptions` から処理対象の `SyncableKind` リストを取得
+    pub(super) fn target_kinds(&self, options: &SyncOptions) -> Vec<SyncableKind> {
+        match options.component_type {
+            Some(kind) => vec![kind],
+            None => SyncableKind::all().to_vec(),
+        }
+    }
+
+    /// `SyncOptions` から処理対象の `Scope` リストを取得
+    pub(super) fn target_scopes(&self, options: &SyncOptions) -> Vec<Scope> {
+        match options.scope {
+            Some(scope) => vec![scope],
+            None => vec![Scope::Personal, Scope::Project],
+        }
+    }
+
+    /// コンポーネントのパスを解決
+    pub(super) fn resolve_path(
+        &self,
+        kind: ComponentKind,
+        name: &str,
+        scope: Scope,
+    ) -> Result<PathBuf> {
+        let (origin, component_name) = parse_component_name(name)?;
+
+        let ctx = PlacementContext {
+            component: ComponentRef::new(kind, component_name),
+            origin: &origin,
+            scope: PlacementScope::new(scope),
+            project: ProjectContext::new(&self.project_root),
+        };
+
+        self.target
+            .placement_location(&ctx)
+            .map(|l| l.into_path())
+            .ok_or_else(|| {
+                PlmError::InvalidArgument(format!(
+                    "Cannot resolve path for {} on {}",
+                    name,
+                    self.target.name()
+                ))
+            })
+    }
+}

--- a/src/sync/endpoint/source.rs
+++ b/src/sync/endpoint/source.rs
@@ -1,27 +1,21 @@
 //! 同期元の定義
 
-use super::super::model::{PlacedComponent, PlacedRef, SyncOptions, SyncableKind};
-use crate::component::{
-    CommandFormat, ComponentKind, ComponentRef, PlacementContext, PlacementScope, ProjectContext,
-    Scope,
-};
-use crate::error::{PlmError, Result};
-use crate::scan::is_instruction_file;
-use crate::target::{parse_target, PluginOrigin, Target, TargetKind};
-use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
+use super::super::model::{PlacedComponent, SyncOptions};
+use super::EndpointInner;
+use crate::component::CommandFormat;
+use crate::error::Result;
+use crate::target::{Target, TargetKind};
+
 /// 同期元
-pub struct SyncSource {
-    target: Box<dyn Target>,
-    project_root: PathBuf,
-}
+pub struct SyncSource(EndpointInner);
 
 impl std::fmt::Debug for SyncSource {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SyncSource")
-            .field("target", &self.target.name())
-            .field("project_root", &self.project_root)
+            .field("target", &self.0.target.name())
+            .field("project_root", &self.0.project_root)
             .finish()
     }
 }
@@ -34,11 +28,7 @@ impl SyncSource {
     /// * `kind` - Target environment kind to read components from.
     /// * `project_root` - Project root directory used when resolving placement paths.
     pub fn new(kind: TargetKind, project_root: &Path) -> Result<Self> {
-        let target = parse_target(kind.as_str())?;
-        Ok(Self {
-            target,
-            project_root: project_root.to_path_buf(),
-        })
+        Ok(Self(EndpointInner::new(kind, project_root)?))
     }
 
     /// テスト用コンストラクタ（Target を注入）
@@ -48,20 +38,17 @@ impl SyncSource {
     /// * `target` - Injected target implementation to use in tests.
     /// * `project_root` - Project root directory used when resolving placement paths.
     pub fn with_target(target: Box<dyn Target>, project_root: &Path) -> Self {
-        Self {
-            target,
-            project_root: project_root.to_path_buf(),
-        }
+        Self(EndpointInner::with_target(target, project_root))
     }
 
     /// ターゲット名を取得
     pub fn name(&self) -> &'static str {
-        self.target.name()
+        self.0.name()
     }
 
     /// Command フォーマットを取得
     pub fn command_format(&self) -> CommandFormat {
-        self.target.command_format()
+        self.0.command_format()
     }
 
     /// 配置済みコンポーネントを取得
@@ -72,35 +59,7 @@ impl SyncSource {
     ///
     /// * `options` - Options selecting which kinds and scopes to include.
     pub fn placed_components(&self, options: &SyncOptions) -> Result<Vec<PlacedComponent>> {
-        let mut components = Vec::new();
-        let mut seen_refs = HashSet::new();
-
-        let kinds = self.target_kinds(options);
-        let scopes = self.target_scopes(options);
-
-        for syncable_kind in kinds {
-            let kind = syncable_kind.to_component_kind();
-
-            for scope in &scopes {
-                let placed = self.target.list_placed(kind, *scope, &self.project_root)?;
-
-                for name in placed {
-                    let placed_ref = PlacedRef::new(kind, name.clone(), *scope);
-
-                    if !seen_refs.insert(placed_ref.clone()) {
-                        return Err(PlmError::InvalidArgument(format!(
-                            "Duplicate placed component ref: {:?}",
-                            placed_ref
-                        )));
-                    }
-
-                    let path = self.resolve_path(kind, &name, *scope)?;
-                    components.push(PlacedComponent::new(kind, name, *scope, path));
-                }
-            }
-        }
-
-        Ok(components)
+        self.0.placed_components(options)
     }
 
     /// コンポーネントのパスを取得
@@ -109,115 +68,8 @@ impl SyncSource {
     ///
     /// * `component` - Placed component whose source path should be resolved.
     pub fn path_for(&self, component: &PlacedComponent) -> Result<PathBuf> {
-        self.resolve_path(component.kind(), component.name(), component.scope())
+        self.0.path_for(component)
     }
-
-    /// 対象の SyncableKind リストを取得
-    ///
-    /// # Arguments
-    ///
-    /// * `options` - Options whose `component_type` filter is applied.
-    fn target_kinds(&self, options: &SyncOptions) -> Vec<SyncableKind> {
-        match options.component_type {
-            Some(kind) => vec![kind],
-            None => SyncableKind::all().to_vec(),
-        }
-    }
-
-    /// 対象の Scope リストを取得
-    ///
-    /// # Arguments
-    ///
-    /// * `options` - Options whose `scope` filter is applied.
-    fn target_scopes(&self, options: &SyncOptions) -> Vec<Scope> {
-        match options.scope {
-            Some(scope) => vec![scope],
-            None => vec![Scope::Personal, Scope::Project],
-        }
-    }
-
-    /// パスを解決
-    ///
-    /// # Arguments
-    ///
-    /// * `kind` - Component kind to resolve.
-    /// * `name` - Fully-qualified component name (e.g. `marketplace/plugin/component`).
-    /// * `scope` - Placement scope (personal or project).
-    fn resolve_path(&self, kind: ComponentKind, name: &str, scope: Scope) -> Result<PathBuf> {
-        let (origin, component_name) = parse_component_name(name)?;
-
-        let ctx = PlacementContext {
-            component: ComponentRef::new(kind, component_name),
-            origin: &origin,
-            scope: PlacementScope::new(scope),
-            project: ProjectContext::new(&self.project_root),
-        };
-
-        self.target
-            .placement_location(&ctx)
-            .map(|l| l.into_path())
-            .ok_or_else(|| {
-                PlmError::InvalidArgument(format!(
-                    "Cannot resolve path for {} on {}",
-                    name,
-                    self.target.name()
-                ))
-            })
-    }
-}
-
-/// コンポーネント名をパース。
-///
-/// フラット化後の識別子は `flattened_name` 単一セグメントのみ。Instruction
-/// (AGENTS.md / copilot-instructions.md / GEMINI.md) はそのままファイル名で
-/// 受け取る特例とする。空文字・パス区切り (`/` `\`) ・null バイト・`.` / `..` ・
-/// 複合パスを含むレガシー識別子は `InvalidArgument` で拒否する
-/// (`placement_location` が `base.join(name)` を直接行うためベースディレクトリ
-/// 外への書き込みを防ぐ)。
-///
-/// # Arguments
-///
-/// * `name` - フラット化された Component 名、または Instruction のファイル名。
-pub fn parse_component_name(name: &str) -> Result<(PluginOrigin, &str)> {
-    // Instruction の特別扱い
-    if is_instruction_file(name) {
-        return Ok((PluginOrigin::from_marketplace("", ""), name));
-    }
-
-    validate_flattened_name(name)?;
-
-    // フラット配置では origin を復元できないためプレースホルダを埋める。
-    Ok((PluginOrigin::placeholder(), name))
-}
-
-/// `flattened_name` が単一の安全なパスセグメントであることを検証する。
-fn validate_flattened_name(name: &str) -> Result<()> {
-    if name.is_empty() {
-        return Err(PlmError::InvalidArgument(
-            "Component name must not be empty".to_string(),
-        ));
-    }
-    if name.contains('/') || name.contains('\\') || name.contains('\0') {
-        return Err(PlmError::InvalidArgument(format!(
-            "Invalid component name '{}': must not contain path separators or null bytes",
-            name
-        )));
-    }
-    if name == "." || name == ".." {
-        return Err(PlmError::InvalidArgument(format!(
-            "Invalid component name '{}': must not be a parent/current directory reference",
-            name
-        )));
-    }
-    let mut components = Path::new(name).components();
-    let first = components.next();
-    if components.next().is_some() || !matches!(first, Some(std::path::Component::Normal(_))) {
-        return Err(PlmError::InvalidArgument(format!(
-            "Invalid component name '{}': must be a single flattened segment",
-            name
-        )));
-    }
-    Ok(())
 }
 
 #[cfg(test)]

--- a/src/sync/endpoint/source.rs
+++ b/src/sync/endpoint/source.rs
@@ -3,13 +3,13 @@
 use std::path::{Path, PathBuf};
 
 use super::super::model::{PlacedComponent, SyncOptions};
-use super::EndpointInner;
+use super::TargetBinding;
 use crate::component::CommandFormat;
 use crate::error::Result;
 use crate::target::{Target, TargetKind};
 
 /// 同期元
-pub struct SyncSource(EndpointInner);
+pub struct SyncSource(TargetBinding);
 
 impl std::fmt::Debug for SyncSource {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -28,7 +28,7 @@ impl SyncSource {
     /// * `kind` - Target environment kind to read components from.
     /// * `project_root` - Project root directory used when resolving placement paths.
     pub fn new(kind: TargetKind, project_root: &Path) -> Result<Self> {
-        Ok(Self(EndpointInner::new(kind, project_root)?))
+        Ok(Self(TargetBinding::new(kind, project_root)?))
     }
 
     /// テスト用コンストラクタ（Target を注入）
@@ -38,7 +38,7 @@ impl SyncSource {
     /// * `target` - Injected target implementation to use in tests.
     /// * `project_root` - Project root directory used when resolving placement paths.
     pub fn with_target(target: Box<dyn Target>, project_root: &Path) -> Self {
-        Self(EndpointInner::with_target(target, project_root))
+        Self(TargetBinding::with_target(target, project_root))
     }
 
     /// ターゲット名を取得

--- a/src/sync/endpoint/source_test.rs
+++ b/src/sync/endpoint/source_test.rs
@@ -1,4 +1,4 @@
-use super::*;
+use super::super::parse_component_name;
 
 #[test]
 fn test_parse_component_name_single_segment() {


### PR DESCRIPTION
## 概要

`src/sync/endpoint/source.rs` と `destination.rs` に存在した共通フィールド 2 個・共通メソッド 9 個（本体ほぼ完全一致）を `EndpointInner` に集約し、`SyncSource(EndpointInner)` / `SyncDestination(EndpointInner)` の newtype 化により重複を解消する。あわせて Issue #255 の対応として `pub(crate) enum Endpoint { Source, Destination }` を足場として導入する。**公開 API（`SyncSource` / `SyncDestination`）のシグネチャは PR 前後で完全一致しており、振る舞い不変のリファクタリング**。

## 変更の種類

- ♻️ [Refactoring]: リファクタリング（振る舞い不変）

## 追加した内容

- `src/sync/endpoint/inner.rs`（新規）: `pub(super) struct EndpointInner { target, project_root }` と共通メソッド 9 個 + `target()` アクセサを集約
- `src/sync/endpoint.rs::Endpoint`（新規）: `pub(crate) enum Endpoint { Source(SyncSource), Destination(SyncDestination) }` + `as_source` / `as_destination` / 共通メソッドのディスパッチ
- `src/sync/endpoint/endpoint_test.rs`（新規）: `FakeTarget` ベースの回帰防止テスト 17 件（Endpoint dispatch / placed_components / path_for / resolve_path / supports 3 ケース / target_kinds / target_scopes / Debug 出力）

## 変更した内容

- `src/sync/endpoint.rs`
  - `mod inner;` 追加、`use self::inner::EndpointInner;` で子モジュールに再導入
  - `parse_component_name` / `validate_flattened_name` を本ファイル直下へ移動（公開度: `pub(super)` / private）
  - `#[path = \"endpoint/endpoint_test.rs\"] mod tests;` を末尾に追加
- `src/sync/endpoint/source.rs`
  - `pub struct SyncSource(EndpointInner);` newtype 化
  - 共通メソッド 9 個の本体を削除し `self.0.〜` への委譲に置換
  - `parse_component_name` / `validate_flattened_name` を削除（移動先: endpoint.rs）
  - 手動 `Debug for SyncSource` を据置（出力フォーマット保存）
- `src/sync/endpoint/destination.rs`
  - `pub struct SyncDestination(EndpointInner);` newtype 化
  - `use super::source::parse_component_name;` の越境 import を削除
  - 共通メソッドを `self.0.〜` 委譲に置換、`supports` のみ固有メソッドとして据置
  - 手動 `Debug for SyncDestination` を据置
- `src/sync/endpoint/source_test.rs`
  - `use super::*;` を `use super::super::parse_component_name;` に書換（関数移動に追従）

## 削除した内容

- `src/sync/endpoint/source.rs` の `parse_component_name` / `validate_flattened_name`（endpoint.rs へ移動）
- `src/sync/endpoint/destination.rs` の `use super::source::parse_component_name;` 越境参照
- `source.rs` / `destination.rs` の共通メソッド本体（合計約 172 行 → `EndpointInner` 1 箇所に集約）

## システム図

### モジュール構造（Before / After）

\`\`\`
[Before]                              [After]
src/sync/endpoint/                    src/sync/endpoint/
├── source.rs (225 LOC)               ├── source.rs (薄い newtype)
│   ├ SyncSource struct               │   └ SyncSource(EndpointInner)
│   ├ 共通メソッド 9 個              ├── destination.rs (薄い newtype)
│   └ parse_component_name           │   ├ SyncDestination(EndpointInner)
├── destination.rs (183 LOC)          │   └ supports (固有メソッド)
│   ├ SyncDestination struct          ├── inner.rs [NEW]
│   ├ 共通メソッド 9 個              │   └ EndpointInner (共通本体)
│   └ use super::source::*           ├── endpoint_test.rs [NEW]
└── endpoint.rs                       │   └ FakeTarget + 共通テスト 17 件
    └ サブ親 (12 LOC)                 └── endpoint.rs
                                          ├ enum Endpoint (pub(crate))
                                          └ parse_component_name (pub(super))
\`\`\`

### 呼出フロー（リファクタ後）

\`\`\`mermaid
flowchart TD
    Caller[呼び出し側<br/>commands/deploy/sync.rs<br/>src/sync.rs]
    Source[SyncSource<br/>newtype]
    Dest[SyncDestination<br/>newtype]
    Inner[EndpointInner<br/>共通本体]
    Target[Box&lt;dyn Target&gt;<br/>既存 trait]
    Endpoint[enum Endpoint<br/>pub crate scaffold]

    Caller -->|公開 API 据置| Source
    Caller -->|公開 API 据置| Dest
    Source -->|委譲| Inner
    Dest -->|委譲| Inner
    Dest -->|supports 固有| Target
    Inner -->|list_placed / placement_location| Target
    Endpoint -.->|as_source / as_destination| Source
    Endpoint -.->|as_source / as_destination| Dest

    style Inner fill:#fef3c7,stroke:#f59e0b
    style Endpoint fill:#dbeafe,stroke:#3b82f6
\`\`\`

## 関連 Spec / Issue

- Spec: \`.plugin-workspace/.specs/017-sync-endpoint-abstraction/\`（gitignore のためコミット対象外）
- Refs #255（Sub-issue C: 実装と既存呼び出し側の移行）
- Refs #254（Parent epic）

> 本 PR は当初 3 PR 分割（A: 重複棚卸しドキュメント / B: 設計ドキュメント / C: 実装）の予定だったが、ローカルワークフローの都合で 1 PR にまとめている。A / B 相当のドキュメント（duplication-inventory.md / design-doc.md）は \`.plugin-workspace/.specs/\` 配下に作成済みでローカル参照のみ。

## 検証

CLAUDE.md / MEMORY.md 規約に従いサブエージェント経由で実行:

- `cargo fmt`（Bash サブエージェント）: 適用済み
- `cargo check` / `cargo check --tests`（rust-workflow-plugin:type-check）: エラー 0
- `cargo test sync::endpoint`（rust-workflow-plugin:test）: **9 → 26 passed**（17 件追加）
- `cargo test`（全件・rust-workflow-plugin:test）: **1553 → 1570 passed**（追加分含む全パス、リグレッションなし）

リファクタ前後の不変条件（grep ベース）:

- `git grep \"use super::source::parse_component_name\"`: ヒット **0**（越境参照解消）
- `grep -E \"^\\s*pub fn\" src/sync/endpoint/source.rs src/sync/endpoint/destination.rs`: 13 シグネチャすべて PR 前と完全一致

Codex レビュー（`codex exec` 経由）:

- review-001: `EndpointInner` 可視性 `pub(crate)` → `pub(super)` への絞り込み指摘 → 修正済み
- review-002: **問題なし**（公開 API 据置・案 S 設計準拠・Debug フォーマット保存・parse_component_name 配置を確認）

## レビューポイント

- **公開 API 完全据置**: `SyncSource` / `SyncDestination` の `pub fn` シグネチャが PR 前後で完全一致していること（破壊的変更なし）
- **手動 `Debug` 実装の据置**: `#[derive(Debug)]` だと `SyncSource(EndpointInner { ... })` 形式に変質するため、`SyncSource { target: ..., project_root: ... }` の出力フォーマット保存のため手動実装を維持している
- **可視性の階層**: `EndpointInner` は `pub(super)` で endpoint サブ親配下のみに閉じ、`Endpoint` enum は `pub(crate)` で crate 内補助型として提供（外部 API は `SyncSource` / `SyncDestination` のまま）
- **`Endpoint` enum は scaffold**: 本 PR では本番コード（`src/sync.rs` / `src/commands/deploy/sync.rs`）の引数型は据置とし、`Endpoint` の利用は `endpoint_test.rs` のディスパッチ確認テストのみ。将来「両端を同列に扱う処理」が現れた段階で活用予定
- **`SyncDestination::supports` を `Endpoint` に生やしていない**: 型レベルで Source variant からの呼出を排除する設計判断（hearing §3.3 確定方針）
- **`FakeTarget::unsafe impl Sync`**: テスト専用・シングルスレッドのため許容（`Mutex` 化は別 issue 案件として保留）