### PR TITLE
🐛 [Bug Fix]: prevent same-marketplace plugin overwrite via plugin_identifier

### DIFF
--- a/src/commands/lifecycle/update.rs
+++ b/src/commands/lifecycle/update.rs
@@ -61,7 +61,18 @@ pub async fn run(args: Args) -> Result<(), String> {
             return Err("All updates failed".to_string());
         }
     } else if let Some(name) = &args.name {
-        let result = update_plugin(&cache, name, &project_root, target_filter).await;
+        let (plugin_input, marketplace_hint) = match name.split_once('@') {
+            Some((p, m)) if !p.is_empty() && !m.is_empty() => (p, Some(m)),
+            _ => (name.as_str(), None),
+        };
+        let result = update_plugin(
+            &cache,
+            plugin_input,
+            marketplace_hint,
+            &project_root,
+            target_filter,
+        )
+        .await;
         display_single_result(&result);
 
         if matches!(result.status, UpdateStatus::Failed) {

--- a/src/error.rs
+++ b/src/error.rs
@@ -52,6 +52,18 @@ pub enum PlmError {
         candidates: Vec<String>,
     },
 
+    #[error("Ambiguous plugin name: '{name}' matches multiple plugins ({})", candidates.join(", "))]
+    AmbiguousPluginName {
+        name: String,
+        candidates: Vec<String>,
+    },
+
+    #[error("Invalid plugin name: {0}")]
+    InvalidPluginName(String),
+
+    #[error("Duplicate plugin name in marketplace manifest: {0}")]
+    DuplicatePluginName(String),
+
     #[error("Marketplace not found: {0}")]
     MarketplaceNotFound(String),
 
@@ -180,6 +192,31 @@ impl From<PlmError> for RichError {
                     candidates.join(", ")
                 );
                 (ErrorCode::Plg003, msg, ctx)
+            }
+            PlmError::AmbiguousPluginName { name, candidates } => {
+                let ctx = ErrorContext::new().with_plugin_name(name.clone());
+                let msg = format!(
+                    "Ambiguous plugin name '{}' matches multiple plugins: {}",
+                    name,
+                    candidates.join(", ")
+                );
+                (ErrorCode::Plg003, msg, ctx)
+            }
+            PlmError::InvalidPluginName(name) => {
+                let ctx = ErrorContext::new().with_plugin_name(name.clone());
+                (
+                    ErrorCode::Val002,
+                    format!("Invalid plugin name: {}", name),
+                    ctx,
+                )
+            }
+            PlmError::DuplicatePluginName(name) => {
+                let ctx = ErrorContext::new().with_plugin_name(name.clone());
+                (
+                    ErrorCode::Plg002,
+                    format!("Duplicate plugin name in marketplace manifest: {}", name),
+                    ctx,
+                )
             }
             PlmError::MarketplaceNotFound(name) => (
                 ErrorCode::Mkt001,

--- a/src/marketplace.rs
+++ b/src/marketplace.rs
@@ -13,6 +13,8 @@ pub use config::validate_name;
 pub use download::download_marketplace_plugin_with_cache;
 pub use path::PluginSourcePath;
 pub use registry::{
-    validate_plugin_name, validate_plugin_names, MarketplaceCache, MarketplaceManifest,
-    MarketplacePlugin, MarketplaceRegistry, PluginSource,
+    validate_plugin_names, MarketplaceCache, MarketplaceManifest, MarketplaceRegistry, PluginSource,
 };
+// Re-exported for tests
+#[cfg(test)]
+pub use registry::MarketplacePlugin;

--- a/src/marketplace.rs
+++ b/src/marketplace.rs
@@ -12,7 +12,7 @@ pub use config::{
 pub use config::validate_name;
 pub use download::download_marketplace_plugin_with_cache;
 pub use path::PluginSourcePath;
-// Re-exported for tests
-#[cfg(test)]
-pub use registry::MarketplacePlugin;
-pub use registry::{MarketplaceCache, MarketplaceManifest, MarketplaceRegistry, PluginSource};
+pub use registry::{
+    validate_plugin_name, validate_plugin_names, MarketplaceCache, MarketplaceManifest,
+    MarketplacePlugin, MarketplaceRegistry, PluginSource,
+};

--- a/src/marketplace/registry.rs
+++ b/src/marketplace/registry.rs
@@ -1,8 +1,10 @@
 use crate::error::{PlmError, Result};
 use crate::host::HostClient;
+use crate::marketplace::config::normalize_name;
 use crate::repo::Repo;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 use std::fs;
 use std::path::PathBuf;
 
@@ -62,6 +64,42 @@ pub struct MarketplaceCache {
     #[serde(default)]
     pub owner: Option<MarketplaceOwner>,
     pub plugins: Vec<MarketplacePlugin>,
+}
+
+/// MarketplacePlugin.name のパス安全性検証。
+///
+/// - 空文字 / `.` / `..` を拒否
+/// - パス区切り (`/`, `\\`) を含む名前を拒否
+/// - 絶対パス的な前置 (`~`) を拒否
+/// - 制御文字を拒否
+pub fn validate_plugin_name(name: &str) -> Result<()> {
+    if name.is_empty() || name == "." || name == ".." {
+        return Err(PlmError::InvalidPluginName(name.to_string()));
+    }
+    if name.contains('/') || name.contains('\\') || name.starts_with('~') {
+        return Err(PlmError::InvalidPluginName(name.to_string()));
+    }
+    if name.chars().any(|c| c.is_control()) {
+        return Err(PlmError::InvalidPluginName(name.to_string()));
+    }
+    Ok(())
+}
+
+/// MarketplaceCache を構築・取得する直前で呼ぶ。
+///
+/// (a) 各 plugin.name のパス安全性を validate
+/// (b) `normalize_name` 後の重複を検出
+pub fn validate_plugin_names(plugins: &[MarketplacePlugin]) -> Result<()> {
+    let mut seen: HashSet<String> = HashSet::new();
+    for p in plugins {
+        validate_plugin_name(&p.name)?;
+        let normalized = normalize_name(&p.name)
+            .map_err(|msg| PlmError::InvalidPluginName(format!("{}: {}", p.name, msg)))?;
+        if !seen.insert(normalized) {
+            return Err(PlmError::DuplicatePluginName(p.name.clone()));
+        }
+    }
+    Ok(())
 }
 
 impl MarketplaceCache {
@@ -146,6 +184,7 @@ impl MarketplaceRegistry {
 
         let content = fs::read_to_string(&path)?;
         let cache: MarketplaceCache = serde_json::from_str(&content)?;
+        validate_plugin_names(&cache.plugins)?;
         Ok(Some(cache))
     }
 
@@ -155,6 +194,7 @@ impl MarketplaceRegistry {
     ///
     /// * `cache` - Marketplace cache entry to persist to disk.
     pub fn store(&self, cache: &MarketplaceCache) -> Result<()> {
+        validate_plugin_names(&cache.plugins)?;
         let path = self.cache_path(&cache.name);
         let content = serde_json::to_string_pretty(cache)?;
         fs::write(path, content)?;

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -4,7 +4,7 @@ mod lifecycle;
 pub mod meta;
 
 pub(crate) use cache::{cleanup_legacy_hierarchy, cleanup_plugin_directories, list_installed};
-pub use cache::{CachedPackage, PackageCache, PackageCacheAccess};
+pub use cache::{CachedPackage, LegacyLayoutSweeper, PackageCache, PackageCacheAccess};
 pub(crate) use content::{load_plugin, Plugin};
 pub use content::{InstalledPlugin, MarketplaceContent};
 pub use lifecycle::{

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -4,7 +4,7 @@ mod lifecycle;
 pub mod meta;
 
 pub(crate) use cache::{cleanup_legacy_hierarchy, cleanup_plugin_directories, list_installed};
-pub use cache::{CachedPackage, LegacyLayoutSweeper, PackageCache, PackageCacheAccess};
+pub use cache::{CachedPackage, LegacyCacheCleaner, PackageCache, PackageCacheAccess};
 pub(crate) use content::{load_plugin, Plugin};
 pub use content::{InstalledPlugin, MarketplaceContent};
 pub use lifecycle::{

--- a/src/plugin/cache.rs
+++ b/src/plugin/cache.rs
@@ -2,10 +2,10 @@
 mod cache;
 mod cached_package;
 mod cleanup;
-mod legacy_layout_sweeper;
+mod legacy_cache_cleaner;
 
 pub(crate) use cache::list_installed;
 pub use cache::{PackageCache, PackageCacheAccess};
 pub use cached_package::CachedPackage;
 pub(crate) use cleanup::{cleanup_legacy_hierarchy, cleanup_plugin_directories};
-pub use legacy_layout_sweeper::LegacyLayoutSweeper;
+pub use legacy_cache_cleaner::LegacyCacheCleaner;

--- a/src/plugin/cache.rs
+++ b/src/plugin/cache.rs
@@ -2,8 +2,10 @@
 mod cache;
 mod cached_package;
 mod cleanup;
+mod legacy_layout_sweeper;
 
 pub(crate) use cache::list_installed;
 pub use cache::{PackageCache, PackageCacheAccess};
 pub use cached_package::CachedPackage;
 pub(crate) use cleanup::{cleanup_legacy_hierarchy, cleanup_plugin_directories};
+pub use legacy_layout_sweeper::LegacyLayoutSweeper;

--- a/src/plugin/cache/cache.rs
+++ b/src/plugin/cache/cache.rs
@@ -190,6 +190,50 @@ pub trait PackageCacheAccess: Send + Sync {
         name: &str,
         archive: &[u8],
     ) -> Result<PathBuf>;
+
+    /// `source_path` 対応のアトミック更新
+    ///
+    /// staging dir に展開してから target dir と swap する。失敗時は staging を破棄。
+    /// 呼び出し側が事前に backup してから呼ぶことで rollback 可能にする。
+    ///
+    /// # Arguments
+    ///
+    /// * `marketplace` - マーケットプレイス名（None の場合は "github"）
+    /// * `name` - プラグイン名
+    /// * `archive` - zipアーカイブのバイト列
+    /// * `source_path` - 抽出するソースパス（正規化済み）
+    fn atomic_update_with_source_path(
+        &self,
+        marketplace: Option<&str>,
+        name: &str,
+        archive: &[u8],
+        source_path: Option<&str>,
+    ) -> Result<PathBuf>;
+
+    /// marketplace 配下に指定 entry が存在するか確認
+    ///
+    /// # Arguments
+    ///
+    /// * `marketplace` - マーケットプレイス名
+    /// * `entry` - ディレクトリ名
+    fn has_marketplace_entry(&self, marketplace: &str, entry: &str) -> Result<bool>;
+
+    /// marketplace 配下の特定 entry のみを削除する
+    ///
+    /// （marketplace 配下全削除はしない）
+    ///
+    /// # Arguments
+    ///
+    /// * `marketplace` - マーケットプレイス名
+    /// * `entry` - ディレクトリ名
+    fn remove_marketplace_entry(&self, marketplace: &str, entry: &str) -> Result<()>;
+
+    /// marketplace 配下に存在するキャッシュディレクトリ名一覧を返す
+    ///
+    /// # Arguments
+    ///
+    /// * `marketplace` - マーケットプレイス名
+    fn list_marketplace_entries(&self, marketplace: &str) -> Result<Vec<String>>;
 }
 
 /// パッケージキャッシュマネージャ
@@ -436,6 +480,16 @@ impl PackageCacheAccess for PackageCache {
         name: &str,
         archive: &[u8],
     ) -> Result<PathBuf> {
+        self.atomic_update_with_source_path(marketplace, name, archive, None)
+    }
+
+    fn atomic_update_with_source_path(
+        &self,
+        marketplace: Option<&str>,
+        name: &str,
+        archive: &[u8],
+        source_path: Option<&str>,
+    ) -> Result<PathBuf> {
         let fs = RealFs;
         let target = self.plugin_path(marketplace, name);
         let temp_dir = self.temp_path(marketplace, name);
@@ -450,12 +504,15 @@ impl PackageCacheAccess for PackageCache {
             fs.create_dir_all(parent)?;
         }
 
-        // temp に展開（source_path なし）
-        extract_archive_with_source_path(&temp_dir, archive, None)?;
+        // temp に展開（source_path 適用）— 失敗時は temp を破棄
+        if let Err(e) = extract_archive_with_source_path(&temp_dir, archive, source_path) {
+            let _ = fs.remove_dir_all(&temp_dir);
+            return Err(e);
+        }
 
         // 検証: plugin.json の存在確認
         if !has_manifest(&temp_dir) {
-            fs.remove_dir_all(&temp_dir)?;
+            let _ = fs.remove_dir_all(&temp_dir);
             return Err(PlmError::InvalidManifest("plugin.json not found".into()));
         }
 
@@ -468,6 +525,38 @@ impl PackageCacheAccess for PackageCache {
         fs.rename(&temp_dir, &target)?;
 
         Ok(target)
+    }
+
+    fn has_marketplace_entry(&self, marketplace: &str, entry: &str) -> Result<bool> {
+        let fs = RealFs;
+        let path = self.cache_dir.join(marketplace).join(entry);
+        Ok(fs.exists(&path))
+    }
+
+    fn remove_marketplace_entry(&self, marketplace: &str, entry: &str) -> Result<()> {
+        let fs = RealFs;
+        let path = self.cache_dir.join(marketplace).join(entry);
+        if fs.exists(&path) {
+            fs.remove_dir_all(&path)?;
+        }
+        Ok(())
+    }
+
+    fn list_marketplace_entries(&self, marketplace: &str) -> Result<Vec<String>> {
+        let fs = RealFs;
+        let mp_dir = self.cache_dir.join(marketplace);
+        let mut entries = Vec::new();
+        if !fs.exists(&mp_dir) {
+            return Ok(entries);
+        }
+        for entry in fs.read_dir(&mp_dir)? {
+            if entry.is_dir() {
+                if let Some(name) = entry.path.file_name() {
+                    entries.push(name.to_string_lossy().to_string());
+                }
+            }
+        }
+        Ok(entries)
     }
 }
 

--- a/src/plugin/cache/legacy_cache_cleaner.rs
+++ b/src/plugin/cache/legacy_cache_cleaner.rs
@@ -10,9 +10,9 @@ use crate::plugin::cache::PackageCacheAccess;
 use std::collections::HashSet;
 
 /// 旧キャッシュレイアウトを安全に掃除するヘルパー
-pub struct LegacyLayoutSweeper;
+pub struct LegacyCacheCleaner;
 
-impl LegacyLayoutSweeper {
+impl LegacyCacheCleaner {
     /// 旧バグ固有のレイアウトを検出し、旧 `<repo.name()>` ディレクトリだけを削除する
     ///
     /// 副作用は idempotent。
@@ -32,7 +32,7 @@ impl LegacyLayoutSweeper {
     /// # Returns
     ///
     /// `Ok(true)` when the legacy directory was removed, `Ok(false)` when no-op.
-    pub fn sweep_if_legacy(
+    pub fn clean_if_legacy(
         cache: &dyn PackageCacheAccess,
         marketplace_name: &str,
         mp_cache: &MarketplaceCache,
@@ -63,7 +63,7 @@ impl LegacyLayoutSweeper {
 /// `"github:owner/repo"` → `Some("repo")`
 ///
 /// パストラバーサル防止のため、抽出した名前が空 / `.` / `..` /
-/// パス区切り（`/`, `\`）を含む場合は `None` を返し、sweep を無効化する。
+/// パス区切り（`/`, `\`）を含む場合は `None` を返し、clean を無効化する。
 ///
 /// # Arguments
 ///
@@ -83,5 +83,5 @@ fn extract_repo_name(source: &str) -> Option<String> {
 }
 
 #[cfg(test)]
-#[path = "legacy_layout_sweeper_test.rs"]
+#[path = "legacy_cache_cleaner_test.rs"]
 mod tests;

--- a/src/plugin/cache/legacy_cache_cleaner_test.rs
+++ b/src/plugin/cache/legacy_cache_cleaner_test.rs
@@ -1,4 +1,4 @@
-use super::LegacyLayoutSweeper;
+use super::LegacyCacheCleaner;
 use crate::marketplace::{MarketplaceCache, MarketplacePlugin, PluginSource};
 use crate::plugin::cache::{PackageCache, PackageCacheAccess};
 use chrono::Utc;
@@ -24,7 +24,7 @@ fn make_cache(plugins: Vec<&str>) -> MarketplaceCache {
 }
 
 #[test]
-fn test_legacy_sweeper_removes_only_repo_name_dir() {
+fn test_legacy_cleaner_removes_only_repo_name_dir() {
     let temp = TempDir::new().unwrap();
     let cache = PackageCache::with_cache_dir(temp.path().to_path_buf()).unwrap();
     let market = "d-market";
@@ -35,7 +35,7 @@ fn test_legacy_sweeper_removes_only_repo_name_dir() {
 
     let mp_cache = make_cache(vec!["plugin-a", "plugin-b"]);
 
-    let removed = LegacyLayoutSweeper::sweep_if_legacy(&cache, market, &mp_cache).unwrap();
+    let removed = LegacyCacheCleaner::clean_if_legacy(&cache, market, &mp_cache).unwrap();
     assert!(removed);
     assert!(!cache.has_marketplace_entry(market, "d-market-git").unwrap());
     assert!(cache.has_marketplace_entry(market, "plugin-a").unwrap());
@@ -43,7 +43,7 @@ fn test_legacy_sweeper_removes_only_repo_name_dir() {
 }
 
 #[test]
-fn test_legacy_sweeper_noop_when_plugins_len_le_1() {
+fn test_legacy_cleaner_noop_when_plugins_len_le_1() {
     let temp = TempDir::new().unwrap();
     let cache = PackageCache::with_cache_dir(temp.path().to_path_buf()).unwrap();
     let market = "d-market";
@@ -51,13 +51,13 @@ fn test_legacy_sweeper_noop_when_plugins_len_le_1() {
     fs::create_dir_all(temp.path().join(market).join("d-market-git")).unwrap();
     let mp_cache = make_cache(vec!["plugin-a"]);
 
-    let removed = LegacyLayoutSweeper::sweep_if_legacy(&cache, market, &mp_cache).unwrap();
+    let removed = LegacyCacheCleaner::clean_if_legacy(&cache, market, &mp_cache).unwrap();
     assert!(!removed);
     assert!(cache.has_marketplace_entry(market, "d-market-git").unwrap());
 }
 
 #[test]
-fn test_legacy_sweeper_noop_when_plugins_empty() {
+fn test_legacy_cleaner_noop_when_plugins_empty() {
     let temp = TempDir::new().unwrap();
     let cache = PackageCache::with_cache_dir(temp.path().to_path_buf()).unwrap();
     let market = "d-market";
@@ -65,13 +65,13 @@ fn test_legacy_sweeper_noop_when_plugins_empty() {
     fs::create_dir_all(temp.path().join(market).join("d-market-git")).unwrap();
     let mp_cache = make_cache(vec![]);
 
-    let removed = LegacyLayoutSweeper::sweep_if_legacy(&cache, market, &mp_cache).unwrap();
+    let removed = LegacyCacheCleaner::clean_if_legacy(&cache, market, &mp_cache).unwrap();
     assert!(!removed);
     assert!(cache.has_marketplace_entry(market, "d-market-git").unwrap());
 }
 
 #[test]
-fn test_legacy_sweeper_noop_when_repo_name_matches_plugin() {
+fn test_legacy_cleaner_noop_when_repo_name_matches_plugin() {
     let temp = TempDir::new().unwrap();
     let cache = PackageCache::with_cache_dir(temp.path().to_path_buf()).unwrap();
     let market = "d-market";
@@ -79,13 +79,13 @@ fn test_legacy_sweeper_noop_when_repo_name_matches_plugin() {
     fs::create_dir_all(temp.path().join(market).join("d-market-git")).unwrap();
     let mp_cache = make_cache(vec!["d-market-git", "plugin-a"]);
 
-    let removed = LegacyLayoutSweeper::sweep_if_legacy(&cache, market, &mp_cache).unwrap();
+    let removed = LegacyCacheCleaner::clean_if_legacy(&cache, market, &mp_cache).unwrap();
     assert!(!removed);
     assert!(cache.has_marketplace_entry(market, "d-market-git").unwrap());
 }
 
 #[test]
-fn test_legacy_sweeper_noop_when_legacy_dir_missing() {
+fn test_legacy_cleaner_noop_when_legacy_dir_missing() {
     let temp = TempDir::new().unwrap();
     let cache = PackageCache::with_cache_dir(temp.path().to_path_buf()).unwrap();
     let market = "d-market";
@@ -93,7 +93,7 @@ fn test_legacy_sweeper_noop_when_legacy_dir_missing() {
     fs::create_dir_all(temp.path().join(market).join("plugin-a")).unwrap();
     let mp_cache = make_cache(vec!["plugin-a", "plugin-b"]);
 
-    let removed = LegacyLayoutSweeper::sweep_if_legacy(&cache, market, &mp_cache).unwrap();
+    let removed = LegacyCacheCleaner::clean_if_legacy(&cache, market, &mp_cache).unwrap();
     assert!(!removed);
     assert!(cache.has_marketplace_entry(market, "plugin-a").unwrap());
 }

--- a/src/plugin/cache/legacy_layout_sweeper.rs
+++ b/src/plugin/cache/legacy_layout_sweeper.rs
@@ -1,0 +1,87 @@
+//! 旧キャッシュレイアウトのピンポイント掃除
+//!
+//! 「`plugins.len() > 1` の marketplace で、`<repo.name()>` ディレクトリが存在し、
+//! かつそれが現 `plugins[].name` のどれにも一致しない」場合のみ、
+//! 旧 `<repo.name()>` ディレクトリ「だけ」を削除する。
+
+use crate::error::Result;
+use crate::marketplace::MarketplaceCache;
+use crate::plugin::cache::PackageCacheAccess;
+use std::collections::HashSet;
+
+/// 旧キャッシュレイアウトを安全に掃除するヘルパー
+pub struct LegacyLayoutSweeper;
+
+impl LegacyLayoutSweeper {
+    /// 旧バグ固有のレイアウトを検出し、旧 `<repo.name()>` ディレクトリだけを削除する
+    ///
+    /// 副作用は idempotent。
+    ///
+    /// 検出条件（すべて満たすときのみ削除）:
+    /// 1. `mp_cache.plugins.len() > 1`
+    /// 2. `mp_cache.source` から repo.name() を抽出できる
+    /// 3. `<market>/<repo.name()>/` が物理的に存在する
+    /// 4. `<repo.name()>` が `plugins[].name` のどれにも一致しない
+    ///
+    /// # Arguments
+    ///
+    /// * `cache` - Package cache accessor for has/remove operations.
+    /// * `marketplace_name` - Marketplace name being inspected.
+    /// * `mp_cache` - Cached marketplace manifest.
+    ///
+    /// # Returns
+    ///
+    /// `Ok(true)` when the legacy directory was removed, `Ok(false)` when no-op.
+    pub fn sweep_if_legacy(
+        cache: &dyn PackageCacheAccess,
+        marketplace_name: &str,
+        mp_cache: &MarketplaceCache,
+    ) -> Result<bool> {
+        if mp_cache.plugins.len() <= 1 {
+            return Ok(false);
+        }
+
+        let Some(legacy_dir_name) = extract_repo_name(&mp_cache.source) else {
+            return Ok(false);
+        };
+
+        let plugin_names: HashSet<&str> =
+            mp_cache.plugins.iter().map(|p| p.name.as_str()).collect();
+        if plugin_names.contains(legacy_dir_name.as_str()) {
+            return Ok(false);
+        }
+
+        if !cache.has_marketplace_entry(marketplace_name, &legacy_dir_name)? {
+            return Ok(false);
+        }
+
+        cache.remove_marketplace_entry(marketplace_name, &legacy_dir_name)?;
+        Ok(true)
+    }
+}
+
+/// `"github:owner/repo"` → `Some("repo")`
+///
+/// パストラバーサル防止のため、抽出した名前が空 / `.` / `..` /
+/// パス区切り（`/`, `\`）を含む場合は `None` を返し、sweep を無効化する。
+///
+/// # Arguments
+///
+/// * `source` - Marketplace source string in `github:owner/repo` form.
+fn extract_repo_name(source: &str) -> Option<String> {
+    let stripped = source.strip_prefix("github:").unwrap_or(source);
+    let candidate = stripped.rsplit('/').next()?;
+    if candidate.is_empty()
+        || candidate == "."
+        || candidate == ".."
+        || candidate.contains('/')
+        || candidate.contains('\\')
+    {
+        return None;
+    }
+    Some(candidate.to_string())
+}
+
+#[cfg(test)]
+#[path = "legacy_layout_sweeper_test.rs"]
+mod tests;

--- a/src/plugin/cache/legacy_layout_sweeper_test.rs
+++ b/src/plugin/cache/legacy_layout_sweeper_test.rs
@@ -1,0 +1,116 @@
+use super::LegacyLayoutSweeper;
+use crate::marketplace::{MarketplaceCache, MarketplacePlugin, PluginSource};
+use crate::plugin::cache::{PackageCache, PackageCacheAccess};
+use chrono::Utc;
+use std::fs;
+use tempfile::TempDir;
+
+fn make_cache(plugins: Vec<&str>) -> MarketplaceCache {
+    MarketplaceCache {
+        name: "d-market".to_string(),
+        fetched_at: Utc::now(),
+        source: "github:owner/d-market-git".to_string(),
+        owner: None,
+        plugins: plugins
+            .into_iter()
+            .map(|n| MarketplacePlugin {
+                name: n.to_string(),
+                source: PluginSource::Local(format!("./plugins/{}", n)),
+                description: None,
+                version: None,
+            })
+            .collect(),
+    }
+}
+
+#[test]
+fn test_legacy_sweeper_removes_only_repo_name_dir() {
+    let temp = TempDir::new().unwrap();
+    let cache = PackageCache::with_cache_dir(temp.path().to_path_buf()).unwrap();
+    let market = "d-market";
+
+    fs::create_dir_all(temp.path().join(market).join("d-market-git")).unwrap();
+    fs::create_dir_all(temp.path().join(market).join("plugin-a")).unwrap();
+    fs::create_dir_all(temp.path().join(market).join("plugin-b")).unwrap();
+
+    let mp_cache = make_cache(vec!["plugin-a", "plugin-b"]);
+
+    let removed = LegacyLayoutSweeper::sweep_if_legacy(&cache, market, &mp_cache).unwrap();
+    assert!(removed);
+    assert!(!cache.has_marketplace_entry(market, "d-market-git").unwrap());
+    assert!(cache.has_marketplace_entry(market, "plugin-a").unwrap());
+    assert!(cache.has_marketplace_entry(market, "plugin-b").unwrap());
+}
+
+#[test]
+fn test_legacy_sweeper_noop_when_plugins_len_le_1() {
+    let temp = TempDir::new().unwrap();
+    let cache = PackageCache::with_cache_dir(temp.path().to_path_buf()).unwrap();
+    let market = "d-market";
+
+    fs::create_dir_all(temp.path().join(market).join("d-market-git")).unwrap();
+    let mp_cache = make_cache(vec!["plugin-a"]);
+
+    let removed = LegacyLayoutSweeper::sweep_if_legacy(&cache, market, &mp_cache).unwrap();
+    assert!(!removed);
+    assert!(cache.has_marketplace_entry(market, "d-market-git").unwrap());
+}
+
+#[test]
+fn test_legacy_sweeper_noop_when_plugins_empty() {
+    let temp = TempDir::new().unwrap();
+    let cache = PackageCache::with_cache_dir(temp.path().to_path_buf()).unwrap();
+    let market = "d-market";
+
+    fs::create_dir_all(temp.path().join(market).join("d-market-git")).unwrap();
+    let mp_cache = make_cache(vec![]);
+
+    let removed = LegacyLayoutSweeper::sweep_if_legacy(&cache, market, &mp_cache).unwrap();
+    assert!(!removed);
+    assert!(cache.has_marketplace_entry(market, "d-market-git").unwrap());
+}
+
+#[test]
+fn test_legacy_sweeper_noop_when_repo_name_matches_plugin() {
+    let temp = TempDir::new().unwrap();
+    let cache = PackageCache::with_cache_dir(temp.path().to_path_buf()).unwrap();
+    let market = "d-market";
+
+    fs::create_dir_all(temp.path().join(market).join("d-market-git")).unwrap();
+    let mp_cache = make_cache(vec!["d-market-git", "plugin-a"]);
+
+    let removed = LegacyLayoutSweeper::sweep_if_legacy(&cache, market, &mp_cache).unwrap();
+    assert!(!removed);
+    assert!(cache.has_marketplace_entry(market, "d-market-git").unwrap());
+}
+
+#[test]
+fn test_legacy_sweeper_noop_when_legacy_dir_missing() {
+    let temp = TempDir::new().unwrap();
+    let cache = PackageCache::with_cache_dir(temp.path().to_path_buf()).unwrap();
+    let market = "d-market";
+
+    fs::create_dir_all(temp.path().join(market).join("plugin-a")).unwrap();
+    let mp_cache = make_cache(vec!["plugin-a", "plugin-b"]);
+
+    let removed = LegacyLayoutSweeper::sweep_if_legacy(&cache, market, &mp_cache).unwrap();
+    assert!(!removed);
+    assert!(cache.has_marketplace_entry(market, "plugin-a").unwrap());
+}
+
+#[test]
+fn test_remove_marketplace_entry_removes_only_specified() {
+    let temp = TempDir::new().unwrap();
+    let cache = PackageCache::with_cache_dir(temp.path().to_path_buf()).unwrap();
+    let market = "d-market";
+
+    fs::create_dir_all(temp.path().join(market).join("a")).unwrap();
+    fs::create_dir_all(temp.path().join(market).join("b")).unwrap();
+    fs::create_dir_all(temp.path().join(market).join("c")).unwrap();
+
+    cache.remove_marketplace_entry(market, "b").unwrap();
+
+    assert!(cache.has_marketplace_entry(market, "a").unwrap());
+    assert!(!cache.has_marketplace_entry(market, "b").unwrap());
+    assert!(cache.has_marketplace_entry(market, "c").unwrap());
+}

--- a/src/plugin/lifecycle.rs
+++ b/src/plugin/lifecycle.rs
@@ -5,5 +5,4 @@ mod update;
 
 pub use action::PluginAction;
 pub use intent::PluginIntent;
-pub use plugin_resolver::{find_by_plugin_name, ResolvedPlugin};
 pub use update::{update_all_plugins, update_plugin, UpdateResult, UpdateStatus};

--- a/src/plugin/lifecycle.rs
+++ b/src/plugin/lifecycle.rs
@@ -1,7 +1,9 @@
 mod action;
 mod intent;
+pub(crate) mod plugin_resolver;
 mod update;
 
 pub use action::PluginAction;
 pub use intent::PluginIntent;
+pub use plugin_resolver::{find_by_plugin_name, ResolvedPlugin};
 pub use update::{update_all_plugins, update_plugin, UpdateResult, UpdateStatus};

--- a/src/plugin/lifecycle/plugin_resolver.rs
+++ b/src/plugin/lifecycle/plugin_resolver.rs
@@ -1,0 +1,87 @@
+//! プラグイン解決ヘルパー（display name fallback 専用）
+//!
+//! `update_plugin` 入口では先に **`cache_id` 完全一致** を試し、
+//! ヒットしなかったときだけ本 helper にフォールバックする。
+
+use crate::error::{PlmError, Result};
+use crate::plugin::cache::{CachedPackage, PackageCacheAccess};
+use crate::plugin::meta;
+use crate::plugin::PluginMeta;
+
+/// 解決された 1 件分のプラグイン情報
+#[derive(Debug)]
+pub struct ResolvedPlugin {
+    pub marketplace: Option<String>,
+    pub cache_id: String,
+    pub display_name: String,
+    pub package: CachedPackage,
+    /// 現在キャッシュされている `.plm-meta.json` の内容
+    pub package_meta: PluginMeta,
+}
+
+/// プラグイン表示名（`CachedPackage.name`）でプラグインを resolve する
+///
+/// 解決方針 (案 A):
+/// - `marketplace_hint` が `Some(m)` のときは走査時点で `marketplace == m` のエントリのみ候補にする
+/// - `None` のときは全 marketplace を候補にし、複数件マッチで `AmbiguousPluginName` を返す
+/// - 0 件 → `Ok(None)`
+/// - 1 件 → `Ok(Some(ResolvedPlugin))`
+/// - 2 件以上 → `Err(PlmError::AmbiguousPluginName { name, candidates })`
+///
+/// # Arguments
+///
+/// * `cache` - Package cache accessor used to enumerate stored plugins.
+/// * `plugin_name` - Display name (`CachedPackage.name`) being searched.
+/// * `marketplace_hint` - Optional marketplace name to disambiguate candidates.
+pub fn find_by_plugin_name(
+    cache: &dyn PackageCacheAccess,
+    plugin_name: &str,
+    marketplace_hint: Option<&str>,
+) -> Result<Option<ResolvedPlugin>> {
+    let mut matches: Vec<ResolvedPlugin> = Vec::new();
+    for (marketplace, cache_id) in cache.list()? {
+        if let Some(hint) = marketplace_hint {
+            if marketplace.as_deref() != Some(hint) {
+                continue;
+            }
+        }
+        let pkg = match cache.load_package(marketplace.as_deref(), &cache_id) {
+            Ok(p) => p,
+            Err(_) => continue,
+        };
+        if pkg.name == plugin_name {
+            let plugin_path = cache.plugin_path(marketplace.as_deref(), &cache_id);
+            let package_meta = meta::load_meta(&plugin_path).unwrap_or_default();
+            matches.push(ResolvedPlugin {
+                marketplace,
+                cache_id: cache_id.clone(),
+                display_name: pkg.name.clone(),
+                package: pkg,
+                package_meta,
+            });
+        }
+    }
+
+    match matches.len() {
+        0 => Ok(None),
+        1 => Ok(Some(matches.into_iter().next().unwrap())),
+        _ => {
+            let mut candidates: Vec<String> = matches
+                .iter()
+                .map(|m| match &m.marketplace {
+                    Some(mk) => format!("{}@{}", m.display_name, mk),
+                    None => m.display_name.clone(),
+                })
+                .collect();
+            candidates.sort();
+            Err(PlmError::AmbiguousPluginName {
+                name: plugin_name.to_string(),
+                candidates,
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "plugin_resolver_test.rs"]
+mod tests;

--- a/src/plugin/lifecycle/plugin_resolver_test.rs
+++ b/src/plugin/lifecycle/plugin_resolver_test.rs
@@ -1,0 +1,113 @@
+use super::find_by_plugin_name;
+use crate::error::PlmError;
+use crate::plugin::cache::{PackageCache, PackageCacheAccess};
+use crate::plugin::meta::{write_meta, PluginMeta};
+use std::fs;
+use tempfile::TempDir;
+
+const SAMPLE_MANIFEST: &str = r#"{ "name": "plugin-a", "version": "0.0.1", "description": "" }"#;
+const SAMPLE_MANIFEST_B: &str = r#"{ "name": "plugin-b", "version": "0.0.1", "description": "" }"#;
+
+fn install_plugin(cache: &PackageCache, marketplace: Option<&str>, cache_id: &str, manifest: &str) {
+    let path = cache.plugin_path(marketplace, cache_id);
+    fs::create_dir_all(&path).unwrap();
+    fs::write(path.join("plugin.json"), manifest).unwrap();
+    write_meta(&path, &PluginMeta::default()).unwrap();
+}
+
+#[test]
+fn test_find_by_plugin_name_returns_none_when_not_found() {
+    let temp = TempDir::new().unwrap();
+    let cache = PackageCache::with_cache_dir(temp.path().to_path_buf()).unwrap();
+    install_plugin(&cache, Some("d-market"), "plugin-a", SAMPLE_MANIFEST);
+
+    let r = find_by_plugin_name(&cache, "plugin-x", None).unwrap();
+    assert!(r.is_none());
+}
+
+#[test]
+fn test_find_by_plugin_name_returns_single_match() {
+    let temp = TempDir::new().unwrap();
+    let cache = PackageCache::with_cache_dir(temp.path().to_path_buf()).unwrap();
+    install_plugin(&cache, Some("d-market"), "plugin-a", SAMPLE_MANIFEST);
+
+    let r = find_by_plugin_name(&cache, "plugin-a", None)
+        .unwrap()
+        .unwrap();
+    assert_eq!(r.display_name, "plugin-a");
+    assert_eq!(r.cache_id, "plugin-a");
+    assert_eq!(r.marketplace.as_deref(), Some("d-market"));
+}
+
+#[test]
+fn test_find_by_plugin_name_returns_ambiguous_error_for_multiple_matches() {
+    let temp = TempDir::new().unwrap();
+    let cache = PackageCache::with_cache_dir(temp.path().to_path_buf()).unwrap();
+    install_plugin(&cache, Some("d-market"), "plugin-a", SAMPLE_MANIFEST);
+    install_plugin(&cache, Some("x-market"), "plugin-a", SAMPLE_MANIFEST);
+
+    let err = find_by_plugin_name(&cache, "plugin-a", None).unwrap_err();
+    match err {
+        PlmError::AmbiguousPluginName { name, candidates } => {
+            assert_eq!(name, "plugin-a");
+            assert_eq!(candidates.len(), 2);
+            // sorted
+            assert_eq!(candidates[0], "plugin-a@d-market");
+            assert_eq!(candidates[1], "plugin-a@x-market");
+        }
+        other => panic!("unexpected error: {:?}", other),
+    }
+}
+
+#[test]
+fn test_find_by_plugin_name_disambiguates_with_marketplace_hint() {
+    let temp = TempDir::new().unwrap();
+    let cache = PackageCache::with_cache_dir(temp.path().to_path_buf()).unwrap();
+    install_plugin(&cache, Some("d-market"), "plugin-a", SAMPLE_MANIFEST);
+    install_plugin(&cache, Some("x-market"), "plugin-a", SAMPLE_MANIFEST);
+
+    let r = find_by_plugin_name(&cache, "plugin-a", Some("d-market"))
+        .unwrap()
+        .unwrap();
+    assert_eq!(r.marketplace.as_deref(), Some("d-market"));
+}
+
+#[test]
+fn test_find_by_plugin_name_returns_none_when_hint_does_not_match_any() {
+    let temp = TempDir::new().unwrap();
+    let cache = PackageCache::with_cache_dir(temp.path().to_path_buf()).unwrap();
+    install_plugin(&cache, Some("d-market"), "plugin-a", SAMPLE_MANIFEST);
+
+    let r = find_by_plugin_name(&cache, "plugin-a", Some("x-market")).unwrap();
+    assert!(r.is_none());
+}
+
+#[test]
+fn test_find_by_plugin_name_skips_corrupt_entries() {
+    let temp = TempDir::new().unwrap();
+    let cache = PackageCache::with_cache_dir(temp.path().to_path_buf()).unwrap();
+    install_plugin(&cache, Some("d-market"), "plugin-a", SAMPLE_MANIFEST);
+    // 壊れたエントリ（plugin.json なし）
+    let broken = cache.plugin_path(Some("d-market"), "broken");
+    fs::create_dir_all(&broken).unwrap();
+
+    let r = find_by_plugin_name(&cache, "plugin-a", None)
+        .unwrap()
+        .unwrap();
+    assert_eq!(r.cache_id, "plugin-a");
+}
+
+#[test]
+fn test_find_by_plugin_name_distinguishes_direct_github() {
+    let temp = TempDir::new().unwrap();
+    let cache = PackageCache::with_cache_dir(temp.path().to_path_buf()).unwrap();
+    install_plugin(&cache, Some("d-market"), "plugin-a", SAMPLE_MANIFEST);
+    install_plugin(&cache, None, "owner--plugin-a", SAMPLE_MANIFEST_B);
+
+    // direct GitHub plugin の display name は "plugin-b"
+    let r = find_by_plugin_name(&cache, "plugin-b", None)
+        .unwrap()
+        .unwrap();
+    assert_eq!(r.marketplace, None);
+    assert_eq!(r.cache_id, "owner--plugin-a");
+}

--- a/src/plugin/lifecycle/update.rs
+++ b/src/plugin/lifecycle/update.rs
@@ -4,11 +4,14 @@
 //! 差分がある場合に再ダウンロード・再デプロイを行う。
 
 use crate::application::enable_plugin;
-use crate::host::{HostClientFactory, HostKind};
+use crate::error::{PlmError, Result};
+use crate::host::{HostClient, HostClientFactory, HostKind};
 use crate::http::with_retry;
-use crate::plugin::version::{fetch_remote_versions, needs_update, VersionQueryResult};
+use crate::marketplace::{MarketplaceCache, MarketplaceRegistry, PluginSource as MpPluginSource};
+use crate::plugin::lifecycle::plugin_resolver::{find_by_plugin_name, ResolvedPlugin};
+use crate::plugin::version::needs_update;
 use crate::plugin::{meta, PackageCacheAccess, PluginMeta};
-use crate::repo::Repo;
+use crate::repo::{self, Repo};
 use std::path::Path;
 
 /// 更新ステータス
@@ -142,7 +145,6 @@ fn restore_repo(
         return Ok(repo);
     }
 
-    // フォールバック: owner--repo 形式からパース
     let parts: Vec<&str> = plugin_name.split("--").collect();
     if parts.len() == 2 {
         let repo = Repo::new(
@@ -160,38 +162,188 @@ fn restore_repo(
     }
 }
 
+/// `MarketplaceCache.source` (`"github:{owner}/{name}"` 形式) と `PluginSource` から
+/// archive 取得用の `Repo` を再構築する。
+///
+/// `git_ref` は呼び出し側で必ず渡す（ローカル `PluginMeta.git_ref` を `unwrap_or("HEAD")` 等で解決）。
+/// `MarketplaceCache.source` は ref を持たないため、`Repo` に ref を詰めることで
+/// `download_archive_with_sha` がデフォルトブランチへフォールバックするのを防ぐ。
+///
+/// # Arguments
+///
+/// * `mp_source` - Marketplace source string in `github:owner/repo` form.
+/// * `plugin_source` - Plugin source descriptor from the marketplace cache entry.
+/// * `git_ref` - Git reference to embed into the resulting `Repo`.
+fn parse_repo_from_mp_source(
+    mp_source: &str,
+    plugin_source: &MpPluginSource,
+    git_ref: Option<&str>,
+) -> Result<Repo> {
+    // External は `repo` 文字列を `repo::from_url` で解析（`owner/repo@tag` や HTTPS URL に対応）。
+    // 取り出した owner / name を使って、ローカル `PluginMeta.git_ref` で上書きした `Repo` を返す。
+    // Local は marketplace 自体の repo を参照（mp_source の "github:owner/name" を strip して再構築）。
+    let parsed = match plugin_source {
+        MpPluginSource::External { repo, .. } => repo::from_url(repo)?,
+        MpPluginSource::Local(_) => {
+            let stripped = mp_source.strip_prefix("github:").unwrap_or(mp_source);
+            repo::from_url(stripped)?
+        }
+    };
+    Ok(Repo::new(
+        parsed.host(),
+        parsed.owner().to_string(),
+        parsed.name().to_string(),
+        git_ref
+            .map(String::from)
+            .or_else(|| parsed.git_ref().map(String::from)),
+    ))
+}
+
+/// `update_plugin` の入力 (`plugin_input`, `marketplace_hint`) を `ResolvedPlugin` に解決する。
+///
+/// 解決順序:
+/// 1. `marketplace_hint` がある場合: `cache.is_cached(Some(hint), plugin_input)` で確認
+/// 2. `marketplace_hint` がない場合: `cache.list()` を全走査して `cache_id == plugin_input` を集める
+///    - 1 件 → 確定 / 複数件 → AmbiguousPluginName
+/// 3. cache_id でヒットしなかった場合のみ display name 解決にフォールバック
+///
+/// # Arguments
+///
+/// * `cache` - Package cache accessor.
+/// * `plugin_input` - User-supplied plugin identifier (cache_id or display name).
+/// * `marketplace_hint` - Optional marketplace hint to disambiguate.
+fn resolve_update_target(
+    cache: &dyn PackageCacheAccess,
+    plugin_input: &str,
+    marketplace_hint: Option<&str>,
+) -> Result<ResolvedPlugin> {
+    // (1)/(2) cache_id 完全一致
+    let cache_id_matches: Vec<(Option<String>, String)> = match marketplace_hint {
+        Some(hint) => {
+            if cache.is_cached(Some(hint), plugin_input) {
+                vec![(Some(hint.to_string()), plugin_input.to_string())]
+            } else {
+                vec![]
+            }
+        }
+        None => cache
+            .list()?
+            .into_iter()
+            .filter(|(_m, cid)| cid == plugin_input)
+            .collect(),
+    };
+
+    if cache_id_matches.len() == 1 {
+        let (market, cache_id) = cache_id_matches.into_iter().next().unwrap();
+        return load_resolved(cache, market, cache_id);
+    } else if cache_id_matches.len() >= 2 {
+        let mut candidates: Vec<String> = cache_id_matches
+            .iter()
+            .map(|(m, cid)| match m {
+                Some(mk) => format!("{}@{}", cid, mk),
+                None => cid.clone(),
+            })
+            .collect();
+        candidates.sort();
+        return Err(PlmError::AmbiguousPluginName {
+            name: plugin_input.to_string(),
+            candidates,
+        });
+    }
+
+    // (3) display name フォールバック
+    match find_by_plugin_name(cache, plugin_input, marketplace_hint)? {
+        Some(r) => Ok(r),
+        None => match marketplace_hint {
+            Some(hint) => Err(PlmError::PluginNotFound(format!(
+                "{}@{}",
+                plugin_input, hint
+            ))),
+            None => Err(PlmError::PluginNotFound(plugin_input.to_string())),
+        },
+    }
+}
+
+fn load_resolved(
+    cache: &dyn PackageCacheAccess,
+    market: Option<String>,
+    cache_id: String,
+) -> Result<ResolvedPlugin> {
+    let pkg = cache.load_package(market.as_deref(), &cache_id)?;
+    let plugin_path = cache.plugin_path(market.as_deref(), &cache_id);
+    let package_meta = meta::load_meta(&plugin_path).unwrap_or_default();
+    Ok(ResolvedPlugin {
+        marketplace: market,
+        cache_id,
+        display_name: pkg.name.clone(),
+        package: pkg,
+        package_meta,
+    })
+}
+
 /// 単一プラグインの更新
 ///
 /// # Arguments
 ///
 /// * `cache` - Package cache accessor for the plugin.
-/// * `plugin_name` - Name of the plugin to update.
+/// * `plugin_input` - Cache ID or display name of the plugin.
+/// * `marketplace_hint` - Optional marketplace hint to disambiguate.
 /// * `project_root` - Project root path used for redeployment.
 /// * `target_filter` - When `Some`, only redeploy to this single target.
 pub async fn update_plugin(
     cache: &dyn PackageCacheAccess,
-    plugin_name: &str,
+    plugin_input: &str,
+    marketplace_hint: Option<&str>,
     project_root: &Path,
     target_filter: Option<&str>,
 ) -> UpdateResult {
-    if !cache.is_cached(Some("github"), plugin_name) {
-        return UpdateResult::failed(plugin_name, "Plugin not found in cache".to_string());
-    }
+    let resolved = match resolve_update_target(cache, plugin_input, marketplace_hint) {
+        Ok(r) => r,
+        Err(PlmError::AmbiguousPluginName { name, candidates }) => {
+            return UpdateResult::failed(
+                &name,
+                format!(
+                    "Ambiguous plugin name (matches: {}). \
+                     Specify with marketplace, e.g. `{}@<marketplace>`.",
+                    candidates.join(", "),
+                    name,
+                ),
+            );
+        }
+        Err(PlmError::PluginNotFound(_)) => {
+            return UpdateResult::failed(plugin_input, "Plugin not found in cache".to_string());
+        }
+        Err(e) => return UpdateResult::failed(plugin_input, e.to_string()),
+    };
 
-    let plugin_path = cache.plugin_path(Some("github"), plugin_name);
-    let plugin_meta = meta::load_meta(&plugin_path).unwrap_or_default();
+    if let Some(market) = resolved.marketplace.clone() {
+        update_marketplace_plugin(cache, &market, &resolved, project_root, target_filter).await
+    } else {
+        update_github_plugin(cache, &resolved, project_root, target_filter).await
+    }
+}
+
+/// 直接 GitHub 経路の安全更新
+async fn update_github_plugin(
+    cache: &dyn PackageCacheAccess,
+    resolved: &ResolvedPlugin,
+    project_root: &Path,
+    target_filter: Option<&str>,
+) -> UpdateResult {
+    let plugin_meta = &resolved.package_meta;
+    let cache_id = resolved.cache_id.as_str();
+    let display_name = resolved.display_name.as_str();
 
     if !plugin_meta.is_github() {
-        return UpdateResult::skipped(plugin_name, "Not a GitHub plugin".to_string());
+        return UpdateResult::skipped(display_name, "Not a GitHub plugin".to_string());
     }
 
-    // 未保存時は HEAD をデフォルト参照として扱う
     let git_ref = plugin_meta.git_ref.as_deref().unwrap_or("HEAD");
     let current_sha = plugin_meta.commit_sha.clone();
 
-    let repo = match restore_repo(&plugin_meta, plugin_name, git_ref) {
+    let repo = match restore_repo(plugin_meta, cache_id, git_ref) {
         Ok(r) => r,
-        Err(e) => return UpdateResult::failed(plugin_name, e),
+        Err(e) => return UpdateResult::failed(display_name, e),
     };
 
     let factory = HostClientFactory::with_defaults();
@@ -200,108 +352,195 @@ pub async fn update_plugin(
     let latest_sha = match with_retry(|| client.get_commit_sha(&repo, git_ref), 3).await {
         Ok(sha) => sha,
         Err(e) => {
-            return UpdateResult::failed(plugin_name, format!("Failed to get latest SHA: {}", e))
+            return UpdateResult::failed(display_name, format!("Failed to get latest SHA: {}", e));
         }
     };
 
     if current_sha.as_deref() == Some(&latest_sha) {
-        return UpdateResult::up_to_date(plugin_name);
+        return UpdateResult::up_to_date(display_name);
     }
 
-    // commit_sha が未保存なら比較できないため強制更新扱いとし、利用者に警告する
     if current_sha.is_none() {
         eprintln!(
             "Warning: No commit SHA recorded for '{}'. Forcing update.",
-            plugin_name
+            display_name
         );
     }
 
-    let ctx = UpdateCtx {
+    do_safe_update(
         cache,
-        client: &*client,
-        repo: &repo,
-        plugin_meta: &plugin_meta,
+        None,
+        cache_id,
+        display_name,
+        plugin_meta,
+        client.as_ref(),
+        &repo,
+        None,
         project_root,
         target_filter,
+    )
+    .await
+}
+
+/// marketplace 経路の安全更新
+async fn update_marketplace_plugin(
+    cache: &dyn PackageCacheAccess,
+    marketplace: &str,
+    resolved: &ResolvedPlugin,
+    project_root: &Path,
+    target_filter: Option<&str>,
+) -> UpdateResult {
+    let display_name = resolved.display_name.as_str();
+    let cache_id = resolved.cache_id.as_str();
+    let plugin_meta = &resolved.package_meta;
+
+    let registry = match MarketplaceRegistry::new() {
+        Ok(r) => r,
+        Err(e) => return UpdateResult::failed(display_name, e.to_string()),
     };
-    do_update(plugin_name, &latest_sha, &ctx).await
+    let mp_cache = match registry.get(marketplace) {
+        Ok(Some(c)) => c,
+        Ok(None) => {
+            return UpdateResult::failed(
+                display_name,
+                format!("Marketplace not found: {}", marketplace),
+            );
+        }
+        Err(e) => return UpdateResult::failed(display_name, e.to_string()),
+    };
+    let entry = match mp_cache.plugins.iter().find(|p| p.name == cache_id) {
+        Some(e) => e.clone(),
+        None => {
+            return UpdateResult::failed(
+                display_name,
+                format!("Plugin entry not found in marketplace: {}", cache_id),
+            );
+        }
+    };
+
+    let git_ref_owned = plugin_meta
+        .git_ref
+        .clone()
+        .unwrap_or_else(|| "HEAD".to_string());
+    let git_ref = git_ref_owned.as_str();
+
+    let repo = match parse_repo_from_mp_source(&mp_cache.source, &entry.source, Some(git_ref)) {
+        Ok(r) => r,
+        Err(e) => return UpdateResult::failed(display_name, e.to_string()),
+    };
+
+    let factory = HostClientFactory::with_defaults();
+    let client = factory.create(HostKind::GitHub);
+
+    let latest_sha = match with_retry(|| client.get_commit_sha(&repo, git_ref), 3).await {
+        Ok(sha) => sha,
+        Err(e) => {
+            return UpdateResult::failed(display_name, format!("Failed to get latest SHA: {}", e));
+        }
+    };
+
+    let current_sha = plugin_meta.commit_sha.clone();
+    if current_sha.as_deref() == Some(&latest_sha) {
+        return UpdateResult::up_to_date(display_name);
+    }
+    if current_sha.is_none() {
+        eprintln!(
+            "Warning: No commit SHA recorded for '{}'. Forcing update.",
+            display_name
+        );
+    }
+
+    let source_path = match &entry.source {
+        MpPluginSource::Local(p) => Some(p.clone()),
+        MpPluginSource::External { .. } => None,
+    };
+
+    do_safe_update(
+        cache,
+        Some(marketplace),
+        cache_id,
+        display_name,
+        plugin_meta,
+        client.as_ref(),
+        &repo,
+        source_path.as_deref(),
+        project_root,
+        target_filter,
+    )
+    .await
 }
 
-/// 更新処理のコンテキスト
-struct UpdateCtx<'a> {
-    cache: &'a dyn PackageCacheAccess,
-    client: &'a dyn crate::host::HostClient,
-    repo: &'a Repo,
-    plugin_meta: &'a PluginMeta,
-    project_root: &'a Path,
-    target_filter: Option<&'a str>,
-}
-
-/// 更新処理の実行
+/// 安全更新フローの共通実装
 ///
-/// # Arguments
-///
-/// * `plugin_name` - Plugin name.
-/// * `latest_sha` - Latest commit SHA reported by the remote.
-/// * `ctx` - Shared update context containing cache, client, and repo info.
-async fn do_update(plugin_name: &str, latest_sha: &str, ctx: &UpdateCtx<'_>) -> UpdateResult {
-    let current_sha = ctx.plugin_meta.commit_sha.clone();
-    let git_ref = ctx.plugin_meta.git_ref.as_deref().unwrap_or("HEAD");
+/// `backup → fetch → atomic_update_with_source_path → redeploy → meta merge → write_meta → remove_backup`
+/// の順で実行し、各失敗ポイントで `cache.restore` による rollback を行う。
+#[allow(clippy::too_many_arguments)]
+async fn do_safe_update(
+    cache: &dyn PackageCacheAccess,
+    marketplace: Option<&str>,
+    cache_id: &str,
+    display_name: &str,
+    old_meta: &PluginMeta,
+    client: &dyn HostClient,
+    repo: &Repo,
+    source_path: Option<&str>,
+    project_root: &Path,
+    target_filter: Option<&str>,
+) -> UpdateResult {
+    let current_sha = old_meta.commit_sha.clone();
+    let git_ref_owned = old_meta
+        .git_ref
+        .clone()
+        .unwrap_or_else(|| "HEAD".to_string());
+    let git_ref = git_ref_owned.as_str();
 
     println!("  Creating backup...");
-    if let Err(e) = ctx.cache.backup(Some("github"), plugin_name) {
-        return UpdateResult::failed(plugin_name, format!("Backup failed: {}", e));
+    if let Err(e) = cache.backup(marketplace, cache_id) {
+        return UpdateResult::failed(display_name, format!("Backup failed: {}", e));
     }
 
     println!("  Downloading...");
-    let archive = match with_retry(|| ctx.client.download_archive(ctx.repo), 3).await {
-        Ok(a) => a,
-        Err(e) => {
-            let _ = ctx.cache.restore(Some("github"), plugin_name);
-            return UpdateResult::failed(plugin_name, format!("Download failed: {}", e));
-        }
-    };
+    let (archive, _archive_git_ref, archive_sha) =
+        match with_retry(|| client.download_archive_with_sha(repo), 3).await {
+            Ok(triple) => triple,
+            Err(e) => {
+                let _ = cache.restore(marketplace, cache_id);
+                return UpdateResult::failed(display_name, format!("Download failed: {}", e));
+            }
+        };
 
     println!("  Extracting...");
-    let plugin_path = match ctx
-        .cache
-        .atomic_update(Some("github"), plugin_name, &archive)
-    {
-        Ok(p) => p,
-        Err(e) => {
-            let _ = ctx.cache.restore(Some("github"), plugin_name);
-            return UpdateResult::failed(plugin_name, format!("Extraction failed: {}", e));
-        }
-    };
+    let plugin_path =
+        match cache.atomic_update_with_source_path(marketplace, cache_id, &archive, source_path) {
+            Ok(p) => p,
+            Err(e) => {
+                let _ = cache.restore(marketplace, cache_id);
+                return UpdateResult::failed(display_name, format!("Extraction failed: {}", e));
+            }
+        };
 
     println!("  Deploying...");
-    let enabled = ctx.plugin_meta.enabled_targets();
-    let targets: Vec<&str> = match ctx.target_filter {
+    let enabled = old_meta.enabled_targets();
+    let targets: Vec<&str> = match target_filter {
         Some(f) => enabled.into_iter().filter(|t| *t == f).collect(),
         None => enabled,
     };
-
     let (deployed, failed) =
-        redeploy_to_targets(ctx.cache, plugin_name, &targets, ctx.project_root);
+        redeploy_to_targets(cache, cache_id, marketplace, &targets, project_root);
 
-    let mut new_meta = ctx.plugin_meta.clone();
-    new_meta.set_git_info(git_ref, latest_sha);
+    let mut new_meta = old_meta.clone();
+    new_meta.set_git_info(git_ref, &archive_sha);
     for t in &failed {
         new_meta.set_status(t, "disabled");
     }
     if let Err(e) = meta::write_meta(&plugin_path, &new_meta) {
-        eprintln!("Warning: Failed to update metadata: {}", e);
+        let _ = cache.restore(marketplace, cache_id);
+        return UpdateResult::failed(display_name, format!("Failed to write metadata: {}", e));
     }
 
-    let _ = ctx.cache.remove_backup(Some("github"), plugin_name);
+    let _ = cache.remove_backup(marketplace, cache_id);
 
-    UpdateResult::updated(
-        plugin_name,
-        current_sha,
-        latest_sha.to_string(),
-        deployed,
-        failed,
-    )
+    UpdateResult::updated(display_name, current_sha, archive_sha, deployed, failed)
 }
 
 /// ターゲットへの再デプロイ
@@ -310,11 +549,13 @@ async fn do_update(plugin_name: &str, latest_sha: &str, ctx: &UpdateCtx<'_>) -> 
 ///
 /// * `cache` - Package cache accessor for the plugin.
 /// * `plugin_name` - Plugin name being redeployed.
+/// * `marketplace` - Marketplace name (`None` falls back to `"github"`).
 /// * `targets` - Target names to redeploy to.
 /// * `project_root` - Project root path used for redeployment.
 fn redeploy_to_targets(
     cache: &dyn PackageCacheAccess,
     plugin_name: &str,
+    marketplace: Option<&str>,
     targets: &[&str],
     project_root: &Path,
 ) -> (Vec<String>, Vec<String>) {
@@ -325,7 +566,7 @@ fn redeploy_to_targets(
         let result = enable_plugin(
             cache,
             plugin_name,
-            Some("github"),
+            marketplace.or(Some("github")),
             project_root,
             Some(target),
         );
@@ -341,10 +582,8 @@ fn redeploy_to_targets(
 
 /// 全プラグインの一括更新
 ///
-/// キャッシュ内の全プラグインを走査し、各プラグインのメタデータから
-/// sourceRepo を取得して更新を実行する。
-/// GitHub以外のプラグインはSkippedとして扱う。
-/// 一部失敗しても後続の処理を継続する。
+/// キャッシュ内の全プラグイン（直接 GitHub / marketplace 経由）を走査し、
+/// 各プラグインの commit SHA を比較して差分があるものを更新する。
 ///
 /// # Arguments
 ///
@@ -369,50 +608,170 @@ pub async fn update_all_plugins(
         return vec![];
     }
 
-    let mut plugin_metas: Vec<(String, PluginMeta)> = Vec::new();
-    for (marketplace, name) in &plugins {
-        // GitHub プラグイン以外（明示的に別マーケットプレイスが設定されたもの）はスキップする
-        if marketplace.is_some() && marketplace.as_deref() != Some("github") {
-            continue;
-        }
-        let plugin_path = cache.plugin_path(marketplace.as_deref(), name);
-        let meta = meta::load_meta(&plugin_path).unwrap_or_default();
-        plugin_metas.push((name.clone(), meta));
-    }
-
     println!("Checking for updates...");
     let factory = HostClientFactory::with_defaults();
     let client = factory.create(HostKind::GitHub);
-    let remote_versions = fetch_remote_versions(&plugin_metas, client.as_ref()).await;
 
-    let mut updates_to_do: Vec<(&str, String, &PluginMeta)> = Vec::new();
-    let mut error_count = 0;
+    // marketplace 別に MarketplaceCache を 1 度だけロード
+    let registry = match MarketplaceRegistry::new() {
+        Ok(r) => Some(r),
+        Err(e) => {
+            eprintln!("Warning: Failed to load marketplace registry: {}", e);
+            None
+        }
+    };
 
-    for ((name, meta), (_plugin_name, result)) in plugin_metas.iter().zip(remote_versions.iter()) {
-        match result {
-            VersionQueryResult::Failed { message } => {
-                error_count += 1;
-                eprintln!("  {}: Failed to check ({})", name, message);
+    let mut mp_caches: std::collections::HashMap<String, MarketplaceCache> =
+        std::collections::HashMap::new();
+    if let Some(reg) = &registry {
+        let unique_markets: std::collections::HashSet<String> = plugins
+            .iter()
+            .filter_map(|(m, _)| m.clone())
+            .filter(|m| m != "github")
+            .collect();
+        for m in unique_markets {
+            if let Ok(Some(c)) = reg.get(&m) {
+                mp_caches.insert(m, c);
             }
-            VersionQueryResult::Found(remote) => {
-                if needs_update(meta.commit_sha.as_deref(), &remote.sha) {
-                    let current_short = meta
-                        .commit_sha
-                        .as_ref()
-                        .map(|s| &s[..7.min(s.len())])
-                        .unwrap_or("unknown");
-                    let latest_short = &remote.sha[..7.min(remote.sha.len())];
-                    println!("  {}: {} -> {}", name, current_short, latest_short);
-                    updates_to_do.push((name, remote.sha.clone(), meta));
-                } else {
-                    println!("  {}: Already up to date", name);
+        }
+    }
+
+    let mut results = Vec::new();
+    let mut up_to_date_count = 0usize;
+    let mut error_count = 0usize;
+    let mut updates_to_do: Vec<(Option<String>, String, String, ResolvedPlugin)> = Vec::new();
+
+    for (marketplace, cache_id) in &plugins {
+        let plugin_path = cache.plugin_path(marketplace.as_deref(), cache_id);
+        let pkg = match cache.load_package(marketplace.as_deref(), cache_id) {
+            Ok(p) => p,
+            Err(e) => {
+                error_count += 1;
+                eprintln!("  {}: Failed to load ({})", cache_id, e);
+                continue;
+            }
+        };
+        let display_name = pkg.name.clone();
+        let plugin_meta = meta::load_meta(&plugin_path).unwrap_or_default();
+
+        // marketplace 経由 plugin
+        if let Some(market) = marketplace.as_deref() {
+            if market == "github" {
+                // 直接 GitHub install
+                let result =
+                    check_github_remote(&*client, &plugin_meta, cache_id, &display_name).await;
+                match result {
+                    RemoteCheck::UpToDate => {
+                        up_to_date_count += 1;
+                        results.push(UpdateResult::up_to_date(&display_name));
+                    }
+                    RemoteCheck::NeedsUpdate(latest) => {
+                        let resolved = ResolvedPlugin {
+                            marketplace: marketplace.clone(),
+                            cache_id: cache_id.clone(),
+                            display_name: display_name.clone(),
+                            package: pkg,
+                            package_meta: plugin_meta,
+                        };
+                        updates_to_do.push((
+                            marketplace.clone(),
+                            cache_id.clone(),
+                            latest,
+                            resolved,
+                        ));
+                    }
+                    RemoteCheck::Failed(msg) => {
+                        error_count += 1;
+                        eprintln!("  {}: Failed to check ({})", display_name, msg);
+                    }
+                    RemoteCheck::Skipped(_reason) => {
+                        // GitHub 以外はあり得ないが念のため
+                    }
                 }
+                continue;
+            }
+
+            let mp_cache = match mp_caches.get(market) {
+                Some(c) => c,
+                None => {
+                    error_count += 1;
+                    eprintln!("  {}: Marketplace not found: {}", display_name, market);
+                    continue;
+                }
+            };
+            let entry = match mp_cache.plugins.iter().find(|p| p.name == *cache_id) {
+                Some(e) => e,
+                None => {
+                    // marketplace から消えたものは up_to_date 扱い
+                    up_to_date_count += 1;
+                    results.push(UpdateResult::up_to_date(&display_name));
+                    continue;
+                }
+            };
+            let git_ref = plugin_meta.git_ref.as_deref().unwrap_or("HEAD");
+            let repo =
+                match parse_repo_from_mp_source(&mp_cache.source, &entry.source, Some(git_ref)) {
+                    Ok(r) => r,
+                    Err(e) => {
+                        error_count += 1;
+                        eprintln!("  {}: {}", display_name, e);
+                        continue;
+                    }
+                };
+            let latest_sha = match with_retry(|| client.get_commit_sha(&repo, git_ref), 3).await {
+                Ok(s) => s,
+                Err(e) => {
+                    error_count += 1;
+                    eprintln!("  {}: Failed to check ({})", display_name, e);
+                    continue;
+                }
+            };
+
+            if !needs_update(plugin_meta.commit_sha.as_deref(), &latest_sha) {
+                up_to_date_count += 1;
+                results.push(UpdateResult::up_to_date(&display_name));
+                continue;
+            }
+
+            let resolved = ResolvedPlugin {
+                marketplace: marketplace.clone(),
+                cache_id: cache_id.clone(),
+                display_name: display_name.clone(),
+                package: pkg,
+                package_meta: plugin_meta,
+            };
+            updates_to_do.push((marketplace.clone(), cache_id.clone(), latest_sha, resolved));
+            continue;
+        }
+
+        // marketplace == None 経路
+        let result = check_github_remote(&*client, &plugin_meta, cache_id, &display_name).await;
+        match result {
+            RemoteCheck::UpToDate => {
+                up_to_date_count += 1;
+                results.push(UpdateResult::up_to_date(&display_name));
+            }
+            RemoteCheck::NeedsUpdate(latest) => {
+                let resolved = ResolvedPlugin {
+                    marketplace: None,
+                    cache_id: cache_id.clone(),
+                    display_name: display_name.clone(),
+                    package: pkg,
+                    package_meta: plugin_meta,
+                };
+                updates_to_do.push((None, cache_id.clone(), latest, resolved));
+            }
+            RemoteCheck::Skipped(reason) => {
+                results.push(UpdateResult::skipped(&display_name, reason));
+            }
+            RemoteCheck::Failed(msg) => {
+                error_count += 1;
+                eprintln!("  {}: Failed to check ({})", display_name, msg);
             }
         }
     }
 
     let update_count = updates_to_do.len();
-    let up_to_date_count = plugin_metas.len() - update_count - error_count;
 
     if update_count == 0 {
         println!(
@@ -424,10 +783,7 @@ pub async fn update_all_plugins(
                 String::new()
             }
         );
-        return plugin_metas
-            .iter()
-            .map(|(name, _)| UpdateResult::up_to_date(name))
-            .collect();
+        return results;
     }
 
     println!(
@@ -441,34 +797,20 @@ pub async fn update_all_plugins(
         }
     );
 
-    let mut results = Vec::new();
-    let mut update_idx = 0;
+    for (idx, (marketplace, _cache_id, _latest, resolved)) in updates_to_do.into_iter().enumerate()
+    {
+        println!(
+            "\n[{}/{}] Updating {}...",
+            idx + 1,
+            update_count,
+            resolved.display_name
+        );
 
-    for (name, latest_sha, meta) in &updates_to_do {
-        update_idx += 1;
-        println!("\n[{}/{}] Updating {}...", update_idx, update_count, name);
-
-        let git_ref = meta.git_ref.as_deref().unwrap_or("HEAD");
-        let repo = match restore_repo(meta, name, git_ref) {
-            Ok(r) => r,
-            Err(e) => {
-                results.push(UpdateResult::failed(name, e));
-                continue;
-            }
+        let result = if let Some(market) = marketplace.as_deref() {
+            update_marketplace_plugin(cache, market, &resolved, project_root, target_filter).await
+        } else {
+            update_github_plugin(cache, &resolved, project_root, target_filter).await
         };
-
-        let update_factory = HostClientFactory::with_defaults();
-        let update_client = update_factory.create(HostKind::GitHub);
-
-        let update_ctx = UpdateCtx {
-            cache,
-            client: &*update_client,
-            repo: &repo,
-            plugin_meta: meta,
-            project_root,
-            target_filter,
-        };
-        let result = do_update(name, latest_sha, &update_ctx).await;
 
         match &result.status {
             UpdateStatus::Updated { from_sha, to_sha } => {
@@ -482,18 +824,42 @@ pub async fn update_all_plugins(
             }
             _ => {}
         }
-
         results.push(result);
     }
 
-    // 更新対象外のプラグインも up_to_date として結果に含める（呼び出し側が全件を集計するため）
-    for (name, _) in &plugin_metas {
-        if !updates_to_do.iter().any(|(n, _, _)| n == name) {
-            results.push(UpdateResult::up_to_date(name));
-        }
-    }
-
     results
+}
+
+enum RemoteCheck {
+    UpToDate,
+    NeedsUpdate(String),
+    Skipped(String),
+    Failed(String),
+}
+
+async fn check_github_remote(
+    client: &dyn HostClient,
+    plugin_meta: &PluginMeta,
+    cache_id: &str,
+    display_name: &str,
+) -> RemoteCheck {
+    if !plugin_meta.is_github() {
+        return RemoteCheck::Skipped("Not a GitHub plugin".to_string());
+    }
+    let git_ref = plugin_meta.git_ref.as_deref().unwrap_or("HEAD");
+    let repo = match restore_repo(plugin_meta, cache_id, git_ref) {
+        Ok(r) => r,
+        Err(e) => return RemoteCheck::Failed(e),
+    };
+    let latest_sha = match with_retry(|| client.get_commit_sha(&repo, git_ref), 3).await {
+        Ok(s) => s,
+        Err(e) => return RemoteCheck::Failed(e.to_string()),
+    };
+    if !needs_update(plugin_meta.commit_sha.as_deref(), &latest_sha) {
+        let _ = display_name;
+        return RemoteCheck::UpToDate;
+    }
+    RemoteCheck::NeedsUpdate(latest_sha)
 }
 
 #[cfg(test)]

--- a/src/source/github_source.rs
+++ b/src/source/github_source.rs
@@ -19,6 +19,11 @@ pub struct GitHubSource {
     /// プラグインのソースパス（正規化済み）
     /// マーケットプレイス内の Local プラグイン用
     source_path: Option<String>,
+    /// marketplace 内でユニークなプラグイン識別子
+    ///
+    /// marketplace 経由 install のときに `MarketplacePlugin.name` (validated) を入れる。
+    /// `None` の場合は `repo.name()` にフォールバックする（直接 GitHub install 経路）。
+    plugin_identifier: Option<String>,
 }
 
 impl GitHubSource {
@@ -32,6 +37,7 @@ impl GitHubSource {
             repo,
             marketplace: None,
             source_path: None,
+            plugin_identifier: None,
         }
     }
 
@@ -46,6 +52,7 @@ impl GitHubSource {
             repo,
             marketplace: Some(marketplace),
             source_path: None,
+            plugin_identifier: None,
         }
     }
 
@@ -66,6 +73,47 @@ impl GitHubSource {
             repo,
             marketplace: Some(marketplace),
             source_path: Some(source_path),
+            plugin_identifier: None,
+        }
+    }
+
+    /// marketplace 経由インストール用フルコンストラクタ。
+    ///
+    /// - `marketplace`: marketplace 名（必須）
+    /// - `source_path`: External プラグインで `None`、Local プラグインで `Some` を渡す
+    /// - `plugin_identifier`: validated 済みのプラグイン識別子（cache key として使用）
+    ///
+    /// # Arguments
+    ///
+    /// * `repo` - Repository descriptor for the underlying Git source.
+    /// * `marketplace` - Name of the marketplace that surfaced this plugin.
+    /// * `source_path` - Optional normalized sub-path for Local plugins, `None` for External.
+    /// * `plugin_identifier` - Validated unique plugin name within the marketplace.
+    pub fn with_marketplace_plugin(
+        repo: Repo,
+        marketplace: String,
+        source_path: Option<String>,
+        plugin_identifier: String,
+    ) -> Self {
+        Self {
+            repo,
+            marketplace: Some(marketplace),
+            source_path,
+            plugin_identifier: Some(plugin_identifier),
+        }
+    }
+
+    /// このソースの cache key を算出する
+    ///
+    /// - marketplace 経由: `plugin_identifier` を優先。`None` のときは `repo.name()` フォールバック
+    /// - 直接 GitHub: `"{owner}--{repo}"`
+    fn compute_cache_name(&self) -> String {
+        if self.marketplace.is_none() {
+            format!("{}--{}", self.repo.owner(), self.repo.name())
+        } else {
+            self.plugin_identifier
+                .clone()
+                .unwrap_or_else(|| self.repo.name().to_string())
         }
     }
 }
@@ -79,20 +127,16 @@ impl PackageSource for GitHubSource {
         Box::pin(async move {
             let factory = HostClientFactory::with_defaults();
             let client = factory.create(self.repo.host());
-            let plugin_name = self.repo.name();
+            let display_name = self.repo.name();
             let marketplace = self.marketplace.as_deref();
 
-            // 直接GitHubインストールの場合は owner--repo 形式にする
-            let cache_name = if self.marketplace.is_none() {
-                format!("{}--{}", self.repo.owner(), self.repo.name())
-            } else {
-                plugin_name.to_string()
-            };
+            let cache_name = self.compute_cache_name();
+            let log_label = self.plugin_identifier.as_deref().unwrap_or(display_name);
 
             if !force && cache.is_cached(marketplace, &cache_name) {
                 println!(
                     "Using cached plugin: {} (cache key: {})",
-                    plugin_name, cache_name
+                    log_label, cache_name
                 );
                 return cache.load_package(marketplace, &cache_name);
             }

--- a/src/source/marketplace_source.rs
+++ b/src/source/marketplace_source.rs
@@ -5,7 +5,7 @@ use crate::marketplace::{
     validate_plugin_names, MarketplaceManifest, MarketplaceRegistry,
     PluginSource as MpPluginSource, PluginSourcePath,
 };
-use crate::plugin::{CachedPackage, LegacyLayoutSweeper, PackageCacheAccess};
+use crate::plugin::{CachedPackage, LegacyCacheCleaner, PackageCacheAccess};
 use crate::repo;
 use std::future::Future;
 use std::pin::Pin;
@@ -50,7 +50,7 @@ impl PackageSource for MarketplaceSource {
             validate_plugin_names(&mp_cache.plugins)?;
 
             // 旧レイアウト残骸の自動掃除（ピンポイント。空 plugins / rename / 別形式は no-op）
-            LegacyLayoutSweeper::sweep_if_legacy(cache, &self.marketplace, &mp_cache)?;
+            LegacyCacheCleaner::clean_if_legacy(cache, &self.marketplace, &mp_cache)?;
 
             let plugin_entry = mp_cache
                 .plugins

--- a/src/source/marketplace_source.rs
+++ b/src/source/marketplace_source.rs
@@ -2,9 +2,10 @@
 
 use crate::error::{PlmError, Result};
 use crate::marketplace::{
-    MarketplaceManifest, MarketplaceRegistry, PluginSource as MpPluginSource, PluginSourcePath,
+    validate_plugin_names, MarketplaceManifest, MarketplaceRegistry,
+    PluginSource as MpPluginSource, PluginSourcePath,
 };
-use crate::plugin::{CachedPackage, PackageCacheAccess};
+use crate::plugin::{CachedPackage, LegacyLayoutSweeper, PackageCacheAccess};
 use crate::repo;
 use std::future::Future;
 use std::pin::Pin;
@@ -45,6 +46,12 @@ impl PackageSource for MarketplaceSource {
                 .get(&self.marketplace)?
                 .ok_or_else(|| PlmError::MarketplaceNotFound(self.marketplace.clone()))?;
 
+            // 取得した manifest の plugin name 群を再検証（保険）
+            validate_plugin_names(&mp_cache.plugins)?;
+
+            // 旧レイアウト残骸の自動掃除（ピンポイント。空 plugins / rename / 別形式は no-op）
+            LegacyLayoutSweeper::sweep_if_legacy(cache, &self.marketplace, &mp_cache)?;
+
             let plugin_entry = mp_cache
                 .plugins
                 .iter()
@@ -56,6 +63,9 @@ impl PackageSource for MarketplaceSource {
                 owner: mp_cache.owner.clone(),
                 plugins: mp_cache.plugins.clone(),
             });
+
+            // plugin_identifier は MarketplacePlugin.name (registry 側で validated 済み)
+            let plugin_identifier = plugin_entry.name.clone();
 
             let mut cached = match &plugin_entry.source {
                 MpPluginSource::Local(path) => {
@@ -76,19 +86,25 @@ impl PackageSource for MarketplaceSource {
 
                     let source_path: PluginSourcePath = path.parse()?;
 
-                    GitHubSource::with_marketplace_and_source_path(
+                    GitHubSource::with_marketplace_plugin(
                         repo,
                         self.marketplace.clone(),
-                        source_path.into(),
+                        Some(source_path.into()),
+                        plugin_identifier.clone(),
                     )
                     .download(cache, force)
                     .await?
                 }
                 MpPluginSource::External { repo: repo_url, .. } => {
                     let repo = repo::from_url(repo_url)?;
-                    GitHubSource::with_marketplace(repo, self.marketplace.clone())
-                        .download(cache, force)
-                        .await?
+                    GitHubSource::with_marketplace_plugin(
+                        repo,
+                        self.marketplace.clone(),
+                        None,
+                        plugin_identifier.clone(),
+                    )
+                    .download(cache, force)
+                    .await?
                 }
             };
 

--- a/src/tui/manager/core.rs
+++ b/src/tui/manager/core.rs
@@ -31,5 +31,5 @@ pub use common::{
 };
 #[allow(unused_imports)]
 pub use common::{BLOCK_BORDER_WIDTH, LIST_HIGHLIGHT_WIDTH};
-pub use data::{DataStore, MarketplaceItem, PluginId};
+pub use data::{DataStore, MarketplaceItem, PluginId, PluginKey};
 pub use filter::filter_plugins;

--- a/src/tui/manager/core/data.rs
+++ b/src/tui/manager/core/data.rs
@@ -10,7 +10,42 @@ use crate::plugin::PackageCache;
 use std::io;
 
 /// プラグインID（`InstalledPlugin::id()` の値で識別。リポジトリ名と異なる場合あり）
+///
+/// 注: 同名 plugin が複数 marketplace に同居するケースを区別できない。
+/// 内部識別が必要な場合は `PluginKey` を使う。
 pub type PluginId = String;
+
+/// プラグインの内部識別キー
+///
+/// 同名 plugin が複数 marketplace に同居するケースを区別するために使用する。
+/// `marketplace == None` は直接 GitHub install。
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct PluginKey {
+    pub marketplace: Option<String>,
+    pub cache_id: String,
+}
+
+impl PluginKey {
+    /// `InstalledPlugin` から `PluginKey` を構築する
+    ///
+    /// # Arguments
+    ///
+    /// * `plugin` - The installed plugin to build a key from.
+    pub fn from_installed(plugin: &InstalledPlugin) -> Self {
+        Self {
+            marketplace: plugin.marketplace().map(|s| s.to_string()),
+            cache_id: plugin.id().to_string(),
+        }
+    }
+
+    /// ユーザー表示用ラベル（曖昧時の候補表示などに使用）
+    pub fn display_label(&self) -> String {
+        match &self.marketplace {
+            Some(m) => format!("{}@{}", self.cache_id, m),
+            None => self.cache_id.clone(),
+        }
+    }
+}
 
 /// マーケットプレイスアイテム（TUI表示用）
 #[derive(Debug, Clone)]

--- a/src/tui/manager/screens/installed/actions.rs
+++ b/src/tui/manager/screens/installed/actions.rs
@@ -6,6 +6,7 @@
 use super::model::UpdateStatusDisplay;
 use crate::application;
 use crate::plugin::{update_plugin, PackageCache, UpdateStatus};
+use crate::tui::manager::core::PluginKey;
 use crate::tui::output_suppress::OutputSuppressGuard;
 use std::env;
 use std::path::Path;
@@ -86,8 +87,8 @@ pub fn enable_plugin(plugin_name: &str, marketplace: Option<&str>) -> ActionResu
 ///
 /// # Arguments
 ///
-/// * `plugin_names` - Plugin ids to update in order.
-pub fn batch_update_plugins(plugin_names: &[String]) -> Vec<(String, UpdateStatusDisplay)> {
+/// * `keys` - Plugin keys to update in order.
+pub fn batch_update_plugins(keys: &[PluginKey]) -> Vec<(PluginKey, UpdateStatusDisplay)> {
     let project_root = env::current_dir().unwrap_or_else(|_| ".".into());
 
     // stdout/stderr をリダイレクト
@@ -95,11 +96,10 @@ pub fn batch_update_plugins(plugin_names: &[String]) -> Vec<(String, UpdateStatu
     // TUI 代替スクリーン上では eprintln! が表示されないため、ログ出力は行わない。
     let _guard = OutputSuppressGuard::new();
 
-    plugin_names
-        .iter()
-        .map(|name| {
-            let status = run_update_plugin(name, &project_root);
-            (name.clone(), status)
+    keys.iter()
+        .map(|key| {
+            let status = run_update_plugin(key, &project_root);
+            (key.clone(), status)
         })
         .collect()
 }
@@ -108,9 +108,9 @@ pub fn batch_update_plugins(plugin_names: &[String]) -> Vec<(String, UpdateStatu
 ///
 /// # Arguments
 ///
-/// * `plugin_name` - Target plugin id.
+/// * `key` - Target plugin key (`marketplace` + `cache_id`).
 /// * `project_root` - Project root directory used for deployment paths.
-fn run_update_plugin(plugin_name: &str, project_root: &Path) -> UpdateStatusDisplay {
+fn run_update_plugin(key: &PluginKey, project_root: &Path) -> UpdateStatusDisplay {
     let handle = match tokio::runtime::Handle::try_current() {
         Ok(h) => h,
         Err(_) => {
@@ -124,7 +124,13 @@ fn run_update_plugin(plugin_name: &str, project_root: &Path) -> UpdateStatusDisp
     };
 
     let result = tokio::task::block_in_place(|| {
-        handle.block_on(update_plugin(&cache, plugin_name, project_root, None))
+        handle.block_on(update_plugin(
+            &cache,
+            &key.cache_id,
+            key.marketplace.as_deref(),
+            project_root,
+            None,
+        ))
     });
 
     match result.status {

--- a/src/tui/manager/screens/installed/update.rs
+++ b/src/tui/manager/screens/installed/update.rs
@@ -4,7 +4,7 @@
 
 use super::actions;
 use super::model::{DetailAction, Model, Msg, UpdateStatusDisplay};
-use crate::tui::manager::core::{filter_plugins, DataStore};
+use crate::tui::manager::core::{filter_plugins, DataStore, PluginKey};
 use ratatui::widgets::ListState;
 use std::collections::{HashMap, HashSet};
 
@@ -195,7 +195,7 @@ fn execute_batch_with(
     model: &mut Model,
     data: &mut DataStore,
     filter_text: &str,
-    run_updates: impl FnOnce(&[String]) -> Vec<(String, UpdateStatusDisplay)>,
+    run_updates: impl FnOnce(&[PluginKey]) -> Vec<(PluginKey, UpdateStatusDisplay)>,
     reload: impl FnOnce(&mut DataStore) -> std::io::Result<()>,
 ) {
     if let Model::PluginList {
@@ -208,18 +208,24 @@ fn execute_batch_with(
         // update_statuses から Updating のプラグイン ID を収集
         // O(n) の HashSet で存在チェックし、find_plugin の線形探索 O(n^2) を回避
         let existing_ids: HashSet<&str> = data.plugins.iter().map(|p| p.id()).collect();
-        let plugin_ids: Vec<String> = update_statuses
+        let plugin_keys: Vec<PluginKey> = update_statuses
             .iter()
             .filter(|(_, status)| matches!(status, UpdateStatusDisplay::Updating))
-            .map(|(id, _)| id.clone())
-            .filter(|id| existing_ids.contains(id.as_str()))
+            .filter(|(id, _)| existing_ids.contains(id.as_str()))
+            .filter_map(|(id, _)| {
+                data.plugins
+                    .iter()
+                    .find(|p| p.id() == id.as_str())
+                    .map(PluginKey::from_installed)
+            })
             .collect();
 
-        let results = run_updates(&plugin_ids);
+        let results = run_updates(&plugin_keys);
 
         let mut new_statuses = HashMap::new();
         let mut batch_errors: Vec<String> = Vec::new();
-        for (name, status) in results {
+        for (key, status) in results {
+            let name = key.cache_id;
             if let UpdateStatusDisplay::Failed(ref reason) = status {
                 batch_errors.push(format!("Update failed for {}: {}", name, reason));
             }

--- a/src/tui/manager/screens/installed/update_test.rs
+++ b/src/tui/manager/screens/installed/update_test.rs
@@ -1,13 +1,12 @@
 use super::{execute_batch_with, update};
 use crate::application::InstalledPlugin;
-use crate::tui::manager::core::DataStore;
+use crate::tui::manager::core::{DataStore, PluginKey};
 use crate::tui::manager::screens::installed::model::{Model, Msg, UpdateStatusDisplay};
 
 /// スタブ: 全プラグインを Updated として返す
-fn stub_run_updates(names: &[String]) -> Vec<(String, UpdateStatusDisplay)> {
-    names
-        .iter()
-        .map(|name| (name.clone(), UpdateStatusDisplay::Updated))
+fn stub_run_updates(keys: &[PluginKey]) -> Vec<(PluginKey, UpdateStatusDisplay)> {
+    keys.iter()
+        .map(|k| (k.clone(), UpdateStatusDisplay::Updated))
         .collect()
 }
 
@@ -711,12 +710,11 @@ fn execute_batch_sets_error_on_failed_updates() {
     }
 
     // スタブ: 全プラグインを Failed として返す
-    let fail_updates = |names: &[String]| -> Vec<(String, UpdateStatusDisplay)> {
-        names
-            .iter()
-            .map(|name| {
+    let fail_updates = |keys: &[PluginKey]| -> Vec<(PluginKey, UpdateStatusDisplay)> {
+        keys.iter()
+            .map(|k| {
                 (
-                    name.clone(),
+                    k.clone(),
                     UpdateStatusDisplay::Failed("test error".to_string()),
                 )
             })


### PR DESCRIPTION
## 概要

同一 marketplace に複数 plugin を登録したとき、`GitHubSource` の `cache_name` に `repo.name()` が使われて全 plugin が同じディレクトリに展開され、後勝ちで上書きされていたバグを修正。`MarketplacePlugin.name` を `plugin_identifier` として下層に伝搬させ、cache key を plugin 単位にすることで根本解決した。あわせて update 経路を marketplace 対応の安全更新に拡張し、TUI の一括更新で `marketplace_hint` を `update_plugin` に確実に渡せるようにした。

## 変更の種類

- 🐛 Bug Fix（cache_name 衝突）
- ✨ New Feature（marketplace 経由 update / `LegacyLayoutSweeper` / `plugin_resolver`）
- ♻️ Refactoring（`update_plugin` の解決ロジック整理）

## 追加した内容

- `GitHubSource::with_marketplace_plugin(repo, marketplace, source_path, plugin_identifier)` — marketplace 経由 install 用フルコンストラクタ
- `marketplace::registry::{validate_plugin_name, validate_plugin_names}` — パストラバーサル / 重複検出
- `PlmError` に `InvalidPluginName` / `DuplicatePluginName` / `AmbiguousPluginName` variant を追加
- `PackageCacheAccess` に `atomic_update_with_source_path` / `has_marketplace_entry` / `remove_marketplace_entry` / `list_marketplace_entries` を追加
- `LegacyLayoutSweeper`（新規モジュール）— 旧 `<repo.name()>` dir のみピンポイント削除
- `plugin::lifecycle::plugin_resolver::find_by_plugin_name`（新規）— display name 解決＋ marketplace hint
- `update_plugin` 内部の `resolve_update_target` / `update_marketplace_plugin` / `update_github_plugin` / `do_safe_update` / `parse_repo_from_mp_source` helpers
- `tui::manager::core::PluginKey { marketplace, cache_id }`

## 変更した内容

- `GitHubSource::download` の cache_name 算出が `plugin_identifier` 優先になり、marketplace 経由でも plugin 単位で別ディレクトリに展開される
- `MarketplaceSource::download` 冒頭で `validate_plugin_names` と `LegacyLayoutSweeper::sweep_if_legacy` を呼び、Local / External 両分岐とも `with_marketplace_plugin` を使う
- `MarketplaceRegistry::store/get` 経路で `validate_plugin_names` を呼ぶ（不正 manifest を弾く）
- `update_plugin(cache, plugin_input, marketplace_hint, project_root, target_filter)` — `marketplace_hint` を末尾追加（既存呼び出しは `None` で互換）
- `update_all_plugins` の `Some("github")` skip を除去し、marketplace 経由 plugin の SHA 比較を統合
- `commands::lifecycle::update`：`<plugin>@<marketplace>` を split して `marketplace_hint` を渡す（案 A）
- TUI `batch_update_plugins(&[PluginKey])` が `key.marketplace.as_deref()` を `update_plugin` に伝搬

## システム図

\`\`\`mermaid
flowchart TD
    A[plm install plugin-a@d-market] --> B[MarketplaceSource::download]
    B --> V[validate_plugin_names]
    V --> S[LegacyLayoutSweeper::sweep_if_legacy<br/>旧 dir 限定削除]
    S --> G[GitHubSource::with_marketplace_plugin<br/>plugin_identifier=plugin-a]
    G --> C{cache_name 算出}
    C -- marketplace あり --> P[plugin_identifier<br/>=plugin-a]
    C -- marketplace なし --> R[owner--repo]
    P --> O[~/.plm/cache/plugins/d-market/plugin-a/]
    R --> Q[~/.plm/cache/plugins/github/owner--repo/]

    U[plm update plugin-a@d-market] --> RT[resolve_update_target<br/>cache_id 完全一致 → display name fallback]
    RT --> UM[update_marketplace_plugin]
    UM --> BK[backup]
    BK --> DL[download_archive_with_sha<br/>同じ Repo+git_ref]
    DL --> AT[atomic_update_with_source_path]
    AT --> RD[redeploy_to_targets]
    RD --> WM[write_meta + set_git_info]
    WM --> RB[remove_backup]
    DL -- err --> RS[cache.restore]
    AT -- err --> RS
    WM -- err --> RS

    style P fill:#ddffdd
    style S fill:#ddffdd
    style RT fill:#ddffdd
    style UM fill:#ddffdd
\`\`\`

## 関連 Spec / Issue

- Spec: \`.plugin-workspace/.specs/018-marketplace-multi-plugin-fix\`

## 検証

- \`cargo fmt\`（Bash サブエージェント経由）: 差分なし
- \`cargo check --tests\`（rust-workflow-plugin:type-check）: エラー 0
- \`cargo test --bins\`（rust-workflow-plugin:test）: **1583 件 全 pass / 0 fail**
- 追加テスト:
  - `legacy_layout_sweeper_test.rs`: sweep 条件（plugins.len > 1 / plugin name 不一致 / dir 存在）/ 境界 (空 plugins / rename 中 / repo.name == plugin name) / `remove_marketplace_entry` のピンポイント削除
  - `plugin_resolver_test.rs`: 0 件 / 1 件 / 複数件 (AmbiguousPluginName) / 壊れたエントリスキップ / hint 一致絞り込み / hint 不一致時 None

## レビューポイント

- **公開 API 影響**: `update_plugin` のシグネチャに `marketplace_hint: Option<&str>` を末尾追加。既存呼び出しは `None` を渡せば従来通り（cache_id 完全一致経路）動く後方互換
- **rollback 経路**: `do_safe_update` の各失敗ポイント（fetch / swap / write_meta）で `cache.restore` を呼ぶ。現行 `do_update` は write_meta 失敗時に警告のみだったが、本 PR で rollback に格上げ
- **git_ref 一貫性**: `parse_repo_from_mp_source` で `git_ref` を必ず `Repo` に詰め、同じ `Repo` インスタンスを `get_commit_sha` と `download_archive_with_sha` の両方に渡す（`MarketplaceCache.source` は ref を持たないため）。`External` の `repo` 文字列は `repo::from_url` で解析するので `owner/repo@tag` や HTTPS URL も解釈される（Codex レビュー指摘 1 反映）
- **LegacyLayoutSweeper の安全側倒し**: `extract_repo_name` で空 / `.` / `..` / `/` / `\` を弾く（Codex レビュー指摘 3 反映）。検出条件は `plugins.len() > 1` AND `<repo.name()>` が plugin name のどれにも一致しない場合のみ

## 既知の制限（フォローアップ候補）

- TUI `Model::PluginList` の内部状態（`selected_id` / `marked_ids` / `update_statuses`）と `DataStore::find_plugin` 等は引き続き `PluginId = String` ベース。`batch_update_plugins` 出口で `marketplace_hint` を渡す経路は確保済みだが、同 cache_id を別 marketplace で同居させた場合の選択ハイライト/マーク表示で曖昧さが残る。次フェーズで `PluginKey` 全面移行を推奨

🤖 Generated with [Claude Code](https://claude.com/claude-code)