### PR TITLE
♻️ #284 sync engineのscanをEndpoint dispatchへ移行

### DIFF
--- a/docs/issue-284-code-review-2026-05-05.md
+++ b/docs/issue-284-code-review-2026-05-05.md
@@ -1,0 +1,31 @@
+# Issue #284 Code Review
+
+## 結果
+
+問題なし。
+
+## 備考
+
+`codex exec --dangerously-bypass-approvals-and-sandbox` によるレビュー実行は、権限審査で外部実行と広い unsandboxed access のリスクとして拒否された。
+迂回は行わず、`.plugin-workspace/.specs/025-issue-284/code-review/context-001.md` と作業差分を同じ観点でローカル確認した。
+
+## 確認内容
+
+- `Endpoint<'a>` は参照 enum に変更され、`SyncSource` / `SyncDestination` の所有権移動を増やしていない。
+- `sync_with_fs` の component scan は `collect_components(Endpoint<'_>, ...)` 経由に限定されている。
+- `sync(&SyncSource, &SyncDestination, &SyncOptions)` の public API は維持されている。
+- `Endpoint` は `pub(super)` のままで、`Endpoint::supports` は追加されていない。
+- `SyncDestination::supports` は destination 固有処理として残っている。
+- scan 段階のエラーは `SyncFailure` に包まず `Result::Err` として伝播するテストで保護されている。
+
+## 検証
+
+- `cargo fmt --check`
+- `cargo clippy`
+- `cargo test endpoint`
+- `cargo test sync`
+- `cargo test commands::deploy::sync`
+- `cargo test`
+- `rg -n "Endpoint::supports|pub fn supports" src/sync src/commands/deploy/sync.rs`
+- `rg -n "pub fn sync\\(|sync_with_fs\\(" src/sync.rs`
+- `rg -n "Endpoint::Source|Endpoint::Destination" src/sync.rs src/sync/endpoint/endpoint_test.rs`

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -32,6 +32,7 @@ pub use model::{
 
 use crate::component::{convert, ComponentKind};
 use crate::error::Result;
+use endpoint::Endpoint;
 use std::collections::HashMap;
 
 /// 同期を実行
@@ -66,8 +67,8 @@ pub(crate) fn sync_with_fs(
     options: &SyncOptions,
     fs: &dyn FileSystem,
 ) -> Result<SyncResult> {
-    let source_components = source.placed_components(options)?;
-    let dest_components = dest.placed_components(options)?;
+    let source_components = collect_components(Endpoint::Source(source), options)?;
+    let dest_components = collect_components(Endpoint::Destination(dest), options)?;
 
     let source_map: HashMap<&PlacedRef, &PlacedComponent> = source_components
         .iter()
@@ -123,6 +124,13 @@ pub(crate) fn sync_with_fs(
         to_delete,
     };
     execute_sync(source, dest, plan, fs)
+}
+
+fn collect_components(
+    endpoint: Endpoint<'_>,
+    options: &SyncOptions,
+) -> Result<Vec<PlacedComponent>> {
+    endpoint.placed_components(options)
 }
 
 /// 更新が必要かを判定（mtime または内容比較）

--- a/src/sync/endpoint.rs
+++ b/src/sync/endpoint.rs
@@ -26,26 +26,26 @@ use crate::target::PluginOrigin;
 ///
 /// External callers must continue to use `SyncSource` / `SyncDestination`.
 /// `Endpoint` exists to deduplicate dispatch logic inside the `sync` feature.
-#[derive(Debug)]
-pub(super) enum Endpoint {
-    Source(SyncSource),
-    Destination(SyncDestination),
+#[derive(Debug, Clone, Copy)]
+pub(super) enum Endpoint<'a> {
+    Source(&'a SyncSource),
+    Destination(&'a SyncDestination),
 }
 
-impl Endpoint {
+impl<'a> Endpoint<'a> {
     /// `Source` variant ならその `&SyncSource` を返す
-    pub(super) fn as_source(&self) -> Option<&SyncSource> {
+    pub(super) fn as_source(&self) -> Option<&'a SyncSource> {
         match self {
-            Self::Source(s) => Some(s),
+            Self::Source(s) => Some(*s),
             Self::Destination(_) => None,
         }
     }
 
     /// `Destination` variant ならその `&SyncDestination` を返す
-    pub(super) fn as_destination(&self) -> Option<&SyncDestination> {
+    pub(super) fn as_destination(&self) -> Option<&'a SyncDestination> {
         match self {
             Self::Source(_) => None,
-            Self::Destination(d) => Some(d),
+            Self::Destination(d) => Some(*d),
         }
     }
 

--- a/src/sync/endpoint/endpoint_test.rs
+++ b/src/sync/endpoint/endpoint_test.rs
@@ -123,7 +123,7 @@ fn test_endpoint_source_dispatch_name() {
         },
         Path::new("."),
     );
-    let ep = Endpoint::Source(src);
+    let ep = Endpoint::Source(&src);
     assert_eq!(ep.name(), "fake-src");
     assert!(ep.as_source().is_some());
     assert!(ep.as_destination().is_none());
@@ -138,7 +138,7 @@ fn test_endpoint_destination_dispatch_name() {
         },
         Path::new("."),
     );
-    let ep = Endpoint::Destination(dst);
+    let ep = Endpoint::Destination(&dst);
     assert_eq!(ep.name(), "fake-dst");
     assert!(ep.as_destination().is_some());
     assert!(ep.as_source().is_none());
@@ -147,7 +147,7 @@ fn test_endpoint_destination_dispatch_name() {
 #[test]
 fn test_endpoint_dispatch_command_format() {
     let src = fake_source(FakeTarget::default(), Path::new("."));
-    let ep = Endpoint::Source(src);
+    let ep = Endpoint::Source(&src);
     assert_eq!(ep.command_format(), CommandFormat::Codex);
 }
 
@@ -155,7 +155,7 @@ fn test_endpoint_dispatch_command_format() {
 fn test_endpoint_source_command_format_parity() {
     let src = fake_source(FakeTarget::default(), Path::new("."));
     let direct = src.command_format();
-    let via_endpoint = Endpoint::Source(src).command_format();
+    let via_endpoint = Endpoint::Source(&src).command_format();
 
     assert_eq!(direct, via_endpoint);
 }
@@ -164,7 +164,7 @@ fn test_endpoint_source_command_format_parity() {
 fn test_endpoint_destination_command_format_parity() {
     let dst = fake_destination(FakeTarget::default(), Path::new("."));
     let direct = dst.command_format();
-    let via_endpoint = Endpoint::Destination(dst).command_format();
+    let via_endpoint = Endpoint::Destination(&dst).command_format();
 
     assert_eq!(direct, via_endpoint);
 }
@@ -445,7 +445,7 @@ fn test_endpoint_source_binding_accessor_exists() {
         },
         Path::new("."),
     );
-    let endpoint = Endpoint::Source(src);
+    let endpoint = Endpoint::Source(&src);
     let _binding: &super::TargetBinding = endpoint.binding();
 }
 
@@ -461,7 +461,7 @@ fn test_endpoint_source_name_parity() {
         Path::new("."),
     );
     let direct = src.name();
-    let via_endpoint = Endpoint::Source(src).name();
+    let via_endpoint = Endpoint::Source(&src).name();
     assert_eq!(direct, via_endpoint);
 }
 
@@ -475,7 +475,7 @@ fn test_endpoint_destination_name_parity() {
         Path::new("."),
     );
     let direct = dst.name();
-    let via_endpoint = Endpoint::Destination(dst).name();
+    let via_endpoint = Endpoint::Destination(&dst).name();
     assert_eq!(direct, via_endpoint);
 }
 
@@ -499,7 +499,8 @@ fn test_endpoint_source_dispatch_placed_components_matches_newtype() {
 
     let src = fake_source(target, Path::new("/tmp/fake"));
     let direct: Vec<PlacedComponent> = src.placed_components(&opt).unwrap();
-    let via_endpoint: Vec<PlacedComponent> = Endpoint::Source(src).placed_components(&opt).unwrap();
+    let via_endpoint: Vec<PlacedComponent> =
+        Endpoint::Source(&src).placed_components(&opt).unwrap();
 
     assert_eq!(direct, via_endpoint);
 }
@@ -525,7 +526,7 @@ fn test_endpoint_destination_dispatch_placed_components_matches_newtype() {
     let dst = fake_destination(target, Path::new("/tmp/fake"));
     let direct: Vec<PlacedComponent> = dst.placed_components(&opt).unwrap();
     let via_endpoint: Vec<PlacedComponent> =
-        Endpoint::Destination(dst).placed_components(&opt).unwrap();
+        Endpoint::Destination(&dst).placed_components(&opt).unwrap();
 
     assert_eq!(direct, via_endpoint);
 }
@@ -548,7 +549,7 @@ fn test_endpoint_source_dispatch_path_for_matches_newtype() {
 
     let src = fake_source(target, Path::new("/tmp/fake"));
     let direct = src.path_for(&comp).unwrap();
-    let via_endpoint = Endpoint::Source(src).path_for(&comp).unwrap();
+    let via_endpoint = Endpoint::Source(&src).path_for(&comp).unwrap();
 
     assert_eq!(direct, via_endpoint);
 }
@@ -571,7 +572,7 @@ fn test_endpoint_destination_dispatch_path_for_matches_newtype() {
 
     let dst = fake_destination(target, Path::new("/tmp/fake"));
     let direct = dst.path_for(&comp).unwrap();
-    let via_endpoint = Endpoint::Destination(dst).path_for(&comp).unwrap();
+    let via_endpoint = Endpoint::Destination(&dst).path_for(&comp).unwrap();
 
     assert_eq!(direct, via_endpoint);
 }
@@ -594,7 +595,7 @@ fn test_endpoint_source_dispatch_invalid_name_matches_newtype() {
 
     let src = fake_source(target, Path::new("/tmp/fake"));
     let direct = src.path_for(&comp).unwrap_err().to_string();
-    let via_endpoint = Endpoint::Source(src)
+    let via_endpoint = Endpoint::Source(&src)
         .path_for(&comp)
         .unwrap_err()
         .to_string();

--- a/src/sync_test.rs
+++ b/src/sync_test.rs
@@ -1,6 +1,115 @@
 use super::*;
-use crate::component::{ComponentKind, Scope};
+use crate::component::{
+    AgentFormat, CommandFormat, ComponentKind, PlacementContext, PlacementLocation, Scope,
+};
 use crate::fs::mock::MockFs;
+use crate::target::{Target, TargetKind};
+use std::path::{Path, PathBuf};
+
+struct FakeTarget {
+    kind: TargetKind,
+    supported_components: Vec<ComponentKind>,
+    supported_scopes: Vec<(ComponentKind, Scope)>,
+    placed: Vec<(ComponentKind, Scope, Vec<String>)>,
+    base_path: PathBuf,
+}
+
+impl Default for FakeTarget {
+    fn default() -> Self {
+        Self {
+            kind: TargetKind::Codex,
+            supported_components: vec![ComponentKind::Skill],
+            supported_scopes: vec![(ComponentKind::Skill, Scope::Project)],
+            placed: Vec::new(),
+            base_path: PathBuf::from("/tmp/fake"),
+        }
+    }
+}
+
+impl FakeTarget {
+    fn with_placed(names: Vec<&str>) -> Self {
+        Self {
+            placed: vec![(
+                ComponentKind::Skill,
+                Scope::Project,
+                names.into_iter().map(str::to_string).collect(),
+            )],
+            ..Default::default()
+        }
+    }
+
+    fn without_skill_support() -> Self {
+        Self {
+            supported_components: Vec::new(),
+            supported_scopes: Vec::new(),
+            ..Default::default()
+        }
+    }
+}
+
+impl Target for FakeTarget {
+    fn name(&self) -> &'static str {
+        "fake"
+    }
+
+    fn display_name(&self) -> &'static str {
+        "Fake"
+    }
+
+    fn kind(&self) -> TargetKind {
+        self.kind
+    }
+
+    fn command_format(&self) -> CommandFormat {
+        CommandFormat::Codex
+    }
+
+    fn agent_format(&self) -> AgentFormat {
+        AgentFormat::Codex
+    }
+
+    fn supported_components(&self) -> &[ComponentKind] {
+        &self.supported_components
+    }
+
+    fn supports_scope(&self, kind: ComponentKind, scope: Scope) -> bool {
+        self.supported_scopes.contains(&(kind, scope))
+    }
+
+    fn placement_location(&self, context: &PlacementContext) -> Option<PlacementLocation> {
+        Some(PlacementLocation::file(
+            self.base_path.join(&context.component.name),
+        ))
+    }
+
+    fn list_placed(
+        &self,
+        kind: ComponentKind,
+        scope: Scope,
+        _project_root: &Path,
+    ) -> Result<Vec<String>> {
+        Ok(self
+            .placed
+            .iter()
+            .find(|(placed_kind, placed_scope, _)| *placed_kind == kind && *placed_scope == scope)
+            .map(|(_, _, names)| names.clone())
+            .unwrap_or_default())
+    }
+}
+
+fn fake_source(target: FakeTarget) -> SyncSource {
+    SyncSource::with_target(Box::new(target), Path::new("/tmp/source"))
+}
+
+fn fake_destination(target: FakeTarget) -> SyncDestination {
+    SyncDestination::with_target(Box::new(target), Path::new("/tmp/dest"))
+}
+
+fn skill_project_options() -> SyncOptions {
+    SyncOptions::default()
+        .with_component_type(SyncableKind::Skill)
+        .with_scope(Scope::Project)
+}
 
 #[test]
 fn test_needs_update_newer_source() {
@@ -50,4 +159,108 @@ fn test_needs_update_same_content() {
 
     let result = needs_update(&src, &dst, &fs).unwrap();
     assert!(!result);
+}
+
+#[test]
+fn test_collect_components_uses_endpoint_dispatch_for_source() {
+    let src = fake_source(FakeTarget::with_placed(vec!["alpha"]));
+    let options = skill_project_options();
+
+    let components = collect_components(endpoint::Endpoint::Source(&src), &options).unwrap();
+
+    assert_eq!(components.len(), 1);
+    assert_eq!(components[0].name(), "alpha");
+    assert_eq!(components[0].kind(), ComponentKind::Skill);
+    assert_eq!(components[0].scope(), Scope::Project);
+}
+
+#[test]
+fn test_collect_components_uses_endpoint_dispatch_for_destination() {
+    let dest = fake_destination(FakeTarget::with_placed(vec!["alpha"]));
+    let options = skill_project_options();
+
+    let components = collect_components(endpoint::Endpoint::Destination(&dest), &options).unwrap();
+
+    assert_eq!(components.len(), 1);
+    assert_eq!(components[0].name(), "alpha");
+    assert_eq!(components[0].kind(), ComponentKind::Skill);
+    assert_eq!(components[0].scope(), Scope::Project);
+}
+
+#[test]
+fn test_collect_components_propagates_source_scan_error() {
+    let src = fake_source(FakeTarget::with_placed(vec!["nested/alpha"]));
+    let options = skill_project_options();
+
+    let err = collect_components(endpoint::Endpoint::Source(&src), &options).unwrap_err();
+
+    assert!(
+        err.to_string().contains("Invalid component name"),
+        "expected invalid component name error, got: {err:?}"
+    );
+}
+
+#[test]
+fn test_collect_components_propagates_destination_scan_error() {
+    let dest = fake_destination(FakeTarget::with_placed(vec!["nested/alpha"]));
+    let options = skill_project_options();
+
+    let err = collect_components(endpoint::Endpoint::Destination(&dest), &options).unwrap_err();
+
+    assert!(
+        err.to_string().contains("Invalid component name"),
+        "expected invalid component name error, got: {err:?}"
+    );
+}
+
+#[test]
+fn test_sync_with_fs_propagates_source_scan_error_without_sync_failure() {
+    let source = fake_source(FakeTarget::with_placed(vec!["nested/alpha"]));
+    let dest = fake_destination(FakeTarget::default());
+    let fs = MockFs::new();
+
+    let err = sync_with_fs(&source, &dest, &skill_project_options(), &fs).unwrap_err();
+
+    assert!(
+        err.to_string().contains("Invalid component name"),
+        "expected invalid component name error, got: {err:?}"
+    );
+}
+
+#[test]
+fn test_sync_with_fs_propagates_destination_scan_error_without_sync_failure() {
+    let source = fake_source(FakeTarget::default());
+    let dest = fake_destination(FakeTarget::with_placed(vec!["nested/alpha"]));
+    let fs = MockFs::new();
+
+    let err = sync_with_fs(&source, &dest, &skill_project_options(), &fs).unwrap_err();
+
+    assert!(
+        err.to_string().contains("Invalid component name"),
+        "expected invalid component name error, got: {err:?}"
+    );
+}
+
+#[test]
+fn test_sync_with_fs_uses_destination_supports_for_unsupported_dry_run() {
+    let source = fake_source(FakeTarget::with_placed(vec!["alpha"]));
+    let dest = fake_destination(FakeTarget::without_skill_support());
+    let fs = MockFs::new();
+
+    let result = sync_with_fs(
+        &source,
+        &dest,
+        &SyncOptions {
+            dry_run: true,
+            ..skill_project_options()
+        },
+        &fs,
+    )
+    .unwrap();
+
+    assert!(result.dry_run);
+    assert_eq!(result.unsupported.len(), 1);
+    assert_eq!(result.unsupported[0].name(), "alpha");
+    assert!(result.created.is_empty());
+    assert!(result.failed.is_empty());
 }


### PR DESCRIPTION
## 概要

sync engine 内部の component scan を `Endpoint` dispatch 経由へ段階移行しました。外部 API と CLI 挙動は維持し、`supports` や create/update の非対称処理は既存境界のまま残しています。

## 変更内容

### 🎯 変更の種類

- [ ] 🐛 バグ修正 (Bug fix)
- [ ] ✨ 新機能 (New feature)
- [x] ♻️ リファクタリング (Refactoring)
- [ ] 🎨 UI/UX 改善 (UI/UX improvement)
- [ ] 🐎 パフォーマンス改善 (Performance improvement)
- [x] 🚨 テスト追加/修正 (Tests)
- [x] 📖 ドキュメント更新 (Documentation)
- [ ] 🔧 設定変更 (Configuration)
- [ ] 🗑️ 削除 (Removal)

### 📝 詳細な変更内容

#### 追加された機能・修正

- `Endpoint` を `Endpoint<'a>` の借用 enum に変更し、`SyncSource` / `SyncDestination` の所有権移動を避ける形に更新
- `sync_with_fs` の source/destination component scan を `collect_components(Endpoint<'_>, ...)` 経由に移行
- source/destination scan error が `SyncFailure` に包まれず `Result::Err` で即時伝播する回帰テストを追加
- dry-run の unsupported 分類が `SyncDestination::supports` に基づくことを保護するテストを追加
- レビュー結果を `docs/issue-284-code-review-2026-05-05.md` に記録

#### 変更されたファイル

- `src/sync.rs`
- `src/sync/endpoint.rs`
- `src/sync/endpoint/endpoint_test.rs`
- `src/sync_test.rs`
- `docs/issue-284-code-review-2026-05-05.md`

#### 削除されたファイル・機能

- なし

## 📊 システム図

```mermaid
flowchart TD
    Caller[CLI / caller] --> Sync[public sync source dest options]
    Sync --> SyncFs[sync_with_fs]
    SyncFs --> SrcEndpoint[Endpoint::Source source]:::changed
    SyncFs --> DstEndpoint[Endpoint::Destination dest]:::changed
    SrcEndpoint --> CollectSrc[collect_components]:::new
    DstEndpoint --> CollectDst[collect_components]:::new
    CollectSrc --> BindingSrc[TargetBinding::placed_components]
    CollectDst --> BindingDst[TargetBinding::placed_components]
    BindingSrc --> Plan[差分分類]
    BindingDst --> Plan
    Plan --> Supports[SyncDestination::supports]
    Plan --> Execute[execute_create / execute_update / execute_delete]

    classDef new fill:#e0f2fe,stroke:#0284c7,stroke-width:2px
    classDef changed fill:#fef3c7,stroke:#d97706,stroke-width:2px
```

## 📋 関連 Issue

- Closes #284

## 🧪 テスト

### テスト実行方法

```bash
cargo fmt --check
cargo clippy
cargo test endpoint
cargo test sync
cargo test commands::deploy::sync
cargo test
rg -n "Endpoint::supports|pub fn supports" src/sync src/commands/deploy/sync.rs
rg -n "pub fn sync\\(|sync_with_fs\\(" src/sync.rs
rg -n "Endpoint::Source|Endpoint::Destination" src/sync.rs src/sync/endpoint/endpoint_test.rs
```

### テスト項目

- [x] 単体テスト (Unit tests)
- [x] 統合テスト (Integration tests)
- [ ] E2E テスト (End-to-end tests)
- [x] 手動テスト (Manual testing)

### テスト結果

- `cargo fmt --check`: 成功
- `cargo clippy`: 成功
- `cargo test endpoint`: 成功
- `cargo test sync`: 成功
- `cargo test commands::deploy::sync`: 成功
- `cargo test`: 成功、1600 passed
- `rg` による API / supports / Endpoint 利用境界確認: 成功

## 🔍 レビューポイント

- `Endpoint` が `pub(super)` のまま sync モジュール内部に閉じていること
- production の `Endpoint` 利用が `sync_with_fs` の scan helper に限定されていること
- `SyncDestination::supports` と create/update の source/destination 非対称処理が維持されていること

## ⚠️ 破壊的変更

- [ ] この変更は既存の API に破壊的変更を含みます

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [x] ドキュメントが更新されている（必要に応じて）
- [x] コミットメッセージが適切な形式で書かれている
- [x] 関連する Issue が PR の「Development」に Linked されている
- [x] PR 本文に `Closes #` / `Fixes #` / `Refs #` などで Issue が記載されている
- [x] セルフレビューを実施した
- [x] 破壊的変更がある場合は明記されている