### PR TITLE
♻️ #265 TUI一覧選択stateを共通型へ移行

### DIFF
--- a/docs/issue-265-implementation-check-2026-05-06.md
+++ b/docs/issue-265-implementation-check-2026-05-06.md
@@ -1,0 +1,41 @@
+# Issue #265 実装状況レビュー
+
+## 結論
+
+Issue #265「画面ごとの段階的移行」は、本実装で着手済みになった。
+
+GitHub 上の Issue #265 は open のままで、本文の目的は「1 画面ずつ共通 state を埋め込み、PR を分けて移行する」ことになっている。依存先の Issue #264「共通 state 型の設計」は closed/completed で、ローカルにも `docs/issue-264-common-state-design-2026-05-05.md` が存在するため、設計までは完了していた。
+
+今回、#264 の方針に沿って `SelectionState<K>` を追加し、`Installed::PluginList` と `Marketplaces::MarketList` の一覧選択 state を共通型へ移行した。
+
+## 確認結果
+
+- `src/tui/manager/core/selection_state.rs` に `SelectionState<K>` を追加した。
+- `src/tui/manager/core.rs` から `SelectionState` を re-export した。
+- `src/tui/manager/screens/installed/model.rs` の `PluginList` は、`selected_id` と `ListState` の直接保持から `selection: SelectionState<PluginId>` へ移行した。
+- `src/tui/manager/screens/marketplaces/model.rs` の `MarketList` は、`selected_id` と `ListState` の直接保持から `selection: SelectionState<String>` へ移行した。
+- `from_cache()` / `to_cache()` の stale ID 検証と semantic cache は各画面側に残した。
+- `Discover` は実データリストと stale ID の検証先が未定義であるため、今回の移行対象外にした。
+
+## #264 設計との差分
+
+`docs/issue-264-common-state-design-2026-05-05.md` では、共通化候補を `ListState + selected key` の小型 helper に限定し、将来の `SelectionState<K>` を画面 `Model` へ composition で埋め込む方針が書かれている。
+
+同ドキュメントの移行順序に対する対応状況は次のとおり。
+
+1. `src/tui/manager/core/selection_state.rs` を追加した。
+2. `Installed::Model::PluginList` の `selected_id` と `state` を `SelectionState<PluginId>` に置き換えた。
+3. `Marketplaces::Model::MarketList` の `selected_id` と `state` を `SelectionState<String>` に置き換えた。
+4. `Discover` は後続判断に残した。
+5. 既存の `from_cache()` / `to_cache()` / update のテストは新しい `selection` 構造へ追従し、挙動を維持した。
+
+## 判定
+
+「段階的移行の初回実装済み」が妥当。
+
+`Installed` と `Marketplaces` の主要な重複箇所は共通 state 型へ移行済み。`Discover` は現時点で UI 未実装寄りのため、実データリストの責務が固まった時点で追加移行を検討する。
+
+## 検証
+
+- `cargo check`
+- `cargo test`（1600 tests passed）

--- a/docs/issue-265-implementation-check-2026-05-06.md
+++ b/docs/issue-265-implementation-check-2026-05-06.md
@@ -4,7 +4,7 @@
 
 Issue #265「画面ごとの段階的移行」は、本実装で着手済みになった。
 
-GitHub 上の Issue #265 は open のままで、本文の目的は「1 画面ずつ共通 state を埋め込み、PR を分けて移行する」ことになっている。依存先の Issue #264「共通 state 型の設計」は closed/completed で、ローカルにも `docs/issue-264-common-state-design-2026-05-05.md` が存在するため、設計までは完了していた。
+Issue #265 の本文の目的は「1 画面ずつ共通 state を埋め込み、PR を分けて移行する」ことになっている。依存先の Issue #264「共通 state 型の設計」は、ローカルにも `docs/issue-264-common-state-design-2026-05-05.md` が存在するため、設計内容を参照できる状態だった。
 
 今回、#264 の方針に沿って `SelectionState<K>` を追加し、`Installed::PluginList` と `Marketplaces::MarketList` の一覧選択 state を共通型へ移行した。
 

--- a/src/tui/manager/core.rs
+++ b/src/tui/manager/core.rs
@@ -11,6 +11,7 @@ mod common;
 mod data;
 pub mod filter;
 pub mod layout;
+mod selection_state;
 pub mod style;
 
 #[cfg(test)]
@@ -33,3 +34,4 @@ pub use common::{
 pub use common::{BLOCK_BORDER_WIDTH, LIST_HIGHLIGHT_WIDTH};
 pub use data::{DataStore, MarketplaceItem, PluginId, PluginKey};
 pub use filter::filter_plugins;
+pub use selection_state::SelectionState;

--- a/src/tui/manager/core/app.rs
+++ b/src/tui/manager/core/app.rs
@@ -323,9 +323,9 @@ fn clamp_selection(model: &mut Model) {
     if let Screen::Installed(m) = &mut model.screen {
         let filtered = filter_plugins(&model.data.plugins, &model.filter_text);
         if let installed::Model::PluginList { selection, .. } = m {
-            if let Some(id) = selection.selected_id.as_ref() {
+            if let Some(id) = selection.selected_id() {
                 if let Some(idx) = filtered.iter().position(|p| p.id() == id.as_str()) {
-                    selection.state.select(Some(idx));
+                    selection.select_index(Some(idx));
                 } else if !filtered.is_empty() {
                     selection.set(Some(filtered[0].id().to_string()), Some(0));
                 } else {
@@ -334,7 +334,7 @@ fn clamp_selection(model: &mut Model) {
             } else if !filtered.is_empty() {
                 selection.set(Some(filtered[0].id().to_string()), Some(0));
             } else {
-                selection.state.select(None);
+                selection.select_index(None);
             }
         }
     }

--- a/src/tui/manager/core/app.rs
+++ b/src/tui/manager/core/app.rs
@@ -322,25 +322,19 @@ pub fn update(model: &mut Model, msg: Msg) -> AppUpdateEffect {
 fn clamp_selection(model: &mut Model) {
     if let Screen::Installed(m) = &mut model.screen {
         let filtered = filter_plugins(&model.data.plugins, &model.filter_text);
-        if let installed::Model::PluginList {
-            selected_id, state, ..
-        } = m
-        {
-            if let Some(id) = selected_id.as_ref() {
+        if let installed::Model::PluginList { selection, .. } = m {
+            if let Some(id) = selection.selected_id.as_ref() {
                 if let Some(idx) = filtered.iter().position(|p| p.id() == id.as_str()) {
-                    state.select(Some(idx));
+                    selection.state.select(Some(idx));
                 } else if !filtered.is_empty() {
-                    state.select(Some(0));
-                    *selected_id = Some(filtered[0].id().to_string());
+                    selection.set(Some(filtered[0].id().to_string()), Some(0));
                 } else {
-                    state.select(None);
-                    *selected_id = None;
+                    selection.set(None, None);
                 }
             } else if !filtered.is_empty() {
-                state.select(Some(0));
-                *selected_id = Some(filtered[0].id().to_string());
+                selection.set(Some(filtered[0].id().to_string()), Some(0));
             } else {
-                state.select(None);
+                selection.state.select(None);
             }
         }
     }

--- a/src/tui/manager/core/selection_state.rs
+++ b/src/tui/manager/core/selection_state.rs
@@ -5,8 +5,8 @@ use ratatui::widgets::ListState;
 /// semantic な選択 ID と ratatui のリストカーソルを束ねた選択状態。
 #[derive(Debug, Clone, Default)]
 pub struct SelectionState<K> {
-    pub selected_id: Option<K>,
-    pub state: ListState,
+    selected_id: Option<K>,
+    state: ListState,
 }
 
 impl<K> SelectionState<K> {
@@ -21,16 +21,16 @@ impl<K> SelectionState<K> {
         self.selected_id.as_ref()
     }
 
-    pub fn selected_id_mut(&mut self) -> &mut Option<K> {
-        &mut self.selected_id
+    pub fn selected_index(&self) -> Option<usize> {
+        self.state.selected()
     }
 
     pub fn list_state(&self) -> &ListState {
         &self.state
     }
 
-    pub fn list_state_mut(&mut self) -> &mut ListState {
-        &mut self.state
+    pub fn select_index(&mut self, selected_index: Option<usize>) {
+        self.state.select(selected_index);
     }
 
     pub fn set(&mut self, selected_id: Option<K>, selected_index: Option<usize>) {

--- a/src/tui/manager/core/selection_state.rs
+++ b/src/tui/manager/core/selection_state.rs
@@ -1,0 +1,40 @@
+//! TUI 画面で共有するリスト選択状態。
+
+use ratatui::widgets::ListState;
+
+/// semantic な選択 ID と ratatui のリストカーソルを束ねた選択状態。
+#[derive(Debug, Clone, Default)]
+pub struct SelectionState<K> {
+    pub selected_id: Option<K>,
+    pub state: ListState,
+}
+
+impl<K> SelectionState<K> {
+    /// 選択 ID とリスト index から選択状態を作成する。
+    pub fn new(selected_id: Option<K>, selected_index: Option<usize>) -> Self {
+        let mut state = ListState::default();
+        state.select(selected_index);
+        Self { selected_id, state }
+    }
+
+    pub fn selected_id(&self) -> Option<&K> {
+        self.selected_id.as_ref()
+    }
+
+    pub fn selected_id_mut(&mut self) -> &mut Option<K> {
+        &mut self.selected_id
+    }
+
+    pub fn list_state(&self) -> &ListState {
+        &self.state
+    }
+
+    pub fn list_state_mut(&mut self) -> &mut ListState {
+        &mut self.state
+    }
+
+    pub fn set(&mut self, selected_id: Option<K>, selected_index: Option<usize>) {
+        self.selected_id = selected_id;
+        self.state.select(selected_index);
+    }
+}

--- a/src/tui/manager/screens/installed/model.rs
+++ b/src/tui/manager/screens/installed/model.rs
@@ -239,14 +239,12 @@ impl Model {
     }
 
     /// 現在選択中の ListState を取得
-    pub fn current_state_mut(&mut self) -> &mut ListState {
+    pub fn current_state_mut(&mut self) -> Option<&mut ListState> {
         match self {
-            Model::PluginList { .. } => {
-                unreachable!("PluginList selection is managed through SelectionState")
-            }
-            Model::PluginDetail { state, .. } => state,
-            Model::ComponentTypes { state, .. } => state,
-            Model::ComponentList { state, .. } => state,
+            Model::PluginList { .. } => None,
+            Model::PluginDetail { state, .. } => Some(state),
+            Model::ComponentTypes { state, .. } => Some(state),
+            Model::ComponentList { state, .. } => Some(state),
         }
     }
 }

--- a/src/tui/manager/screens/installed/model.rs
+++ b/src/tui/manager/screens/installed/model.rs
@@ -203,7 +203,7 @@ impl Model {
                 marked_ids,
                 ..
             } => CacheState {
-                selected_plugin_id: selection.selected_id.clone(),
+                selected_plugin_id: selection.selected_id().cloned(),
                 marked_ids: marked_ids.clone(),
             },
             Model::PluginDetail {
@@ -241,7 +241,9 @@ impl Model {
     /// 現在選択中の ListState を取得
     pub fn current_state_mut(&mut self) -> &mut ListState {
         match self {
-            Model::PluginList { selection, .. } => selection.list_state_mut(),
+            Model::PluginList { .. } => {
+                unreachable!("PluginList selection is managed through SelectionState")
+            }
             Model::PluginDetail { state, .. } => state,
             Model::ComponentTypes { state, .. } => state,
             Model::ComponentList { state, .. } => state,

--- a/src/tui/manager/screens/installed/model.rs
+++ b/src/tui/manager/screens/installed/model.rs
@@ -3,7 +3,7 @@
 //! 画面状態とメッセージ型を定義。
 
 use crate::component::ComponentKind;
-use crate::tui::manager::core::{DataStore, PluginId};
+use crate::tui::manager::core::{DataStore, PluginId, SelectionState};
 use crossterm::event::KeyCode;
 use ratatui::prelude::*;
 use ratatui::widgets::ListState;
@@ -106,8 +106,7 @@ impl DetailAction {
 pub enum Model {
     /// プラグイン一覧画面
     PluginList {
-        selected_id: Option<PluginId>,
-        state: ListState,
+        selection: SelectionState<PluginId>,
         marked_ids: HashSet<PluginId>,
         update_statuses: HashMap<PluginId, UpdateStatusDisplay>,
     },
@@ -151,13 +150,9 @@ impl Model {
     /// * `data` - Data store providing the installed plugin list.
     pub fn new(data: &DataStore) -> Self {
         let selected_id = data.plugins.first().map(|p| p.id().to_string());
-        let mut state = ListState::default();
-        if selected_id.is_some() {
-            state.select(Some(0));
-        }
+        let selected_index = selected_id.as_ref().map(|_| 0);
         Model::PluginList {
-            selected_id,
-            state,
+            selection: SelectionState::new(selected_id, selected_index),
             marked_ids: HashSet::new(),
             update_statuses: HashMap::new(),
         }
@@ -185,9 +180,6 @@ impl Model {
                 Some(0)
             });
 
-        let mut state = ListState::default();
-        state.select(index);
-
         // マーク状態を復元（DataStore に存在しないプラグインIDは除外）
         let marked_ids = cache
             .marked_ids
@@ -197,8 +189,7 @@ impl Model {
             .collect();
 
         Model::PluginList {
-            selected_id,
-            state,
+            selection: SelectionState::new(selected_id, index),
             marked_ids,
             update_statuses: HashMap::new(),
         }
@@ -208,11 +199,11 @@ impl Model {
     pub fn to_cache(&self) -> CacheState {
         match self {
             Model::PluginList {
-                selected_id,
+                selection,
                 marked_ids,
                 ..
             } => CacheState {
-                selected_plugin_id: selected_id.clone(),
+                selected_plugin_id: selection.selected_id.clone(),
                 marked_ids: marked_ids.clone(),
             },
             Model::PluginDetail {
@@ -250,7 +241,7 @@ impl Model {
     /// 現在選択中の ListState を取得
     pub fn current_state_mut(&mut self) -> &mut ListState {
         match self {
-            Model::PluginList { state, .. } => state,
+            Model::PluginList { selection, .. } => selection.list_state_mut(),
             Model::PluginDetail { state, .. } => state,
             Model::ComponentTypes { state, .. } => state,
             Model::ComponentList { state, .. } => state,

--- a/src/tui/manager/screens/installed/update.rs
+++ b/src/tui/manager/screens/installed/update.rs
@@ -97,7 +97,7 @@ fn toggle_mark(model: &mut Model) {
         ..
     } = model
     {
-        if let Some(id) = selection.selected_id.as_ref() {
+        if let Some(id) = selection.selected_id() {
             if marked_ids.contains(id) {
                 marked_ids.remove(id);
             } else {
@@ -264,7 +264,7 @@ fn execute_batch_with(
 
         // reload 後にフィルタ済みリストに対して選択状態を再同期
         let filtered = filter_plugins(&data.plugins, filter_text);
-        let current_selected = selection.selected_id.as_ref();
+        let current_selected = selection.selected_id();
         let new_idx = current_selected
             .and_then(|id| filtered.iter().position(|p| p.id() == id.as_str()))
             .or(if filtered.is_empty() { None } else { Some(0) });
@@ -288,6 +288,17 @@ fn select_prev(model: &mut Model, data: &DataStore, filter_text: &str) -> bool {
         }
         return false;
     }
+    if let Model::PluginList { selection, .. } = model {
+        let current = selection.selected_index().unwrap_or(0);
+        if current == 0 {
+            return true;
+        }
+        let prev = current.saturating_sub(1);
+        selection.select_index(Some(prev));
+        update_selected_id(model, data, filter_text);
+        return false;
+    }
+
     let state = model.current_state_mut();
     let current = state.selected().unwrap_or(0);
     if current == 0 {
@@ -310,6 +321,14 @@ fn select_next(model: &mut Model, data: &DataStore, filter_text: &str) {
     if len == 0 {
         return;
     }
+    if let Model::PluginList { selection, .. } = model {
+        let current = selection.selected_index().unwrap_or(0);
+        let next = (current + 1).min(len.saturating_sub(1));
+        selection.select_index(Some(next));
+        update_selected_id(model, data, filter_text);
+        return;
+    }
+
     let state = model.current_state_mut();
     let current = state.selected().unwrap_or(0);
     let next = (current + 1).min(len.saturating_sub(1));
@@ -328,7 +347,7 @@ fn enter(model: &mut Model, data: &mut DataStore, filter_text: &str) -> UpdateEf
             ..
         } => {
             // PluginList → PluginDetail へ遷移（マーク状態を保存）
-            if let Some(plugin_id) = selection.selected_id.clone() {
+            if let Some(plugin_id) = selection.selected_id().cloned() {
                 if data.find_plugin(&plugin_id).is_some() {
                     let saved_marked = std::mem::take(marked_ids);
                     let saved_statuses = std::mem::take(update_statuses);
@@ -632,9 +651,9 @@ fn list_len(model: &Model, data: &DataStore, filter_text: &str) -> usize {
 /// selected_id を現在のインデックスから更新
 fn update_selected_id(model: &mut Model, data: &DataStore, filter_text: &str) {
     if let Model::PluginList { selection, .. } = model {
-        if let Some(idx) = selection.state.selected() {
+        if let Some(idx) = selection.selected_index() {
             let filtered = filter_plugins(&data.plugins, filter_text);
-            selection.selected_id = filtered.get(idx).map(|p| p.id().to_string());
+            selection.set(filtered.get(idx).map(|p| p.id().to_string()), Some(idx));
         }
     }
 }

--- a/src/tui/manager/screens/installed/update.rs
+++ b/src/tui/manager/screens/installed/update.rs
@@ -4,7 +4,7 @@
 
 use super::actions;
 use super::model::{DetailAction, Model, Msg, UpdateStatusDisplay};
-use crate::tui::manager::core::{filter_plugins, DataStore, PluginKey};
+use crate::tui::manager::core::{filter_plugins, DataStore, PluginKey, SelectionState};
 use ratatui::widgets::ListState;
 use std::collections::{HashMap, HashSet};
 
@@ -92,12 +92,12 @@ pub fn update(
 /// 個別プラグインのマークをトグル
 fn toggle_mark(model: &mut Model) {
     if let Model::PluginList {
-        selected_id,
+        selection,
         marked_ids,
         ..
     } = model
     {
-        if let Some(id) = selected_id.as_ref() {
+        if let Some(id) = selection.selected_id.as_ref() {
             if marked_ids.contains(id) {
                 marked_ids.remove(id);
             } else {
@@ -201,8 +201,7 @@ fn execute_batch_with(
     if let Model::PluginList {
         marked_ids,
         update_statuses,
-        selected_id,
-        state,
+        selection,
     } = model
     {
         // update_statuses から Updating のプラグイン ID を収集
@@ -265,13 +264,15 @@ fn execute_batch_with(
 
         // reload 後にフィルタ済みリストに対して選択状態を再同期
         let filtered = filter_plugins(&data.plugins, filter_text);
-        let current_selected = selected_id.as_ref();
+        let current_selected = selection.selected_id.as_ref();
         let new_idx = current_selected
             .and_then(|id| filtered.iter().position(|p| p.id() == id.as_str()))
             .or(if filtered.is_empty() { None } else { Some(0) });
 
-        state.select(new_idx);
-        *selected_id = new_idx.and_then(|idx| filtered.get(idx).map(|p| p.id().to_string()));
+        selection.set(
+            new_idx.and_then(|idx| filtered.get(idx).map(|p| p.id().to_string())),
+            new_idx,
+        );
     }
 }
 
@@ -321,13 +322,13 @@ fn select_next(model: &mut Model, data: &DataStore, filter_text: &str) {
 fn enter(model: &mut Model, data: &mut DataStore, filter_text: &str) -> UpdateEffect {
     match model {
         Model::PluginList {
-            selected_id,
+            selection,
             marked_ids,
             update_statuses,
             ..
         } => {
             // PluginList → PluginDetail へ遷移（マーク状態を保存）
-            if let Some(plugin_id) = selected_id.clone() {
+            if let Some(plugin_id) = selection.selected_id.clone() {
                 if data.find_plugin(&plugin_id).is_some() {
                     let saved_marked = std::mem::take(marked_ids);
                     let saved_statuses = std::mem::take(update_statuses);
@@ -406,8 +407,7 @@ fn enter(model: &mut Model, data: &mut DataStore, filter_text: &str) -> UpdateEf
                                 None
                             };
                             *model = Model::PluginList {
-                                selected_id,
-                                state: new_state,
+                                selection: SelectionState::new(selected_id, new_state.selected()),
                                 marked_ids: restored_marks,
                                 update_statuses: restored_statuses,
                             };
@@ -449,8 +449,7 @@ fn enter(model: &mut Model, data: &mut DataStore, filter_text: &str) -> UpdateEf
                         None
                     };
                     *model = Model::PluginList {
-                        selected_id,
-                        state: new_state,
+                        selection: SelectionState::new(selected_id, new_state.selected()),
                         marked_ids: restored_marks,
                         update_statuses: restored_statuses,
                     };
@@ -477,8 +476,7 @@ fn enter(model: &mut Model, data: &mut DataStore, filter_text: &str) -> UpdateEf
                         None
                     };
                     *model = Model::PluginList {
-                        selected_id,
-                        state: new_state,
+                        selection: SelectionState::new(selected_id, new_state.selected()),
                         marked_ids: restored_marks,
                         update_statuses: restored_statuses,
                     };
@@ -557,8 +555,7 @@ fn back(model: &mut Model, filter_text: &str, data: &DataStore) {
                 None
             };
             *model = Model::PluginList {
-                selected_id,
-                state: new_state,
+                selection: SelectionState::new(selected_id, new_state.selected()),
                 marked_ids: restored_marks,
                 update_statuses: restored_statuses,
             };
@@ -634,13 +631,10 @@ fn list_len(model: &Model, data: &DataStore, filter_text: &str) -> usize {
 
 /// selected_id を現在のインデックスから更新
 fn update_selected_id(model: &mut Model, data: &DataStore, filter_text: &str) {
-    if let Model::PluginList {
-        selected_id, state, ..
-    } = model
-    {
-        if let Some(idx) = state.selected() {
+    if let Model::PluginList { selection, .. } = model {
+        if let Some(idx) = selection.state.selected() {
             let filtered = filter_plugins(&data.plugins, filter_text);
-            *selected_id = filtered.get(idx).map(|p| p.id().to_string());
+            selection.selected_id = filtered.get(idx).map(|p| p.id().to_string());
         }
     }
 }

--- a/src/tui/manager/screens/installed/update.rs
+++ b/src/tui/manager/screens/installed/update.rs
@@ -299,19 +299,20 @@ fn select_prev(model: &mut Model, data: &DataStore, filter_text: &str) -> bool {
         return false;
     }
 
-    let state = model.current_state_mut();
-    let current = state.selected().unwrap_or(0);
-    if current == 0 {
-        // PluginList の先頭ならフィルタへフォーカス移動
-        if matches!(model, Model::PluginList { .. }) {
-            return true;
+    if let Some(state) = model.current_state_mut() {
+        let current = state.selected().unwrap_or(0);
+        if current == 0 {
+            // PluginList の先頭ならフィルタへフォーカス移動
+            if matches!(model, Model::PluginList { .. }) {
+                return true;
+            }
+            return false;
         }
-        return false;
-    }
-    let prev = current.saturating_sub(1);
-    state.select(Some(prev));
+        let prev = current.saturating_sub(1);
+        state.select(Some(prev));
 
-    update_selected_id(model, data, filter_text);
+        update_selected_id(model, data, filter_text);
+    }
     false
 }
 
@@ -329,12 +330,13 @@ fn select_next(model: &mut Model, data: &DataStore, filter_text: &str) {
         return;
     }
 
-    let state = model.current_state_mut();
-    let current = state.selected().unwrap_or(0);
-    let next = (current + 1).min(len.saturating_sub(1));
-    state.select(Some(next));
+    if let Some(state) = model.current_state_mut() {
+        let current = state.selected().unwrap_or(0);
+        let next = (current + 1).min(len.saturating_sub(1));
+        state.select(Some(next));
 
-    update_selected_id(model, data, filter_text);
+        update_selected_id(model, data, filter_text);
+    }
 }
 
 /// 次の階層へ遷移

--- a/src/tui/manager/screens/installed/update.rs
+++ b/src/tui/manager/screens/installed/update.rs
@@ -302,10 +302,6 @@ fn select_prev(model: &mut Model, data: &DataStore, filter_text: &str) -> bool {
     if let Some(state) = model.current_state_mut() {
         let current = state.selected().unwrap_or(0);
         if current == 0 {
-            // PluginList の先頭ならフィルタへフォーカス移動
-            if matches!(model, Model::PluginList { .. }) {
-                return true;
-            }
             return false;
         }
         let prev = current.saturating_sub(1);

--- a/src/tui/manager/screens/installed/view.rs
+++ b/src/tui/manager/screens/installed/view.rs
@@ -70,7 +70,7 @@ pub fn view(
         } => {
             view_plugin_list(
                 f,
-                selection.state.clone(),
+                *selection.list_state(),
                 &ctx,
                 marked_ids,
                 update_statuses,

--- a/src/tui/manager/screens/installed/view.rs
+++ b/src/tui/manager/screens/installed/view.rs
@@ -63,12 +63,18 @@ pub fn view(
     };
     match model {
         Model::PluginList {
-            state,
+            selection,
             marked_ids,
             update_statuses,
             ..
         } => {
-            view_plugin_list(f, *state, &ctx, marked_ids, update_statuses);
+            view_plugin_list(
+                f,
+                selection.state.clone(),
+                &ctx,
+                marked_ids,
+                update_statuses,
+            );
         }
         Model::PluginDetail {
             plugin_id, state, ..

--- a/src/tui/manager/screens/marketplaces/model.rs
+++ b/src/tui/manager/screens/marketplaces/model.rs
@@ -226,7 +226,7 @@ impl Model {
     pub fn to_cache(&self) -> CacheState {
         match self {
             Model::MarketList { selection, .. } => CacheState {
-                selected_id: selection.selected_id.clone(),
+                selected_id: selection.selected_id().cloned(),
             },
             Model::MarketDetail {
                 marketplace_name, ..

--- a/src/tui/manager/screens/marketplaces/model.rs
+++ b/src/tui/manager/screens/marketplaces/model.rs
@@ -4,7 +4,7 @@
 
 use crate::component::Scope;
 use crate::marketplace::PluginSource;
-use crate::tui::manager::core::DataStore;
+use crate::tui::manager::core::{DataStore, SelectionState};
 use crossterm::event::KeyCode;
 use ratatui::widgets::ListState;
 use std::collections::HashSet;
@@ -113,8 +113,7 @@ pub struct InstallSummary {
 pub enum Model {
     /// マーケットプレイス一覧
     MarketList {
-        selected_id: Option<String>,
-        state: ListState,
+        selection: SelectionState<String>,
         operation_status: Option<OperationStatus>,
         error_message: Option<String>,
     },
@@ -190,12 +189,9 @@ impl Model {
     /// * `data` - Data store providing the marketplace list.
     pub fn new(data: &DataStore) -> Self {
         let selected_id = data.marketplaces.first().map(|m| m.name.clone());
-        let mut state = ListState::default();
         // マーケットプレイスがあれば最初を選択、なければ "+ Add new" (index 0) を選択
-        state.select(Some(0));
         Model::MarketList {
-            selected_id,
-            state,
+            selection: SelectionState::new(selected_id, Some(0)),
             operation_status: None,
             error_message: None,
         }
@@ -219,12 +215,8 @@ impl Model {
             .and_then(|id| data.marketplace_index(id))
             .unwrap_or(0);
 
-        let mut state = ListState::default();
-        state.select(Some(index));
-
         Model::MarketList {
-            selected_id,
-            state,
+            selection: SelectionState::new(selected_id, Some(index)),
             operation_status: None,
             error_message: None,
         }
@@ -233,8 +225,8 @@ impl Model {
     /// キャッシュ状態を取得
     pub fn to_cache(&self) -> CacheState {
         match self {
-            Model::MarketList { selected_id, .. } => CacheState {
-                selected_id: selected_id.clone(),
+            Model::MarketList { selection, .. } => CacheState {
+                selected_id: selection.selected_id.clone(),
             },
             Model::MarketDetail {
                 marketplace_name, ..

--- a/src/tui/manager/screens/marketplaces/model_test.rs
+++ b/src/tui/manager/screens/marketplaces/model_test.rs
@@ -29,8 +29,11 @@ fn new_with_marketplaces_selects_first() {
     let (_temp_dir, data) = make_data(&["market-a", "market-b"]);
     let model = Model::new(&data);
     if let Model::MarketList { selection, .. } = &model {
-        assert_eq!(selection.selected_id.as_deref(), Some("market-a"));
-        assert_eq!(selection.state.selected(), Some(0));
+        assert_eq!(
+            selection.selected_id().map(String::as_str),
+            Some("market-a")
+        );
+        assert_eq!(selection.selected_index(), Some(0));
     } else {
         panic!("Expected MarketList");
     }
@@ -41,8 +44,8 @@ fn new_with_empty_marketplaces() {
     let (_temp_dir, data) = make_data(&[]);
     let model = Model::new(&data);
     if let Model::MarketList { selection, .. } = &model {
-        assert_eq!(selection.selected_id, None);
-        assert_eq!(selection.state.selected(), Some(0)); // "+ Add new" is selected
+        assert_eq!(selection.selected_id(), None);
+        assert_eq!(selection.selected_index(), Some(0)); // "+ Add new" is selected
     } else {
         panic!("Expected MarketList");
     }
@@ -418,8 +421,11 @@ fn to_cache_and_from_cache_round_trip() {
 
     let restored = Model::from_cache(&data, &cache);
     if let Model::MarketList { selection, .. } = &restored {
-        assert_eq!(selection.selected_id.as_deref(), Some("market-a"));
-        assert_eq!(selection.state.selected(), Some(0));
+        assert_eq!(
+            selection.selected_id().map(String::as_str),
+            Some("market-a")
+        );
+        assert_eq!(selection.selected_index(), Some(0));
     } else {
         panic!("Expected MarketList");
     }
@@ -433,7 +439,10 @@ fn from_cache_with_stale_id() {
     };
     let model = Model::from_cache(&data, &cache);
     if let Model::MarketList { selection, .. } = &model {
-        assert_eq!(selection.selected_id.as_deref(), Some("market-a"));
+        assert_eq!(
+            selection.selected_id().map(String::as_str),
+            Some("market-a")
+        );
     } else {
         panic!("Expected MarketList");
     }

--- a/src/tui/manager/screens/marketplaces/model_test.rs
+++ b/src/tui/manager/screens/marketplaces/model_test.rs
@@ -28,12 +28,9 @@ fn make_data(names: &[&str]) -> (tempfile::TempDir, DataStore) {
 fn new_with_marketplaces_selects_first() {
     let (_temp_dir, data) = make_data(&["market-a", "market-b"]);
     let model = Model::new(&data);
-    if let Model::MarketList {
-        selected_id, state, ..
-    } = &model
-    {
-        assert_eq!(selected_id.as_deref(), Some("market-a"));
-        assert_eq!(state.selected(), Some(0));
+    if let Model::MarketList { selection, .. } = &model {
+        assert_eq!(selection.selected_id.as_deref(), Some("market-a"));
+        assert_eq!(selection.state.selected(), Some(0));
     } else {
         panic!("Expected MarketList");
     }
@@ -43,12 +40,9 @@ fn new_with_marketplaces_selects_first() {
 fn new_with_empty_marketplaces() {
     let (_temp_dir, data) = make_data(&[]);
     let model = Model::new(&data);
-    if let Model::MarketList {
-        selected_id, state, ..
-    } = &model
-    {
-        assert_eq!(selected_id, &None);
-        assert_eq!(state.selected(), Some(0)); // "+ Add new" is selected
+    if let Model::MarketList { selection, .. } = &model {
+        assert_eq!(selection.selected_id, None);
+        assert_eq!(selection.state.selected(), Some(0)); // "+ Add new" is selected
     } else {
         panic!("Expected MarketList");
     }
@@ -423,12 +417,9 @@ fn to_cache_and_from_cache_round_trip() {
     assert_eq!(cache.selected_id.as_deref(), Some("market-a"));
 
     let restored = Model::from_cache(&data, &cache);
-    if let Model::MarketList {
-        selected_id, state, ..
-    } = &restored
-    {
-        assert_eq!(selected_id.as_deref(), Some("market-a"));
-        assert_eq!(state.selected(), Some(0));
+    if let Model::MarketList { selection, .. } = &restored {
+        assert_eq!(selection.selected_id.as_deref(), Some("market-a"));
+        assert_eq!(selection.state.selected(), Some(0));
     } else {
         panic!("Expected MarketList");
     }
@@ -441,8 +432,8 @@ fn from_cache_with_stale_id() {
         selected_id: Some("deleted-market".to_string()),
     };
     let model = Model::from_cache(&data, &cache);
-    if let Model::MarketList { selected_id, .. } = &model {
-        assert_eq!(selected_id.as_deref(), Some("market-a"));
+    if let Model::MarketList { selection, .. } = &model {
+        assert_eq!(selection.selected_id.as_deref(), Some("market-a"));
     } else {
         panic!("Expected MarketList");
     }

--- a/src/tui/manager/screens/marketplaces/update.rs
+++ b/src/tui/manager/screens/marketplaces/update.rs
@@ -104,7 +104,7 @@ fn market_selection(
 fn select_prev(model: &mut Model, data: &DataStore) {
     match model {
         Model::MarketList { selection, .. } => {
-            let current = selection.state.selected().unwrap_or(0);
+            let current = selection.selected_index().unwrap_or(0);
             if current == 0 {
                 return;
             }
@@ -179,7 +179,7 @@ fn select_next(model: &mut Model, data: &DataStore) {
     match model {
         Model::MarketList { selection, .. } => {
             let len = market_list_len(data);
-            let current = selection.state.selected().unwrap_or(0);
+            let current = selection.selected_index().unwrap_or(0);
             let next = (current + 1).min(len - 1);
             selection.set(
                 data.marketplaces.get(next).map(|m| m.name.clone()),
@@ -258,7 +258,7 @@ fn enter(model: &mut Model, data: &mut DataStore) -> UpdateEffect {
                 return UpdateEffect::none();
             }
 
-            if let Some(name) = selection.selected_id.clone() {
+            if let Some(name) = selection.selected_id().cloned() {
                 // 通常項目 -> MarketDetail
                 let mut state = ListState::default();
                 state.select(Some(0));
@@ -1010,7 +1010,7 @@ fn update_market(model: &mut Model) -> UpdateEffect {
         if operation_status.is_some() {
             return UpdateEffect::none();
         }
-        if let Some(name) = selection.selected_id.clone() {
+        if let Some(name) = selection.selected_id().cloned() {
             *error_message = None;
             *operation_status = Some(OperationStatus::Updating(name));
             return UpdateEffect::phase2(Msg::ExecuteUpdate);
@@ -1092,9 +1092,9 @@ fn execute_update_with(
                     *error_message = Some(format!("Failed to update: {}", errors.join(", ")));
                 }
                 // 選択状態を維持
-                if let Some(id) = selection.selected_id.as_ref() {
+                if let Some(id) = selection.selected_id() {
                     let idx = data.marketplace_index(id).unwrap_or(0);
-                    selection.state.select(Some(idx));
+                    selection.select_index(Some(idx));
                 }
             }
             other => {

--- a/src/tui/manager/screens/marketplaces/update.rs
+++ b/src/tui/manager/screens/marketplaces/update.rs
@@ -4,7 +4,7 @@ use super::actions;
 use super::model::{AddFormModel, DetailAction, Model, Msg, OperationStatus};
 use crate::marketplace::normalize_name;
 use crate::repo;
-use crate::tui::manager::core::{DataStore, MarketplaceItem};
+use crate::tui::manager::core::{DataStore, MarketplaceItem, SelectionState};
 use ratatui::widgets::ListState;
 use std::collections::HashSet;
 
@@ -93,19 +93,26 @@ fn market_list_len(data: &DataStore) -> usize {
     data.marketplaces.len() + 1
 }
 
+fn market_selection(
+    selected_id: Option<String>,
+    selected_index: Option<usize>,
+) -> SelectionState<String> {
+    SelectionState::new(selected_id, selected_index)
+}
+
 /// 選択を上に移動
 fn select_prev(model: &mut Model, data: &DataStore) {
     match model {
-        Model::MarketList {
-            state, selected_id, ..
-        } => {
-            let current = state.selected().unwrap_or(0);
+        Model::MarketList { selection, .. } => {
+            let current = selection.state.selected().unwrap_or(0);
             if current == 0 {
                 return;
             }
             let prev = current - 1;
-            state.select(Some(prev));
-            *selected_id = data.marketplaces.get(prev).map(|m| m.name.clone());
+            selection.set(
+                data.marketplaces.get(prev).map(|m| m.name.clone()),
+                Some(prev),
+            );
         }
         Model::MarketDetail { state, .. } => {
             let current = state.selected().unwrap_or(0);
@@ -170,14 +177,14 @@ fn select_prev(model: &mut Model, data: &DataStore) {
 /// 選択を下に移動
 fn select_next(model: &mut Model, data: &DataStore) {
     match model {
-        Model::MarketList {
-            state, selected_id, ..
-        } => {
+        Model::MarketList { selection, .. } => {
             let len = market_list_len(data);
-            let current = state.selected().unwrap_or(0);
+            let current = selection.state.selected().unwrap_or(0);
             let next = (current + 1).min(len - 1);
-            state.select(Some(next));
-            *selected_id = data.marketplaces.get(next).map(|m| m.name.clone());
+            selection.set(
+                data.marketplaces.get(next).map(|m| m.name.clone()),
+                Some(next),
+            );
         }
         Model::MarketDetail { state, .. } => {
             let len = DetailAction::all().len();
@@ -242,7 +249,7 @@ fn select_next(model: &mut Model, data: &DataStore) {
 fn enter(model: &mut Model, data: &mut DataStore) -> UpdateEffect {
     match model {
         Model::MarketList {
-            selected_id,
+            selection,
             operation_status,
             ..
         } => {
@@ -251,7 +258,7 @@ fn enter(model: &mut Model, data: &mut DataStore) -> UpdateEffect {
                 return UpdateEffect::none();
             }
 
-            if let Some(name) = selected_id.clone() {
+            if let Some(name) = selection.selected_id.clone() {
                 // 通常項目 -> MarketDetail
                 let mut state = ListState::default();
                 state.select(Some(0));
@@ -284,8 +291,7 @@ fn enter(model: &mut Model, data: &mut DataStore) -> UpdateEffect {
                     let mut new_state = ListState::default();
                     new_state.select(Some(data.marketplace_index(&name).unwrap_or(0)));
                     *model = Model::MarketList {
-                        selected_id: Some(name.clone()),
-                        state: new_state,
+                        selection: market_selection(Some(name.clone()), new_state.selected()),
                         operation_status: Some(OperationStatus::Updating(name)),
                         error_message: None,
                     };
@@ -296,8 +302,7 @@ fn enter(model: &mut Model, data: &mut DataStore) -> UpdateEffect {
                     let mut new_state = ListState::default();
                     new_state.select(Some(data.marketplace_index(&name).unwrap_or(0)));
                     *model = Model::MarketList {
-                        selected_id: Some(name.clone()),
-                        state: new_state,
+                        selection: market_selection(Some(name.clone()), new_state.selected()),
                         operation_status: Some(OperationStatus::Removing(name)),
                         error_message: None,
                     };
@@ -490,8 +495,7 @@ fn execute_add_with(
             let mut state = ListState::default();
             state.select(Some(idx));
             *model = Model::MarketList {
-                selected_id: Some(name_owned),
-                state,
+                selection: market_selection(Some(name_owned), state.selected()),
                 operation_status: None,
                 error_message: None,
             };
@@ -543,8 +547,7 @@ fn back(model: &mut Model, data: &DataStore) {
             let mut state = ListState::default();
             state.select(Some(0));
             *model = Model::MarketList {
-                selected_id,
-                state,
+                selection: market_selection(selected_id, state.selected()),
                 operation_status: None,
                 error_message: None,
             };
@@ -554,8 +557,7 @@ fn back(model: &mut Model, data: &DataStore) {
             let old = std::mem::replace(
                 model,
                 Model::MarketList {
-                    selected_id: None,
-                    state: ListState::default(),
+                    selection: SelectionState::default(),
                     operation_status: None,
                     error_message: None,
                 },
@@ -583,8 +585,7 @@ fn back(model: &mut Model, data: &DataStore) {
             let old = std::mem::replace(
                 model,
                 Model::MarketList {
-                    selected_id: None,
-                    state: ListState::default(),
+                    selection: SelectionState::default(),
                     operation_status: None,
                     error_message: None,
                 },
@@ -614,8 +615,7 @@ fn back(model: &mut Model, data: &DataStore) {
             let old = std::mem::replace(
                 model,
                 Model::MarketList {
-                    selected_id: None,
-                    state: ListState::default(),
+                    selection: SelectionState::default(),
                     operation_status: None,
                     error_message: None,
                 },
@@ -664,8 +664,7 @@ fn back_to_market_list(model: &mut Model, data: &DataStore, marketplace_name: St
     let mut state = ListState::default();
     state.select(Some(idx));
     *model = Model::MarketList {
-        selected_id,
-        state,
+        selection: market_selection(selected_id, state.selected()),
         operation_status: None,
         error_message: None,
     };
@@ -688,8 +687,7 @@ fn start_install(model: &mut Model) -> UpdateEffect {
     let (marketplace_name, plugins, selected_plugins) = match std::mem::replace(
         model,
         Model::MarketList {
-            selected_id: None,
-            state: ListState::default(),
+            selection: SelectionState::default(),
             operation_status: None,
             error_message: None,
         },
@@ -733,8 +731,7 @@ fn confirm_scope(model: &mut Model) -> UpdateEffect {
     let old = std::mem::replace(
         model,
         Model::MarketList {
-            selected_id: None,
-            state: ListState::default(),
+            selection: SelectionState::default(),
             operation_status: None,
             error_message: None,
         },
@@ -789,8 +786,7 @@ fn back_to_plugin_browse(model: &mut Model, data: &DataStore) -> UpdateEffect {
     let old = std::mem::replace(
         model,
         Model::MarketList {
-            selected_id: None,
-            state: ListState::default(),
+            selection: SelectionState::default(),
             operation_status: None,
             error_message: None,
         },
@@ -849,8 +845,7 @@ pub(super) fn execute_install_with(
     let old = std::mem::replace(
         model,
         Model::MarketList {
-            selected_id: None,
-            state: ListState::default(),
+            selection: SelectionState::default(),
             operation_status: None,
             error_message: None,
         },
@@ -895,8 +890,7 @@ fn confirm_targets(model: &mut Model) -> UpdateEffect {
     let old = std::mem::replace(
         model,
         Model::MarketList {
-            selected_id: None,
-            state: ListState::default(),
+            selection: SelectionState::default(),
             operation_status: None,
             error_message: None,
         },
@@ -1007,7 +1001,7 @@ fn form_backspace(model: &mut Model) {
 /// 'u' キー: 選択中のマーケットプレイスを更新
 fn update_market(model: &mut Model) -> UpdateEffect {
     if let Model::MarketList {
-        selected_id,
+        selection,
         operation_status,
         error_message,
         ..
@@ -1016,7 +1010,7 @@ fn update_market(model: &mut Model) -> UpdateEffect {
         if operation_status.is_some() {
             return UpdateEffect::none();
         }
-        if let Some(name) = selected_id.clone() {
+        if let Some(name) = selection.selected_id.clone() {
             *error_message = None;
             *operation_status = Some(OperationStatus::Updating(name));
             return UpdateEffect::phase2(Msg::ExecuteUpdate);
@@ -1068,8 +1062,7 @@ fn execute_update_with(
     if let Model::MarketList {
         operation_status,
         error_message,
-        selected_id,
-        state,
+        selection,
     } = model
     {
         match operation_status.take() {
@@ -1077,8 +1070,7 @@ fn execute_update_with(
                 Ok(_) => {
                     reload(data);
                     let idx = data.marketplace_index(&name).unwrap_or(0);
-                    state.select(Some(idx));
-                    *selected_id = Some(name);
+                    selection.set(Some(name), Some(idx));
                     *error_message = None;
                 }
                 Err(e) => {
@@ -1100,9 +1092,9 @@ fn execute_update_with(
                     *error_message = Some(format!("Failed to update: {}", errors.join(", ")));
                 }
                 // 選択状態を維持
-                if let Some(id) = selected_id.as_ref() {
+                if let Some(id) = selection.selected_id.as_ref() {
                     let idx = data.marketplace_index(id).unwrap_or(0);
-                    state.select(Some(idx));
+                    selection.state.select(Some(idx));
                 }
             }
             other => {
@@ -1131,8 +1123,7 @@ fn execute_remove_with(
     if let Model::MarketList {
         operation_status,
         error_message,
-        selected_id,
-        state,
+        selection,
     } = model
     {
         match operation_status.take() {
@@ -1142,8 +1133,7 @@ fn execute_remove_with(
                         reload(data);
                         // 先頭にクランプ
                         let new_selected = data.marketplaces.first().map(|m| m.name.clone());
-                        *selected_id = new_selected;
-                        state.select(Some(0));
+                        selection.set(new_selected, Some(0));
                         *error_message = None;
                     }
                     Err(e) => {

--- a/src/tui/manager/screens/marketplaces/update_test.rs
+++ b/src/tui/manager/screens/marketplaces/update_test.rs
@@ -52,15 +52,15 @@ fn down_moves_selection_in_market_list() {
 
     // 初期状態: index 0 (mp-a), selected_id = Some("mp-a")
     if let Model::MarketList { selection, .. } = &model {
-        assert_eq!(selection.state.selected(), Some(0));
-        assert_eq!(selection.selected_id.as_deref(), Some("mp-a"));
+        assert_eq!(selection.selected_index(), Some(0));
+        assert_eq!(selection.selected_id().map(String::as_str), Some("mp-a"));
     }
 
     update(&mut model, Msg::Down, &mut data);
 
     if let Model::MarketList { selection, .. } = &model {
-        assert_eq!(selection.state.selected(), Some(1));
-        assert_eq!(selection.selected_id.as_deref(), Some("mp-b"));
+        assert_eq!(selection.selected_index(), Some(1));
+        assert_eq!(selection.selected_id().map(String::as_str), Some("mp-b"));
     } else {
         panic!("Expected MarketList");
     }
@@ -75,9 +75,10 @@ fn down_past_last_marketplace_selects_add_new() {
     update(&mut model, Msg::Down, &mut data);
 
     if let Model::MarketList { selection, .. } = &model {
-        assert_eq!(selection.state.selected(), Some(1));
+        assert_eq!(selection.selected_index(), Some(1));
         assert_eq!(
-            selection.selected_id, None,
+            selection.selected_id(),
+            None,
             "At '+ Add new', selected_id should be None"
         );
     } else {
@@ -95,7 +96,7 @@ fn down_does_not_go_past_add_new() {
     update(&mut model, Msg::Down, &mut data); // should stay at 1
 
     if let Model::MarketList { selection, .. } = &model {
-        assert_eq!(selection.state.selected(), Some(1));
+        assert_eq!(selection.selected_index(), Some(1));
     } else {
         panic!("Expected MarketList");
     }
@@ -109,7 +110,7 @@ fn up_does_not_go_past_zero() {
     update(&mut model, Msg::Up, &mut data);
 
     if let Model::MarketList { selection, .. } = &model {
-        assert_eq!(selection.state.selected(), Some(0));
+        assert_eq!(selection.selected_index(), Some(0));
     } else {
         panic!("Expected MarketList");
     }
@@ -128,8 +129,8 @@ fn up_from_add_new_returns_to_last_marketplace() {
     update(&mut model, Msg::Up, &mut data);
 
     if let Model::MarketList { selection, .. } = &model {
-        assert_eq!(selection.state.selected(), Some(1));
-        assert_eq!(selection.selected_id.as_deref(), Some("mp-b"));
+        assert_eq!(selection.selected_index(), Some(1));
+        assert_eq!(selection.selected_id().map(String::as_str), Some("mp-b"));
     } else {
         panic!("Expected MarketList");
     }
@@ -355,7 +356,7 @@ fn detail_back_action_returns_to_market_list() {
     update(&mut model, Msg::Enter, &mut data);
 
     if let Model::MarketList { selection, .. } = &model {
-        assert_eq!(selection.selected_id.as_deref(), Some("mp-a"));
+        assert_eq!(selection.selected_id().map(String::as_str), Some("mp-a"));
     } else {
         panic!("Expected MarketList");
     }
@@ -1269,7 +1270,7 @@ fn back_from_detail_returns_to_market_list() {
     update(&mut model, Msg::Back, &mut data);
 
     if let Model::MarketList { selection, .. } = &model {
-        assert_eq!(selection.selected_id.as_deref(), Some("mp-a"));
+        assert_eq!(selection.selected_id().map(String::as_str), Some("mp-a"));
     } else {
         panic!("Expected MarketList");
     }
@@ -1576,7 +1577,7 @@ fn execute_add_success_transitions_to_market_list() {
         ..
     } = &model
     {
-        assert_eq!(selection.selected_id.as_deref(), Some("my-repo"));
+        assert_eq!(selection.selected_id().map(String::as_str), Some("my-repo"));
         assert!(operation_status.is_none());
     } else {
         panic!("Expected MarketList after successful add");
@@ -1655,7 +1656,7 @@ fn execute_update_success_clears_status() {
     {
         assert!(operation_status.is_none(), "Should clear operation_status");
         assert!(error_message.is_none(), "Should have no error");
-        assert_eq!(selection.selected_id.as_deref(), Some("mp-a"));
+        assert_eq!(selection.selected_id().map(String::as_str), Some("mp-a"));
     } else {
         panic!("Expected MarketList");
     }
@@ -1807,8 +1808,8 @@ fn execute_remove_success_reloads_and_clamps() {
     } = &model
     {
         assert!(operation_status.is_none());
-        assert_eq!(selection.selected_id.as_deref(), Some("mp-b"));
-        assert_eq!(selection.state.selected(), Some(0));
+        assert_eq!(selection.selected_id().map(String::as_str), Some("mp-b"));
+        assert_eq!(selection.selected_index(), Some(0));
     } else {
         panic!("Expected MarketList");
     }

--- a/src/tui/manager/screens/marketplaces/update_test.rs
+++ b/src/tui/manager/screens/marketplaces/update_test.rs
@@ -1,5 +1,5 @@
 use super::{execute_add_with, execute_remove_with, execute_update_with, update, AddEntry};
-use crate::tui::manager::core::{DataStore, MarketplaceItem};
+use crate::tui::manager::core::{DataStore, MarketplaceItem, SelectionState};
 use crate::tui::manager::screens::marketplaces::actions::AddResult;
 use crate::tui::manager::screens::marketplaces::model::{
     AddFormModel, DetailAction, Model, Msg, OperationStatus,
@@ -34,6 +34,13 @@ fn make_add_result(name: &str) -> AddResult {
     }
 }
 
+fn market_selection(
+    selected_id: Option<&str>,
+    selected_index: Option<usize>,
+) -> SelectionState<String> {
+    SelectionState::new(selected_id.map(str::to_string), selected_index)
+}
+
 // ============================================================================
 // Up/Down ナビゲーション
 // ============================================================================
@@ -44,22 +51,16 @@ fn down_moves_selection_in_market_list() {
     let mut model = Model::new(&data);
 
     // 初期状態: index 0 (mp-a), selected_id = Some("mp-a")
-    if let Model::MarketList {
-        selected_id, state, ..
-    } = &model
-    {
-        assert_eq!(state.selected(), Some(0));
-        assert_eq!(selected_id.as_deref(), Some("mp-a"));
+    if let Model::MarketList { selection, .. } = &model {
+        assert_eq!(selection.state.selected(), Some(0));
+        assert_eq!(selection.selected_id.as_deref(), Some("mp-a"));
     }
 
     update(&mut model, Msg::Down, &mut data);
 
-    if let Model::MarketList {
-        selected_id, state, ..
-    } = &model
-    {
-        assert_eq!(state.selected(), Some(1));
-        assert_eq!(selected_id.as_deref(), Some("mp-b"));
+    if let Model::MarketList { selection, .. } = &model {
+        assert_eq!(selection.state.selected(), Some(1));
+        assert_eq!(selection.selected_id.as_deref(), Some("mp-b"));
     } else {
         panic!("Expected MarketList");
     }
@@ -73,13 +74,10 @@ fn down_past_last_marketplace_selects_add_new() {
     // Move past mp-a to "+ Add new" (index 1)
     update(&mut model, Msg::Down, &mut data);
 
-    if let Model::MarketList {
-        selected_id, state, ..
-    } = &model
-    {
-        assert_eq!(state.selected(), Some(1));
+    if let Model::MarketList { selection, .. } = &model {
+        assert_eq!(selection.state.selected(), Some(1));
         assert_eq!(
-            selected_id, &None,
+            selection.selected_id, None,
             "At '+ Add new', selected_id should be None"
         );
     } else {
@@ -96,8 +94,8 @@ fn down_does_not_go_past_add_new() {
     update(&mut model, Msg::Down, &mut data); // index 1 (Add new)
     update(&mut model, Msg::Down, &mut data); // should stay at 1
 
-    if let Model::MarketList { state, .. } = &model {
-        assert_eq!(state.selected(), Some(1));
+    if let Model::MarketList { selection, .. } = &model {
+        assert_eq!(selection.state.selected(), Some(1));
     } else {
         panic!("Expected MarketList");
     }
@@ -110,8 +108,8 @@ fn up_does_not_go_past_zero() {
 
     update(&mut model, Msg::Up, &mut data);
 
-    if let Model::MarketList { state, .. } = &model {
-        assert_eq!(state.selected(), Some(0));
+    if let Model::MarketList { selection, .. } = &model {
+        assert_eq!(selection.state.selected(), Some(0));
     } else {
         panic!("Expected MarketList");
     }
@@ -129,12 +127,9 @@ fn up_from_add_new_returns_to_last_marketplace() {
     // Move back up
     update(&mut model, Msg::Up, &mut data);
 
-    if let Model::MarketList {
-        selected_id, state, ..
-    } = &model
-    {
-        assert_eq!(state.selected(), Some(1));
-        assert_eq!(selected_id.as_deref(), Some("mp-b"));
+    if let Model::MarketList { selection, .. } = &model {
+        assert_eq!(selection.state.selected(), Some(1));
+        assert_eq!(selection.selected_id.as_deref(), Some("mp-b"));
     } else {
         panic!("Expected MarketList");
     }
@@ -359,8 +354,8 @@ fn detail_back_action_returns_to_market_list() {
     update(&mut model, Msg::Down, &mut data);
     update(&mut model, Msg::Enter, &mut data);
 
-    if let Model::MarketList { selected_id, .. } = &model {
-        assert_eq!(selected_id.as_deref(), Some("mp-a"));
+    if let Model::MarketList { selection, .. } = &model {
+        assert_eq!(selection.selected_id.as_deref(), Some("mp-a"));
     } else {
         panic!("Expected MarketList");
     }
@@ -719,8 +714,6 @@ fn toggle_select_in_plugin_browse_adds_to_selected() {
 
 #[test]
 fn toggle_select_in_plugin_browse_removes_from_selected() {
-    use std::collections::HashSet;
-
     let (_temp_dir, mut data) = make_data(&["mp-a"]);
     let mut model = make_plugin_browse("mp-a", 3);
 
@@ -1126,8 +1119,6 @@ fn back_from_plugin_browse_returns_to_detail() {
 
 #[test]
 fn back_from_target_select_returns_to_plugin_browse() {
-    use std::collections::HashSet;
-
     let (_temp_dir, mut data) = make_data(&["mp-a"]);
     let mut model = make_target_select("mp-a");
 
@@ -1277,8 +1268,8 @@ fn back_from_detail_returns_to_market_list() {
     // Back -> MarketList
     update(&mut model, Msg::Back, &mut data);
 
-    if let Model::MarketList { selected_id, .. } = &model {
-        assert_eq!(selected_id.as_deref(), Some("mp-a"));
+    if let Model::MarketList { selection, .. } = &model {
+        assert_eq!(selection.selected_id.as_deref(), Some("mp-a"));
     } else {
         panic!("Expected MarketList");
     }
@@ -1580,12 +1571,12 @@ fn execute_add_success_transitions_to_market_list() {
     );
 
     if let Model::MarketList {
-        selected_id,
+        selection,
         operation_status,
         ..
     } = &model
     {
-        assert_eq!(selected_id.as_deref(), Some("my-repo"));
+        assert_eq!(selection.selected_id.as_deref(), Some("my-repo"));
         assert!(operation_status.is_none());
     } else {
         panic!("Expected MarketList after successful add");
@@ -1642,8 +1633,7 @@ fn execute_update_success_clears_status() {
     let mut state = ListState::default();
     state.select(Some(0));
     let mut model = Model::MarketList {
-        selected_id: Some("mp-a".to_string()),
-        state,
+        selection: market_selection(Some("mp-a"), state.selected()),
         operation_status: Some(OperationStatus::Updating("mp-a".to_string())),
         error_message: None,
     };
@@ -1659,13 +1649,13 @@ fn execute_update_success_clears_status() {
     if let Model::MarketList {
         operation_status,
         error_message,
-        selected_id,
+        selection,
         ..
     } = &model
     {
         assert!(operation_status.is_none(), "Should clear operation_status");
         assert!(error_message.is_none(), "Should have no error");
-        assert_eq!(selected_id.as_deref(), Some("mp-a"));
+        assert_eq!(selection.selected_id.as_deref(), Some("mp-a"));
     } else {
         panic!("Expected MarketList");
     }
@@ -1677,8 +1667,7 @@ fn execute_update_failure_sets_error_message() {
     let mut state = ListState::default();
     state.select(Some(0));
     let mut model = Model::MarketList {
-        selected_id: Some("mp-a".to_string()),
-        state,
+        selection: market_selection(Some("mp-a"), state.selected()),
         operation_status: Some(OperationStatus::Updating("mp-a".to_string())),
         error_message: None,
     };
@@ -1714,8 +1703,7 @@ fn execute_update_all_success() {
     let mut state = ListState::default();
     state.select(Some(0));
     let mut model = Model::MarketList {
-        selected_id: Some("mp-a".to_string()),
-        state,
+        selection: market_selection(Some("mp-a"), state.selected()),
         operation_status: Some(OperationStatus::UpdatingAll),
         error_message: None,
     };
@@ -1752,8 +1740,7 @@ fn execute_update_all_partial_failure_sets_error() {
     let mut state = ListState::default();
     state.select(Some(0));
     let mut model = Model::MarketList {
-        selected_id: Some("mp-a".to_string()),
-        state,
+        selection: market_selection(Some("mp-a"), state.selected()),
         operation_status: Some(OperationStatus::UpdatingAll),
         error_message: None,
     };
@@ -1799,8 +1786,7 @@ fn execute_remove_success_reloads_and_clamps() {
     let mut state = ListState::default();
     state.select(Some(0));
     let mut model = Model::MarketList {
-        selected_id: Some("mp-a".to_string()),
-        state,
+        selection: market_selection(Some("mp-a"), state.selected()),
         operation_status: Some(OperationStatus::Removing("mp-a".to_string())),
         error_message: None,
     };
@@ -1815,15 +1801,14 @@ fn execute_remove_success_reloads_and_clamps() {
     );
 
     if let Model::MarketList {
-        selected_id,
+        selection,
         operation_status,
-        state,
         ..
     } = &model
     {
         assert!(operation_status.is_none());
-        assert_eq!(selected_id.as_deref(), Some("mp-b"));
-        assert_eq!(state.selected(), Some(0));
+        assert_eq!(selection.selected_id.as_deref(), Some("mp-b"));
+        assert_eq!(selection.state.selected(), Some(0));
     } else {
         panic!("Expected MarketList");
     }
@@ -1835,8 +1820,7 @@ fn execute_remove_failure_sets_error() {
     let mut state = ListState::default();
     state.select(Some(0));
     let mut model = Model::MarketList {
-        selected_id: Some("mp-a".to_string()),
-        state,
+        selection: market_selection(Some("mp-a"), state.selected()),
         operation_status: Some(OperationStatus::Removing("mp-a".to_string())),
         error_message: None,
     };
@@ -1981,8 +1965,7 @@ fn error_message_cleared_on_up() {
     let mut state = ListState::default();
     state.select(Some(1));
     let mut model = Model::MarketList {
-        selected_id: Some("mp-b".to_string()),
-        state,
+        selection: market_selection(Some("mp-b"), state.selected()),
         operation_status: None,
         error_message: Some("some error".to_string()),
     };
@@ -1998,12 +1981,7 @@ fn error_message_cleared_on_up() {
 fn error_message_cleared_on_down() {
     let (_temp_dir, mut data) = make_data(&["mp-a", "mp-b"]);
     let mut model = Model::MarketList {
-        selected_id: Some("mp-a".to_string()),
-        state: {
-            let mut s = ListState::default();
-            s.select(Some(0));
-            s
-        },
+        selection: market_selection(Some("mp-a"), Some(0)),
         operation_status: None,
         error_message: Some("some error".to_string()),
     };
@@ -2019,12 +1997,7 @@ fn error_message_cleared_on_down() {
 fn error_message_cleared_on_enter() {
     let (_temp_dir, mut data) = make_data(&["mp-a"]);
     let mut model = Model::MarketList {
-        selected_id: Some("mp-a".to_string()),
-        state: {
-            let mut s = ListState::default();
-            s.select(Some(0));
-            s
-        },
+        selection: market_selection(Some("mp-a"), Some(0)),
         operation_status: None,
         error_message: Some("some error".to_string()),
     };
@@ -2070,12 +2043,7 @@ fn error_message_cleared_on_back() {
 fn stale_error_cleared_on_update_market_start() {
     let (_temp_dir, mut data) = make_data(&["mp-a"]);
     let mut model = Model::MarketList {
-        selected_id: Some("mp-a".to_string()),
-        state: {
-            let mut s = ListState::default();
-            s.select(Some(0));
-            s
-        },
+        selection: market_selection(Some("mp-a"), Some(0)),
         operation_status: None,
         error_message: Some("previous error".to_string()),
     };
@@ -2095,12 +2063,7 @@ fn stale_error_cleared_on_update_market_start() {
 fn stale_error_cleared_on_update_all_start() {
     let (_temp_dir, mut data) = make_data(&["mp-a"]);
     let mut model = Model::MarketList {
-        selected_id: Some("mp-a".to_string()),
-        state: {
-            let mut s = ListState::default();
-            s.select(Some(0));
-            s
-        },
+        selection: market_selection(Some("mp-a"), Some(0)),
         operation_status: None,
         error_message: Some("previous error".to_string()),
     };
@@ -2122,8 +2085,7 @@ fn stale_error_cleared_on_successful_update_retry() {
     let mut state = ListState::default();
     state.select(Some(0));
     let mut model = Model::MarketList {
-        selected_id: Some("mp-a".to_string()),
-        state,
+        selection: market_selection(Some("mp-a"), state.selected()),
         operation_status: Some(OperationStatus::Updating("mp-a".to_string())),
         error_message: Some("previous failure".to_string()),
     };
@@ -2152,8 +2114,7 @@ fn stale_error_cleared_on_successful_remove_retry() {
     let mut state = ListState::default();
     state.select(Some(0));
     let mut model = Model::MarketList {
-        selected_id: Some("mp-a".to_string()),
-        state,
+        selection: market_selection(Some("mp-a"), state.selected()),
         operation_status: Some(OperationStatus::Removing("mp-a".to_string())),
         error_message: Some("previous failure".to_string()),
     };
@@ -2183,8 +2144,7 @@ fn stale_error_cleared_on_successful_update_all_retry() {
     let mut state = ListState::default();
     state.select(Some(0));
     let mut model = Model::MarketList {
-        selected_id: Some("mp-a".to_string()),
-        state,
+        selection: market_selection(Some("mp-a"), state.selected()),
         operation_status: Some(OperationStatus::UpdatingAll),
         error_message: Some("previous failure".to_string()),
     };

--- a/src/tui/manager/screens/marketplaces/view.rs
+++ b/src/tui/manager/screens/marketplaces/view.rs
@@ -74,7 +74,7 @@ pub fn view(
         } => {
             view_market_list(
                 f,
-                selection.state.clone(),
+                *selection.list_state(),
                 &ctx,
                 operation_status,
                 error_message,

--- a/src/tui/manager/screens/marketplaces/view.rs
+++ b/src/tui/manager/screens/marketplaces/view.rs
@@ -67,12 +67,18 @@ pub fn view(
     };
     match model {
         Model::MarketList {
-            state,
+            selection,
             operation_status,
             error_message,
             ..
         } => {
-            view_market_list(f, *state, &ctx, operation_status, error_message);
+            view_market_list(
+                f,
+                selection.state.clone(),
+                &ctx,
+                operation_status,
+                error_message,
+            );
         }
         Model::MarketDetail {
             marketplace_name,


### PR DESCRIPTION
## 概要

TUI manager の一覧選択状態を `SelectionState<K>` として共通化し、Issue #265 の段階的移行を実装しました。

## 変更内容

### 🎯 変更の種類

- [ ] 🐛 バグ修正 (Bug fix)
- [ ] ✨ 新機能 (New feature)
- [x] ♻️ リファクタリング (Refactoring)
- [ ] 🎨 UI/UX 改善 (UI/UX improvement)
- [ ] 🐎 パフォーマンス改善 (Performance improvement)
- [x] 🚨 テスト追加/修正 (Tests)
- [x] 📖 ドキュメント更新 (Documentation)
- [ ] 🔧 設定変更 (Configuration)
- [ ] 🗑️ 削除 (Removal)

### 📝 詳細な変更内容

#### 追加された機能・修正

- `src/tui/manager/core/selection_state.rs` に `SelectionState<K>` を追加
- `Installed::PluginList` の `selected_id + ListState` を `SelectionState<PluginId>` へ移行
- `Marketplaces::MarketList` の `selected_id + ListState` を `SelectionState<String>` へ移行
- `from_cache()` / `to_cache()` の semantic state と stale ID 検証は各画面側に維持
- Marketplaces の model/update テストを新しい `selection` 構造へ追従
- Issue #265 の実装状況レビューを `docs/` に記録

#### 変更されたファイル

- `src/tui/manager/core.rs`
- `src/tui/manager/core/selection_state.rs`
- `src/tui/manager/core/app.rs`
- `src/tui/manager/screens/installed/*`
- `src/tui/manager/screens/marketplaces/*`
- `docs/issue-265-implementation-check-2026-05-06.md`

#### 削除されたファイル・機能

- なし

## 📊 システム図

```mermaid
flowchart TD
    Core["tui::manager::core"] --> SelectionState["SelectionState<K> [NEW]"]
    SelectionState --> SelectedId["selected_id: Option<K>"]
    SelectionState --> ListCursor["state: ListState"]

    Installed["Installed::PluginList"] --> InstalledSelection["selection: SelectionState<PluginId> [CHANGED]"]
    Marketplaces["Marketplaces::MarketList"] --> MarketSelection["selection: SelectionState<String> [CHANGED]"]

    InstalledSelection --> SelectionState
    MarketSelection --> SelectionState

    Cache["画面別 CacheState"] --> Restore["from_cache / to_cache"]
    Restore --> InstalledSelection
    Restore --> MarketSelection

    classDef new fill:#e0f2fe,stroke:#0284c7,stroke-width:2px
    classDef changed fill:#fef3c7,stroke:#d97706,stroke-width:2px
    class SelectionState new
    class InstalledSelection,MarketSelection changed
```

## 📋 関連 Issue

- Closes #265
- Refs #256
- Refs #264

## 🧪 テスト

### テスト実行方法

```bash
cargo check
cargo test
```

### テスト項目

- [x] 単体テスト (Unit tests)
- [ ] 統合テスト (Integration tests)
- [ ] E2E テスト (End-to-end tests)
- [ ] 手動テスト (Manual testing)

### テスト結果

- `cargo check`: pass
- `cargo test`: pass（1600 tests passed）
- 既存の `assert_cmd::cargo_bin` deprecated warning は残存

## 🔍 レビューポイント

- `SelectionState<K>` の公開 API と `core` からの re-export の粒度
- `Installed` / `Marketplaces` の cache 復元挙動が従来どおり維持されているか
- `Discover` を今回対象外にした判断が #264 の設計方針と整合しているか

## ⚠️ 破壊的変更

- [ ] この変更は既存の API に破壊的変更を含みます

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [x] ドキュメントが更新されている（必要に応じて）
- [x] コミットメッセージが適切な形式で書かれている
- [x] 関連する Issue が PR の「Development」に Linked されている
- [x] PR 本文に `Closes #` / `Fixes #` / `Refs #` などで Issue が記載されている
- [x] セルフレビューを実施した
- [x] 破壊的変更がある場合は明記されている