### PR TITLE
#262 Endpoint dispatch parity を拡充

### DIFF
--- a/docs/issue-262-endpoint-review.md
+++ b/docs/issue-262-endpoint-review.md
@@ -1,0 +1,19 @@
+# Issue #262 Endpoint Review
+
+## 結論
+
+- `Endpoint` は既存の `pub(super)` enum を維持し、新規 production enum / wrapper は追加しない。
+- `name` / `command_format` / `placed_components` / `path_for` は `binding()` 経由の dispatch に集約済み。
+- `SyncDestination::supports` は Destination 固有の capability 判定であり、`Endpoint` には移さない。
+- `sync.rs` の `sync` / `sync_with_fs` / `execute_sync` / `execute_create` / `execute_update` は Source が入力、Destination が出力として役割差分を持つため、現段階では `Endpoint` 化しない。
+
+## 確認内容
+
+- `Endpoint` の visibility は `pub(super)` のまま。
+- public API `sync(&SyncSource, &SyncDestination, &SyncOptions)` は維持。
+- `Endpoint::supports` は存在しない。
+- parity test は `Source` / `Destination` の `name` / `command_format` / `placed_components` / `path_for` と invalid component name 経路を対象に維持・追加。
+
+## 将来の移行条件
+
+両 endpoint を完全に同じ操作として扱える private helper が複数出てきた場合のみ、限定的に `Endpoint` 利用を検討する。`supports` のように Destination の意味を持つ操作や、copy / convert のように Source と Destination の役割が分かれる処理は移行対象にしない。

--- a/src/sync/endpoint/endpoint_test.rs
+++ b/src/sync/endpoint/endpoint_test.rs
@@ -151,6 +151,24 @@ fn test_endpoint_dispatch_command_format() {
     assert_eq!(ep.command_format(), CommandFormat::Codex);
 }
 
+#[test]
+fn test_endpoint_source_command_format_parity() {
+    let src = fake_source(FakeTarget::default(), Path::new("."));
+    let direct = src.command_format();
+    let via_endpoint = Endpoint::Source(src).command_format();
+
+    assert_eq!(direct, via_endpoint);
+}
+
+#[test]
+fn test_endpoint_destination_command_format_parity() {
+    let dst = fake_destination(FakeTarget::default(), Path::new("."));
+    let direct = dst.command_format();
+    let via_endpoint = Endpoint::Destination(dst).command_format();
+
+    assert_eq!(direct, via_endpoint);
+}
+
 // --- placed_components / path_for / resolve_path 経由 ---
 
 #[test]
@@ -487,6 +505,55 @@ fn test_endpoint_source_dispatch_placed_components_matches_newtype() {
 }
 
 #[test]
+fn test_endpoint_destination_dispatch_placed_components_matches_newtype() {
+    use crate::sync::model::PlacedComponent;
+
+    let target = FakeTarget {
+        name: "fake-dst",
+        placed: vec![(
+            ComponentKind::Skill,
+            Scope::Project,
+            vec!["skill-a".to_string()],
+        )],
+        location: Some(PathBuf::from("/tmp/fake/dst/skill-a")),
+        ..Default::default()
+    };
+    let opt = SyncOptions::default()
+        .with_component_type(SyncableKind::Skill)
+        .with_scope(Scope::Project);
+
+    let dst = fake_destination(target, Path::new("/tmp/fake"));
+    let direct: Vec<PlacedComponent> = dst.placed_components(&opt).unwrap();
+    let via_endpoint: Vec<PlacedComponent> =
+        Endpoint::Destination(dst).placed_components(&opt).unwrap();
+
+    assert_eq!(direct, via_endpoint);
+}
+
+#[test]
+fn test_endpoint_source_dispatch_path_for_matches_newtype() {
+    use crate::sync::model::PlacedComponent;
+
+    let target = FakeTarget {
+        name: "fake-src",
+        location: Some(PathBuf::from("/tmp/fake/src/skill-a")),
+        ..Default::default()
+    };
+    let comp = PlacedComponent::new(
+        ComponentKind::Skill,
+        "skill-a",
+        Scope::Project,
+        PathBuf::from("/tmp/fake/src/skill-a"),
+    );
+
+    let src = fake_source(target, Path::new("/tmp/fake"));
+    let direct = src.path_for(&comp).unwrap();
+    let via_endpoint = Endpoint::Source(src).path_for(&comp).unwrap();
+
+    assert_eq!(direct, via_endpoint);
+}
+
+#[test]
 fn test_endpoint_destination_dispatch_path_for_matches_newtype() {
     use crate::sync::model::PlacedComponent;
 
@@ -505,6 +572,32 @@ fn test_endpoint_destination_dispatch_path_for_matches_newtype() {
     let dst = fake_destination(target, Path::new("/tmp/fake"));
     let direct = dst.path_for(&comp).unwrap();
     let via_endpoint = Endpoint::Destination(dst).path_for(&comp).unwrap();
+
+    assert_eq!(direct, via_endpoint);
+}
+
+#[test]
+fn test_endpoint_source_dispatch_invalid_name_matches_newtype() {
+    use crate::sync::model::PlacedComponent;
+
+    let target = FakeTarget {
+        name: "fake-src",
+        location: Some(PathBuf::from("/tmp/fake/src/skill-a")),
+        ..Default::default()
+    };
+    let comp = PlacedComponent::new(
+        ComponentKind::Skill,
+        "nested/skill-a",
+        Scope::Project,
+        PathBuf::from("/ignored"),
+    );
+
+    let src = fake_source(target, Path::new("/tmp/fake"));
+    let direct = src.path_for(&comp).unwrap_err().to_string();
+    let via_endpoint = Endpoint::Source(src)
+        .path_for(&comp)
+        .unwrap_err()
+        .to_string();
 
     assert_eq!(direct, via_endpoint);
 }


### PR DESCRIPTION
## 概要

Endpoint 内部抽象の段階移行可否判断として、production 実装は増やさずに dispatch parity のテスト範囲を拡充しました。あわせて、現段階で `sync.rs` を Endpoint 化しない判断を docs に記録しています。

## 変更内容

### 🎯 変更の種類

- [ ] 🐛 バグ修正 (Bug fix)
- [ ] ✨ 新機能 (New feature)
- [ ] ♻️ リファクタリング (Refactoring)
- [ ] 🎨 UI/UX 改善 (UI/UX improvement)
- [ ] 🐎 パフォーマンス改善 (Performance improvement)
- [x] 🚨 テスト追加/修正 (Tests)
- [x] 📖 ドキュメント更新 (Documentation)
- [ ] 🔧 設定変更 (Configuration)
- [ ] 🗑️ 削除 (Removal)

### 📝 詳細な変更内容

#### 追加された機能・修正

- `Endpoint::Source` / `Endpoint::Destination` の `command_format` parity test を追加
- Destination 側 `placed_components` と Source 側 `path_for` の parity test を追加
- invalid component name 経路が直接呼び出しと Endpoint 経由で一致することを検証
- `Endpoint` 化しない判断と将来移行条件を `docs/issue-262-endpoint-review.md` に記録

#### 変更されたファイル

- `src/sync/endpoint/endpoint_test.rs`
- `docs/issue-262-endpoint-review.md`

#### 削除されたファイル・機能

- なし

## 📋 関連 Issue

- Closes #262

## 🧪 テスト

### テスト実行方法

```bash
cargo test endpoint
cargo test sync
cargo fmt -- --check
cargo clippy --all-targets --all-features
```

### テスト項目

- [x] 単体テスト (Unit tests)
- [x] 統合テスト (Integration tests)
- [ ] E2E テスト (End-to-end tests)
- [ ] 手動テスト (Manual testing)

### テスト結果

- `cargo test endpoint`: 通過
- `cargo test sync`: 通過
- `cargo fmt -- --check`: 通過
- `cargo clippy --all-targets --all-features`: 終了、既存警告のみ

## 🔍 レビューポイント

- `Endpoint` が `pub(super)` のまま維持されていること
- `SyncDestination::supports` を `Endpoint` に移していないこと
- `sync.rs` の Source / Destination の役割差分を維持し、過剰に Endpoint 化していないこと

## ⚠️ 破壊的変更

- [ ] この変更は既存の API に破壊的変更を含みます

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [x] ドキュメントが更新されている（必要に応じて）
- [x] コミットメッセージが適切な形式で書かれている
- [x] 関連する Issue が PR の「Development」に Linked されている
- [x] PR 本文に `Closes #` / `Fixes #` / `Refs #` などで Issue が記載されている
- [x] セルフレビューを実施した
- [x] 破壊的変更がある場合は明記されている