### PR TITLE
♻️ [Refactoring]: aggregate Endpoint dispatch through binding() accessor

### DIFF
--- a/src/sync/endpoint.rs
+++ b/src/sync/endpoint.rs
@@ -51,10 +51,10 @@ impl Endpoint {
 
     /// variant に内包された `TargetBinding` への参照を返す集約点。
     ///
-    /// `TargetBinding` 自体が `pub(super)` で `endpoint` モジュール配下にのみ可視
-    /// なため、accessor も同等以下の可視性に揃える（private = `endpoint.rs` モジ
-    /// ュール配下のみ）。子モジュールである `mod tests;` からは可視なのでテスト
-    /// から呼び出せる。
+    /// `TargetBinding` は `pub(super)` で `endpoint` モジュール配下にのみ可視。
+    /// accessor も同等以下の可視性（private = `endpoint.rs` モジュール配下のみ）
+    /// に揃える。子モジュールである `mod tests;` からは可視のため、テストから
+    /// 呼び出せる。
     fn binding(&self) -> &TargetBinding {
         match self {
             Self::Source(s) => s.binding(),

--- a/src/sync/endpoint.rs
+++ b/src/sync/endpoint.rs
@@ -50,7 +50,12 @@ impl Endpoint {
     }
 
     /// variant に内包された `TargetBinding` への参照を返す集約点。
-    pub(super) fn binding(&self) -> &TargetBinding {
+    ///
+    /// `TargetBinding` 自体が `pub(super)` で `endpoint` モジュール配下にのみ可視
+    /// なため、accessor も同等以下の可視性に揃える（private = `endpoint.rs` モジ
+    /// ュール配下のみ）。子モジュールである `mod tests;` からは可視なのでテスト
+    /// から呼び出せる。
+    fn binding(&self) -> &TargetBinding {
         match self {
             Self::Source(s) => s.binding(),
             Self::Destination(d) => d.binding(),

--- a/src/sync/endpoint.rs
+++ b/src/sync/endpoint.rs
@@ -49,6 +49,14 @@ impl Endpoint {
         }
     }
 
+    /// variant に内包された `TargetBinding` への参照を返す集約点。
+    pub(crate) fn binding(&self) -> &TargetBinding {
+        match self {
+            Self::Source(s) => s.binding(),
+            Self::Destination(d) => d.binding(),
+        }
+    }
+
     /// ターゲット名（共通メソッド・variant 別ディスパッチ）
     pub(crate) fn name(&self) -> &'static str {
         match self {

--- a/src/sync/endpoint.rs
+++ b/src/sync/endpoint.rs
@@ -57,36 +57,24 @@ impl Endpoint {
         }
     }
 
-    /// ターゲット名（共通メソッド・variant 別ディスパッチ）
+    /// ターゲット名（`binding()` 経由で `TargetBinding` に集約）
     pub(crate) fn name(&self) -> &'static str {
-        match self {
-            Self::Source(s) => s.name(),
-            Self::Destination(d) => d.name(),
-        }
+        self.binding().name()
     }
 
-    /// Command フォーマット（共通メソッド・variant 別ディスパッチ）
+    /// Command フォーマット（`binding()` 経由で `TargetBinding` に集約）
     pub(crate) fn command_format(&self) -> CommandFormat {
-        match self {
-            Self::Source(s) => s.command_format(),
-            Self::Destination(d) => d.command_format(),
-        }
+        self.binding().command_format()
     }
 
-    /// 配置済みコンポーネント一覧（共通メソッド・variant 別ディスパッチ）
+    /// 配置済みコンポーネント一覧（`binding()` 経由で `TargetBinding` に集約）
     pub(crate) fn placed_components(&self, options: &SyncOptions) -> Result<Vec<PlacedComponent>> {
-        match self {
-            Self::Source(s) => s.placed_components(options),
-            Self::Destination(d) => d.placed_components(options),
-        }
+        self.binding().placed_components(options)
     }
 
-    /// 配置済みコンポーネントのパスを解決（共通メソッド・variant 別ディスパッチ）
+    /// 配置済みコンポーネントのパスを解決（`binding()` 経由で `TargetBinding` に集約）
     pub(crate) fn path_for(&self, component: &PlacedComponent) -> Result<PathBuf> {
-        match self {
-            Self::Source(s) => s.path_for(component),
-            Self::Destination(d) => d.path_for(component),
-        }
+        self.binding().path_for(component)
     }
 }
 

--- a/src/sync/endpoint.rs
+++ b/src/sync/endpoint.rs
@@ -27,14 +27,14 @@ use crate::target::PluginOrigin;
 /// External callers must continue to use `SyncSource` / `SyncDestination`.
 /// `Endpoint` exists to deduplicate dispatch logic inside the `sync` feature.
 #[derive(Debug)]
-pub(crate) enum Endpoint {
+pub(super) enum Endpoint {
     Source(SyncSource),
     Destination(SyncDestination),
 }
 
 impl Endpoint {
     /// `Source` variant ならその `&SyncSource` を返す
-    pub(crate) fn as_source(&self) -> Option<&SyncSource> {
+    pub(super) fn as_source(&self) -> Option<&SyncSource> {
         match self {
             Self::Source(s) => Some(s),
             Self::Destination(_) => None,
@@ -42,7 +42,7 @@ impl Endpoint {
     }
 
     /// `Destination` variant ならその `&SyncDestination` を返す
-    pub(crate) fn as_destination(&self) -> Option<&SyncDestination> {
+    pub(super) fn as_destination(&self) -> Option<&SyncDestination> {
         match self {
             Self::Source(_) => None,
             Self::Destination(d) => Some(d),
@@ -50,7 +50,7 @@ impl Endpoint {
     }
 
     /// variant に内包された `TargetBinding` への参照を返す集約点。
-    pub(crate) fn binding(&self) -> &TargetBinding {
+    pub(super) fn binding(&self) -> &TargetBinding {
         match self {
             Self::Source(s) => s.binding(),
             Self::Destination(d) => d.binding(),
@@ -58,22 +58,22 @@ impl Endpoint {
     }
 
     /// ターゲット名（`binding()` 経由で `TargetBinding` に集約）
-    pub(crate) fn name(&self) -> &'static str {
+    pub(super) fn name(&self) -> &'static str {
         self.binding().name()
     }
 
     /// Command フォーマット（`binding()` 経由で `TargetBinding` に集約）
-    pub(crate) fn command_format(&self) -> CommandFormat {
+    pub(super) fn command_format(&self) -> CommandFormat {
         self.binding().command_format()
     }
 
     /// 配置済みコンポーネント一覧（`binding()` 経由で `TargetBinding` に集約）
-    pub(crate) fn placed_components(&self, options: &SyncOptions) -> Result<Vec<PlacedComponent>> {
+    pub(super) fn placed_components(&self, options: &SyncOptions) -> Result<Vec<PlacedComponent>> {
         self.binding().placed_components(options)
     }
 
     /// 配置済みコンポーネントのパスを解決（`binding()` 経由で `TargetBinding` に集約）
-    pub(crate) fn path_for(&self, component: &PlacedComponent) -> Result<PathBuf> {
+    pub(super) fn path_for(&self, component: &PlacedComponent) -> Result<PathBuf> {
         self.binding().path_for(component)
     }
 }

--- a/src/sync/endpoint/destination.rs
+++ b/src/sync/endpoint/destination.rs
@@ -83,6 +83,11 @@ impl SyncDestination {
         let target = self.0.target();
         target.supports(placed_ref.kind) && target.supports_scope(placed_ref.kind, placed_ref.scope)
     }
+
+    /// `Endpoint` enum から内包する `TargetBinding` に到達するための accessor
+    pub(super) fn binding(&self) -> &TargetBinding {
+        &self.0
+    }
 }
 
 #[cfg(test)]

--- a/src/sync/endpoint/endpoint_test.rs
+++ b/src/sync/endpoint/endpoint_test.rs
@@ -415,3 +415,18 @@ fn test_sync_destination_debug_format_preserved() {
     assert!(dbg.contains("target: \"fake-dst\""), "got: {dbg}");
     assert!(dbg.contains("project_root:"), "got: {dbg}");
 }
+
+// --- (T2 Red) binding accessor 存在確認: メソッド未実装時はコンパイル Red になる ---
+
+#[test]
+fn test_endpoint_source_binding_accessor_exists() {
+    let src = fake_source(
+        FakeTarget {
+            name: "fake-src",
+            ..Default::default()
+        },
+        Path::new("."),
+    );
+    let endpoint = Endpoint::Source(src);
+    let _binding: &super::TargetBinding = endpoint.binding();
+}

--- a/src/sync/endpoint/endpoint_test.rs
+++ b/src/sync/endpoint/endpoint_test.rs
@@ -430,3 +430,81 @@ fn test_endpoint_source_binding_accessor_exists() {
     let endpoint = Endpoint::Source(src);
     let _binding: &super::TargetBinding = endpoint.binding();
 }
+
+// --- (T4 Green 安全網) dispatch 整合性: newtype 経路と Endpoint 経路の戻り値一致 ---
+
+#[test]
+fn test_endpoint_source_name_parity() {
+    let src = fake_source(
+        FakeTarget {
+            name: "fake-src",
+            ..Default::default()
+        },
+        Path::new("."),
+    );
+    let direct = src.name();
+    let via_endpoint = Endpoint::Source(src).name();
+    assert_eq!(direct, via_endpoint);
+}
+
+#[test]
+fn test_endpoint_destination_name_parity() {
+    let dst = fake_destination(
+        FakeTarget {
+            name: "fake-dst",
+            ..Default::default()
+        },
+        Path::new("."),
+    );
+    let direct = dst.name();
+    let via_endpoint = Endpoint::Destination(dst).name();
+    assert_eq!(direct, via_endpoint);
+}
+
+#[test]
+fn test_endpoint_source_dispatch_placed_components_matches_newtype() {
+    use crate::sync::model::PlacedComponent;
+
+    let target = FakeTarget {
+        name: "fake-src",
+        placed: vec![(
+            ComponentKind::Skill,
+            Scope::Project,
+            vec!["skill-a".to_string()],
+        )],
+        location: Some(PathBuf::from("/tmp/fake/skill-a")),
+        ..Default::default()
+    };
+    let opt = SyncOptions::default()
+        .with_component_type(SyncableKind::Skill)
+        .with_scope(Scope::Project);
+
+    let src = fake_source(target, Path::new("/tmp/fake"));
+    let direct: Vec<PlacedComponent> = src.placed_components(&opt).unwrap();
+    let via_endpoint: Vec<PlacedComponent> = Endpoint::Source(src).placed_components(&opt).unwrap();
+
+    assert_eq!(direct, via_endpoint);
+}
+
+#[test]
+fn test_endpoint_destination_dispatch_path_for_matches_newtype() {
+    use crate::sync::model::PlacedComponent;
+
+    let target = FakeTarget {
+        name: "fake-dst",
+        location: Some(PathBuf::from("/tmp/fake/dest/skill-a")),
+        ..Default::default()
+    };
+    let comp = PlacedComponent::new(
+        ComponentKind::Skill,
+        "skill-a",
+        Scope::Project,
+        PathBuf::from("/tmp/fake/dest/skill-a"),
+    );
+
+    let dst = fake_destination(target, Path::new("/tmp/fake"));
+    let direct = dst.path_for(&comp).unwrap();
+    let via_endpoint = Endpoint::Destination(dst).path_for(&comp).unwrap();
+
+    assert_eq!(direct, via_endpoint);
+}

--- a/src/sync/endpoint/source.rs
+++ b/src/sync/endpoint/source.rs
@@ -70,6 +70,11 @@ impl SyncSource {
     pub fn path_for(&self, component: &PlacedComponent) -> Result<PathBuf> {
         self.0.path_for(component)
     }
+
+    /// `Endpoint` enum から内包する `TargetBinding` に到達するための accessor
+    pub(super) fn binding(&self) -> &TargetBinding {
+        &self.0
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## 概要

`sync/endpoint` の `enum Endpoint` を「`TargetBinding` を直接呼ぶ集約点」として再構成しました（候補C: オーナード `pub(super) enum Endpoint` + `binding()` accessor 経由）。`SyncSource` / `SyncDestination` の `pub` API は完全互換、振る舞い不変のリファクタリングです。

## 変更の種類

- ♻️ Refactoring（振る舞い不変）
- 🧪 Tests（dispatch 整合性 parity テスト 5 件追加）

## 追加した内容

- `SyncSource::binding(&self) -> &TargetBinding`（`pub(super)`）
- `SyncDestination::binding(&self) -> &TargetBinding`（`pub(super)`）
- `Endpoint::binding(&self) -> &TargetBinding`（module-private — 戻り値型 `TargetBinding` の可視性に揃えるため）
- dispatch 整合性テスト 5 件（`src/sync/endpoint/endpoint_test.rs`）
  - `test_endpoint_source_binding_accessor_exists`（T2 Red 観測用）
  - `test_endpoint_source_name_parity` / `test_endpoint_destination_name_parity`
  - `test_endpoint_source_dispatch_placed_components_matches_newtype`
  - `test_endpoint_destination_dispatch_path_for_matches_newtype`

## 変更した内容

- `Endpoint::name` / `command_format` / `placed_components` / `path_for` を `match` arm から `self.binding().method()` の 1 ホップに集約
- `Endpoint` enum とメソッド群（`as_source` / `as_destination` / `name` / `command_format` / `placed_components` / `path_for`）の可視性を `pub(crate)` → `pub(super)` に絞った
- `SyncSource` / `SyncDestination` の既存 `pub` API（`new` / `with_target` / `name` / `command_format` / `placed_components` / `path_for` / `supports`）は完全に未変更

## 削除した内容

- `Endpoint` の variant 別 dispatch における重複 `match` arm（4 メソッド分）

## システム図

```mermaid
flowchart TB
    caller["caller<br/>(sync.rs / commands/deploy/sync.rs)"]
    src["SyncSource(TargetBinding)"]
    dst["SyncDestination(TargetBinding)"]
    ep["Endpoint [pub(super)]<br/>(test / dispatch)"]
    binding["TargetBinding<br/>(実装本体)"]

    caller -->|pub API 不変| src
    caller -->|pub API 不変| dst
    src -.->|self.0.method passthrough| binding
    dst -.->|self.0.method passthrough| binding
    ep -->|self.binding NEW| binding

    src -->|binding pub super NEW| ep
    dst -->|binding pub super NEW| ep

    style ep fill:#fff3cd,stroke:#856404
    style binding fill:#d4edda,stroke:#155724
```

要点: newtype 経路（`SyncSource/Destination`）と Endpoint 経路の両方が `TargetBinding` に集約され、結果が機械的に一致することを dispatch parity テストで保証しています。

## 関連 Spec / Issue

- Spec: `.plugin-workspace/.specs/020-sync-endpoint-enum-abstraction/`
- Refs #255（Sub-issue ISSUE-01-B / ISSUE-01-C）
- 親 Epic: #254

## 検証

サブエージェント経由で以下を実施しました（CLAUDE.md 規約準拠）。

| コマンド | 結果 |
|----------|------|
| `cargo fmt` | 差分なし |
| `cargo check` | グリーン（警告 0、`private_interfaces` 警告も解消済み） |
| `cargo test` | **1588 passed / 0 failed / 0 ignored**（既存 1583 + 新規 5 件） |

新規テスト内訳（`sync::endpoint::tests`）:
- `test_endpoint_source_binding_accessor_exists` ✅
- `test_endpoint_source_name_parity` ✅
- `test_endpoint_destination_name_parity` ✅
- `test_endpoint_source_dispatch_placed_components_matches_newtype` ✅
- `test_endpoint_destination_dispatch_path_for_matches_newtype` ✅

加えて Codex CLI による全変更レビューを 2 回実施し、初回指摘（`Endpoint::binding()` の `pub(super)` と戻り値型 `TargetBinding`（`pub(super) in endpoint/binding.rs`）の `private_interfaces` 警告）に対応した結果、最終的に **問題なし** との評価を取得しています。

## レビューポイント

- **公開 API 影響**: なし。`SyncSource` / `SyncDestination` の `pub` メソッド群は完全未変更。`Endpoint` は `pub(super)` に絞られましたが、production の他モジュールからの参照はゼロ（exploration 確認済）。
- **`Endpoint::binding()` の可視性**: 計画書では `pub(super)` 想定でしたが、戻り値型 `TargetBinding` 自体が `pub(super) in endpoint` で `endpoint` モジュール配下にしか可視でないため、`pub(super)` だと `crate::sync` まで届いてしまい `private_interfaces` 警告が発生。Codex レビュー指摘を受け module-private に絞りました（テストモジュールは `endpoint.rs` の子モジュール `mod tests;` として埋め込み済みなので呼び出し可）。
- **振る舞い不変の保証**: dispatch parity テスト（newtype 経路と Endpoint 経路の戻り値完全一致）+ 既存テスト 28 件（`endpoint_test.rs` 17 / `source_test.rs` 8 / `destination_test.rs` 1 / `sync_test.rs` 2）で保護。
- **`Debug` 実装**: `"SyncSource {"` / `"SyncDestination {"` prefix を保持（既存 `test_sync_source_debug_format_preserved` / `test_sync_destination_debug_format_preserved` で検証）。

## チェックリスト

- [x] `cargo fmt` をサブエージェント経由で実行した
- [x] `cargo check` を実行しグリーン（警告 0）
- [x] `cargo test` を実行しグリーン（1588 passed）
- [x] 公開 API（`pub fn` / `struct` / `enum` / `trait`）への破壊的変更がないことを確認した
- [x] セルフレビュー実施（Codex レビューも併用）
- [x] 関連 Spec / Issue を本文にリンクした
- [x] リファクタリングが振る舞い不変であることをテストで検証した（dispatch parity 4 件 + 既存 28 件）