### PR TITLE
Codex Hooks変換と配置を有効化

### DIFF
--- a/docs/codex-hooks-conversion-implementation-plan-2026-05-06.md
+++ b/docs/codex-hooks-conversion-implementation-plan-2026-05-06.md
@@ -1,0 +1,336 @@
+# Codex Hooks 変換 実装計画
+
+作成日: 2026-05-06
+
+## 目的
+
+Claude Code 形式の Hook コンポーネントを Codex ターゲットへインストールできるようにする。
+
+既存の Hooks 自動変換は主に Claude Code 形式から Copilot CLI 形式への変換を扱っている。一方、現在の OpenAI Codex 公式ドキュメントでは Codex Hooks が提供されており、`~/.codex/hooks.json`、`<repo>/.codex/hooks.json`、または plugin の `hooks/hooks.json` からライフサイクル設定を読み込める。Codex の JSON 形状は Claude Code と近いため、Codex 向けは Copilot 向けのような大きなスキーマ変換ではなく、対応イベントの検証、非対応 hook 種別の除外、配置パスの有効化を中心に実装する。
+
+参照:
+- OpenAI Codex Hooks: https://developers.openai.com/codex/hooks
+- Codex plugin packaging: https://developers.openai.com/codex/plugins/build
+- 既存仕様: [docs/hooks-conversion/index.md](./hooks-conversion/index.md)
+- 既存実装メモ: [docs/architecture/hooks-conversion.md](./architecture/hooks-conversion.md)
+
+## 現状
+
+### 実装済み
+
+- `src/hooks/converter/converter.rs` に、ターゲット別の `EventMap`、`ToolMap`、`KeyMap`、`StructureConverter`、`ScriptGenerator` を差し替える多層コンバータがある。
+- `TargetKind::Copilot` は `create_layers()` で有効化済み。
+- `src/hooks/converter/codex.rs`、`src/hooks/event/codex.rs`、`src/hooks/tool/codex.rs` は存在するが、実質 skeleton。
+- `ComponentDeployment::deploy_hook_converted()` は `converter::convert(input, target_kind)` を呼べるため、ターゲット種別を渡す設計は既にある。
+
+### 未実装・古い前提
+
+- `src/target/env/codex.rs` は `ComponentKind::Hook` を非対応としている。
+- `create_layers(TargetKind::Codex)` が未登録。
+- `CodexEventMap` は全イベントを未対応扱いする。
+- `CodexScriptGenerator` は空 script を返すため、そのまま有効化すると壊れた配置になる。
+- 既存ドキュメントの一部は「Codex Hooks 非対応」前提が残っている。
+
+## 設計方針
+
+Feature ベースの既存構成に合わせ、Hooks 関連の変換は `src/hooks/`、ターゲット配置は `src/target/env/codex.rs`、デプロイ統合は `src/component/deployment/` に閉じる。
+
+Codex 向け変換は以下の原則にする。
+
+- Codex のネイティブ JSON 形状は PascalCase event + matcher group + `hooks[]` なので、Claude Code 形式を基本的に保持する。
+- Codex が対応する event と field だけを通し、明確に非対応な hook 種別は警告付きで除外する。
+- `command` hook は script wrapper を生成しない。元の `command` をそのまま使う。
+- `http` / `prompt` / `agent` hook は Codex公式仕様上の command hook として直接実行できないため、初期実装では除外する。必要なら Phase 2 で command wrapper 化する。
+- Codex Hooks は feature flag `codex_hooks = true` が必要なため、PLMが自動で `config.toml` を編集するかは別判断にする。初期実装では hook配置時に警告またはドキュメント更新で明示し、設定ファイル編集は追加Phaseへ分離する。
+
+## システム図
+
+### 状態マシン
+
+```mermaid
+stateDiagram-v2
+    [*] --> InputRead
+    InputRead --> FormatDetected
+    FormatDetected --> TargetPassthrough: Codex形式
+    FormatDetected --> ClaudeCodeConvert: Claude Code形式
+    ClaudeCodeConvert --> EventMapped
+    EventMapped --> HookFiltered
+    HookFiltered --> JsonWritten
+    TargetPassthrough --> JsonWritten
+    JsonWritten --> Success
+    FormatDetected --> Failed: JSON不正 / hooks欠落
+    EventMapped --> Failed: 構造不正
+    HookFiltered --> EmptyWarning: 全hook除外
+    EmptyWarning --> JsonWritten
+    Failed --> [*]
+    Success --> [*]
+```
+
+### データフロー
+
+```mermaid
+flowchart TD
+    A["Plugin Hook JSON"] --> B["ComponentDeployment::deploy_hook_converted"]
+    B --> C["converter::convert(input, TargetKind::Codex)"]
+    C --> D["CodexStructureConverter"]
+    C --> E["CodexEventMap"]
+    C --> F["CodexKeyMap"]
+    C --> G["CodexScriptGenerator"]
+    D --> H["hooks JSON: Codex native shape"]
+    E --> H
+    F --> H
+    G --> H
+    H --> I["CodexTarget placement"]
+    I --> J["Project: <repo>/.codex/hooks.json or managed file"]
+    I --> K["Personal: ~/.codex/hooks.json or managed file"]
+    H --> L["warnings for unsupported events/types/fields"]
+```
+
+## フォルダ構造
+
+### 現在
+
+```text
+src/
+├── hooks/
+│   ├── converter.rs
+│   ├── converter/
+│   │   ├── converter.rs
+│   │   ├── copilot.rs
+│   │   └── codex.rs        # skeleton
+│   ├── event/
+│   │   └── codex.rs        # skeleton
+│   └── tool/
+│       └── codex.rs        # passthrough
+├── component/deployment/
+│   └── hook_deploy.rs
+└── target/env/
+    └── codex.rs            # Hook非対応
+```
+
+### 実装後
+
+```text
+src/
+├── hooks/
+│   ├── converter/
+│   │   ├── converter.rs    # TargetKind::Codex を登録
+│   │   ├── copilot.rs
+│   │   └── codex.rs        # Codex変換の本体
+│   ├── event/
+│   │   └── codex.rs        # Codex対応イベントのマッピング
+│   └── tool/
+│       └── codex.rs        # matcher alias正規化を必要に応じて実装
+├── component/deployment/
+│   └── hook_deploy.rs      # scriptなし変換の扱いを確認
+└── target/env/
+    └── codex.rs            # Hook対応と配置パス追加
+```
+
+## 主要コンポーネント設計
+
+### `CodexEventMap`
+
+対応イベントを Codex ネイティブ名へ写像する。Claude Code と Codex はどちらも PascalCase なので、多くは同名で返す。
+
+初期対応:
+
+| 入力 | 出力 | 備考 |
+|---|---|---|
+| `SessionStart` | `SessionStart` | matcher は `source` に適用 |
+| `PreToolUse` | `PreToolUse` | Bash / apply_patch / MCP |
+| `PostToolUse` | `PostToolUse` | Bash / apply_patch / MCP |
+| `UserPromptSubmit` | `UserPromptSubmit` | matcher は無視される |
+| `Stop` | `Stop` | matcher は無視される |
+| `PermissionRequest` | `PermissionRequest` | Codex固有イベント。入力にあれば保持 |
+
+`SubagentStop` など Codex公式Hooksにないイベントは `UnsupportedEvent` にする。
+
+### `CodexStructureConverter`
+
+Codex形式判定:
+
+- `hooks` が object で、event key が PascalCase の場合は target format と見なしてよい。
+- Claude Code形式もほぼ同形なので、実装上は `SourceFormat::ClaudeCode` として検証・フィルタリングを通す。
+- `version` は Codex Hooks JSON では不要。Copilot向けの `version: 1` は追加しない。
+- `disableAllHooks` は Codex仕様にないため `RemovedField` で除去する。
+
+### `CodexKeyMap`
+
+`command` hook では以下を保持する。
+
+- `type`
+- `command`
+- `timeout`
+- `statusMessage`
+
+以下は初期実装では除去候補。
+
+- `async`
+- `once`
+- Copilot専用の `bash` / `timeoutSec` / `comment`
+
+### `CodexScriptGenerator`
+
+Codexは command hook をそのまま実行できるため、command hook では script を生成しない設計にしたい。ただし既存の `convert_hook_definition()` は `ScriptGenerator` が必ず `ScriptInfo` を返し、`bash` フィールドを挿入する前提になっている。
+
+そのため、実装では次のどちらかを選ぶ。
+
+1. 推奨: `ScriptGenerator` の戻り値を `HookActionOutput` のような enum に拡張する。
+   - `Inline(Value)` または `NoScript`
+   - `GeneratedScript(ScriptInfo)`
+   - Copilot は `GeneratedScript`
+   - Codex command は `Inline`
+2. 最小変更: `CodexScriptGenerator` にだけ特別扱いを入れ、空 path を script 生成なしとして解釈する。
+   - 既存設計の意味が崩れるため非推奨。
+
+計画としては 1 を採用する。Copilot既存挙動は維持し、Codexだけ inline command を返す。
+
+### `CodexTarget`
+
+`supported_components()` に `ComponentKind::Hook` を追加する。
+
+配置先は公式探索パスに合わせる。
+
+- Project: `<repo>/.codex/hooks.json`
+- Personal: `~/.codex/hooks.json`
+
+ただし現行PLMは複数Hookコンポーネントを個別ファイルとして置く構造を採る。Codexは複数hook sourceを読むが、公式の代表パスはレイヤーごとに `hooks.json` である。ここは設計判断が必要。
+
+推奨は「Phase 1では単一ファイル配置」:
+
+- `ComponentKind::Hook` の Codex 配置先を `.codex/hooks.json` にする。
+- 複数Hookコンポーネントの同時インストールは上書きリスクがあるため、Phase 1では検知して警告、Phase 2でマージ機構を入れる。
+
+代替案は「`.codex/hooks/<name>.json` に置く」だが、Codex公式探索パスとして明記されていないため採用しない。
+
+## 実装フェーズ
+
+### Phase 1: CodexネイティブHooksの最小対応
+
+1. `CodexEventMap` を実装する。
+2. `CodexKeyMap` で command hook の許可フィールドを整理する。
+3. `CodexStructureConverter` で `version` 非追加、`disableAllHooks` 除去、PascalCase維持を実装する。
+4. `create_layers(TargetKind::Codex)` を登録する。
+5. `ScriptGenerator` 周辺を inline command を表現できる設計へ拡張する。
+6. `CodexTarget` で `ComponentKind::Hook` をサポートする。
+7. Project/Personal の配置先を `.codex/hooks.json` / `~/.codex/hooks.json` にする。
+
+成果物:
+
+- Claude Code command hooks が Codex hooks.json として配置される。
+- 非対応イベント・非対応hook種別は警告される。
+- Copilot向け変換の既存挙動は維持される。
+
+### Phase 2: マージと安全な上書き制御
+
+1. 既存 `.codex/hooks.json` を読み込み、同一event配下に新規hook groupをマージする。
+2. PLM管理ブロックの識別子を導入する。
+3. uninstall/update時にPLM管理分だけ削除・更新できるようにする。
+4. 複数プラグインのhookを同一 `hooks.json` に共存させる。
+
+成果物:
+
+- 複数Hookコンポーネントを安全に共存可能。
+- ユーザー手書きhookを壊さず更新可能。
+
+### Phase 3: Codex feature flag 補助
+
+1. `config.toml` に `[features] codex_hooks = true` があるか検出する。
+2. 自動編集するか、警告表示に留めるかをCLIオプションで分ける。
+3. `plm install --enable-codex-hooks` のような明示オプションを検討する。
+
+成果物:
+
+- インストール後にCodex Hooksが実行されない原因をユーザーが把握できる。
+- 設定ファイル自動編集のリスクを明示的に扱える。
+
+### Phase 4: 非command hookのベストエフォート対応
+
+1. `http` hook を command wrapper に変換する。
+2. `prompt` / `agent` hook は stub 生成または除外のままにする。
+3. Codexのstdout/exit code仕様に合わせて wrapper を調整する。
+
+成果物:
+
+- Claude Code由来の `http` hook もCodex上で動作可能。
+- `prompt` / `agent` は明確な警告付きで扱える。
+
+## テスト計画
+
+TDD順序で進める。
+
+1. `CodexEventMap`
+   - `SessionStart` / `PreToolUse` / `PostToolUse` / `UserPromptSubmit` / `Stop` / `PermissionRequest` が同名に変換される。
+   - `SubagentStop` や未知イベントは `None`。
+2. `CodexStructureConverter`
+   - `version` を追加しない。
+   - `disableAllHooks` を除去して警告を返す。
+   - `hooks` が object でない場合は既存共通バリデーションでエラー。
+3. `CodexKeyMap`
+   - command hook の `command` / `timeout` / `statusMessage` を保持。
+   - `async` / `once` を警告付きで除去。
+4. `converter::convert(..., TargetKind::Codex)`
+   - command hook が `bash` wrapper なしで Codex JSON として出る。
+   - `scripts` は空。
+   - 非対応eventは警告付きで除外。
+   - `http` / `prompt` / `agent` はPhase 1では警告付きで除外。
+5. `CodexTarget`
+   - `supports(ComponentKind::Hook)` が true。
+   - Project配置先が `<repo>/.codex/hooks.json`。
+   - Personal配置先が `~/.codex/hooks.json`。
+6. 統合テスト
+   - `plm install ... --target codex --type hook --scope project --dry-run` 相当の確認。
+   - 既存Copilot Hooks変換テストが全て通る。
+
+検証コマンド:
+
+```bash
+cargo test hooks::converter::codex
+cargo test hooks::event::codex
+cargo test target::env::codex
+cargo test component::deployment
+cargo test
+cargo clippy
+```
+
+## リスクと判断ポイント
+
+### 1. Codex配置先の競合
+
+Codex公式の代表パスは `<repo>/.codex/hooks.json` と `~/.codex/hooks.json`。PLMの既存Copilot実装のように `<base>/hooks/<name>.json` へ個別配置してもCodexが読む保証はない。
+
+判断: Phase 1は公式パスを優先し、複数コンポーネントの共存はPhase 2でマージ対応する。
+
+### 2. 既存コンバータの ScriptGenerator 前提
+
+現在は全hookが script を生成し、その path を `bash` に入れる設計。Codex command hook ではこの前提が不要。
+
+判断: `ScriptGenerator` を enum戻り値に拡張し、Copilotのwrapper生成とCodexのinline保持を同じ抽象で表現する。
+
+### 3. feature flag
+
+Codex Hooksは `config.toml` の `[features] codex_hooks = true` が必要。PLMが勝手に設定を編集すると副作用が大きい。
+
+判断: Phase 1では自動編集しない。警告とドキュメント更新で扱う。自動編集は明示オプションを追加するPhase 3へ分ける。
+
+### 4. `http` / `prompt` / `agent`
+
+Codex公式Hooksは command handler 中心。Claude Code固有hook種別の完全変換は過剰。
+
+判断: Phase 1では除外、Phase 4で必要に応じて wrapper 化する。
+
+## ドキュメント更新対象
+
+- [docs/architecture/hooks-conversion.md](./architecture/hooks-conversion.md): Copilot専用に見える記述を、ターゲット別Hooks変換へ更新。
+- [docs/hooks-conversion/index.md](./hooks-conversion/index.md): Codex向け変換を別セクションとして追加。
+- [docs/concepts/targets.md](./concepts/targets.md): Codex Hooks対応と feature flag を追記。
+- [docs/concepts/components.md](./concepts/components.md): Hook のCodex対応表を更新。
+
+## 完了条件
+
+- Claude Code形式の command hook を Codexターゲットへインストールできる。
+- 生成される `hooks.json` はCodex公式の三層構造を満たす。
+- Copilot Hooks変換の既存テストが退行しない。
+- Codex Hooksがfeature flag必須であることがCLI出力またはドキュメントで明示されている。
+- 非対応イベント・非対応hook種別がサイレントに欠落しない。

--- a/docs/codex-hooks-conversion-implementation-plan-2026-05-06.md
+++ b/docs/codex-hooks-conversion-implementation-plan-2026-05-06.md
@@ -173,17 +173,9 @@ Codex形式の扱い:
 
 Codexは command hook をそのまま実行できるため、command hook では script を生成しない設計にしたい。ただし既存の `convert_hook_definition()` は `ScriptGenerator` が必ず `ScriptInfo` を返し、`bash` フィールドを挿入する前提になっている。
 
-そのため、実装では次のどちらかを選ぶ。
+実装では最小変更として、`CodexScriptGenerator` が空 path の `ScriptInfo` を返し、共通変換側が `script_info.path.is_empty()` を script 生成なしの inline hook として扱う。Copilot既存挙動は維持し、Codex command hook だけ元の `command` を保持する。
 
-1. 推奨: `ScriptGenerator` の戻り値を `HookActionOutput` のような enum に拡張する。
-   - `Inline(Value)` または `NoScript`
-   - `GeneratedScript(ScriptInfo)`
-   - Copilot は `GeneratedScript`
-   - Codex command は `Inline`
-2. 最小変更: `CodexScriptGenerator` にだけ特別扱いを入れ、空 path を script 生成なしとして解釈する。
-   - 既存設計の意味が崩れるため非推奨。
-
-計画としては 1 を採用する。Copilot既存挙動は維持し、Codexだけ inline command を返す。
+この方式は抽象としては暫定であり、将来的に `ScriptGenerator` の戻り値を `Inline(Value)` / `GeneratedScript(ScriptInfo)` のような enum に拡張すると、意図を型で表現できる。
 
 ### `CodexTarget`
 
@@ -211,7 +203,7 @@ Codexは command hook をそのまま実行できるため、command hook では
 2. `CodexKeyMap` で command hook の許可フィールドを整理する。
 3. `CodexStructureConverter` で `version` 非追加、`disableAllHooks` 除去、PascalCase維持を実装する。
 4. `create_layers(TargetKind::Codex)` を登録する。
-5. `ScriptGenerator` 周辺を inline command を表現できる設計へ拡張する。
+5. `ScriptGenerator` 周辺で空 path を inline command として扱う暫定経路を追加する。
 6. `CodexTarget` で `ComponentKind::Hook` をサポートする。
 7. Project/Personal の配置先を `.codex/hooks.json` / `~/.codex/hooks.json` にする。
 
@@ -305,7 +297,7 @@ Codex公式の代表パスは `<repo>/.codex/hooks.json` と `~/.codex/hooks.jso
 
 現在は全hookが script を生成し、その path を `bash` に入れる設計。Codex command hook ではこの前提が不要。
 
-判断: `ScriptGenerator` を enum戻り値に拡張し、Copilotのwrapper生成とCodexのinline保持を同じ抽象で表現する。
+判断: Phase 1では空 path を inline保持の sentinel として扱う最小変更で実装する。将来的には `ScriptGenerator` を enum戻り値に拡張し、Copilotのwrapper生成とCodexのinline保持を同じ抽象で表現する。
 
 ### 3. feature flag
 

--- a/docs/codex-hooks-conversion-implementation-plan-2026-05-06.md
+++ b/docs/codex-hooks-conversion-implementation-plan-2026-05-06.md
@@ -51,12 +51,10 @@ Codex 向け変換は以下の原則にする。
 stateDiagram-v2
     [*] --> InputRead
     InputRead --> FormatDetected
-    FormatDetected --> TargetPassthrough: Codex形式
-    FormatDetected --> ClaudeCodeConvert: Claude Code形式
+    FormatDetected --> ClaudeCodeConvert: Claude Code / Codex同形JSON
     ClaudeCodeConvert --> EventMapped
     EventMapped --> HookFiltered
     HookFiltered --> JsonWritten
-    TargetPassthrough --> JsonWritten
     JsonWritten --> Success
     FormatDetected --> Failed: JSON不正 / hooks欠落
     EventMapped --> Failed: 構造不正
@@ -148,10 +146,11 @@ src/
 
 ### `CodexStructureConverter`
 
-Codex形式判定:
+Codex形式の扱い:
 
-- `hooks` が object で、event key が PascalCase の場合は target format と見なしてよい。
-- Claude Code形式もほぼ同形なので、実装上は `SourceFormat::ClaudeCode` として検証・フィルタリングを通す。
+- `CodexStructureConverter::detect_format` は Codex専用の passthrough 判定を持たず、`hooks` を持つJSONを `SourceFormat::ClaudeCode` として扱う。
+- Claude Code形式とCodex形式はほぼ同形なので、同じ検証・フィルタリング経路を通す。
+- PascalCase event key は `CodexEventMap` で対応イベントだけ保持し、非対応イベントは警告付きで除外する。
 - `version` は Codex Hooks JSON では不要。Copilot向けの `version: 1` は追加しない。
 - `disableAllHooks` は Codex仕様にないため `RemovedField` で除去する。
 

--- a/src/commands/deploy/import.rs
+++ b/src/commands/deploy/import.rs
@@ -12,7 +12,9 @@ use crate::import::{ImportRecord, ImportRegistry};
 use crate::output::CommandSummary;
 use crate::plugin::PackageCache;
 use crate::source::parse_source;
-use crate::target::{all_targets, parse_target, PluginOrigin, Scope, Target, TargetKind};
+use crate::target::{
+    all_targets, parse_target, CodexTarget, PluginOrigin, Scope, Target, TargetKind,
+};
 use crate::tui;
 use chrono::Utc;
 use clap::Parser;
@@ -322,8 +324,27 @@ fn place_components(
 
     for target_name in target_names {
         let target = parse_target(target_name).map_err(|e| e.to_string())?;
+        let codex_hook_conflict = if target.kind() == TargetKind::Codex {
+            CodexTarget::hook_component_conflict_error(components)
+        } else {
+            None
+        };
 
         for component in components {
+            if component.kind == ComponentKind::Hook {
+                if let Some(error) = &codex_hook_conflict {
+                    println!(
+                        "  x {} {}: {} - {}",
+                        target.name(),
+                        component.kind,
+                        component.name,
+                        error
+                    );
+                    total_failure += 1;
+                    continue;
+                }
+            }
+
             let deployment = match build_deployment(target.as_ref(), component, ctx) {
                 Ok(None) => continue,
                 Ok(Some(d)) => d,

--- a/src/commands/deploy/import.rs
+++ b/src/commands/deploy/import.rs
@@ -279,6 +279,10 @@ fn deploy_one(
             );
 
             let target_kind = target.kind();
+            if target_kind == TargetKind::Codex && deployment.kind() == ComponentKind::Hook {
+                crate::install::record_codex_hook_ownership(ctx.plugin_root, deployment.path());
+            }
+
             if target_kind == TargetKind::GeminiCli {
                 return DeployOutcome::Skipped;
             }

--- a/src/commands/deploy/import.rs
+++ b/src/commands/deploy/import.rs
@@ -226,6 +226,12 @@ fn build_deployment(
         None => return Ok(None),
     };
 
+    if component.kind == ComponentKind::Hook && target.kind() == TargetKind::Codex {
+        if let Some(error) = CodexTarget::hook_overwrite_error(&target_path, ctx.plugin_root) {
+            return Err(error);
+        }
+    }
+
     let conversion = match component.kind {
         ComponentKind::Agent => ConversionConfig::Agent {
             source: AgentFormat::ClaudeCode,

--- a/src/commands/deploy/import.rs
+++ b/src/commands/deploy/import.rs
@@ -185,6 +185,7 @@ struct ImportContext<'a> {
     origin: &'a PluginOrigin,
     scope: Scope,
     project_root: &'a Path,
+    plugin_root: &'a Path,
     source_repo: &'a str,
     git_ref: &'a str,
     commit_sha: &'a str,
@@ -228,6 +229,12 @@ fn build_deployment(
             source: AgentFormat::ClaudeCode,
             dest: target.agent_format(),
         },
+        ComponentKind::Hook if matches!(target.kind(), TargetKind::Codex | TargetKind::Copilot) => {
+            ConversionConfig::Hook {
+                target_kind: target.kind(),
+                plugin_root: Some(ctx.plugin_root.to_path_buf()),
+            }
+        }
         _ => ConversionConfig::None,
     };
 
@@ -429,6 +436,7 @@ pub async fn run(args: Args) -> Result<(), String> {
         origin: &origin,
         scope,
         project_root: &project_root,
+        plugin_root: &cached_plugin.path,
         source_repo: &args.source,
         git_ref: &cached_plugin.git_ref,
         commit_sha: &cached_plugin.commit_sha,

--- a/src/commands/deploy/import_test.rs
+++ b/src/commands/deploy/import_test.rs
@@ -310,4 +310,37 @@ mod place_components_tests {
         assert_eq!(result.unwrap(), (0, 2));
         assert!(!project_dir.path().join(".codex/hooks.json").exists());
     }
+
+    #[test]
+    fn codex_rejects_hook_when_existing_hooks_json_unowned() {
+        let project_dir = TempDir::new().unwrap();
+        let plugin_dir = TempDir::new().unwrap();
+        let registry_dir = TempDir::new().unwrap();
+
+        // 既存の hooks.json を配置（プラグイン管理外）
+        let codex_dir = project_dir.path().join(".codex");
+        std::fs::create_dir_all(&codex_dir).unwrap();
+        std::fs::write(codex_dir.join("hooks.json"), b"{\"hooks\":{}}\n").unwrap();
+        let original = std::fs::read(codex_dir.join("hooks.json")).unwrap();
+
+        let origin = PluginOrigin::from_marketplace("test-marketplace", "test-plugin");
+        let ctx = ImportContext {
+            origin: &origin,
+            scope: Scope::Project,
+            project_root: project_dir.path(),
+            plugin_root: plugin_dir.path(),
+            source_repo: "owner/repo",
+            git_ref: "main",
+            commit_sha: "abc123",
+        };
+        let components = vec![make_hook("only")];
+        let mut registry = ImportRegistry::with_path(registry_dir.path().join("imports.json"));
+
+        let result = place_components(&["codex".to_string()], &components, &ctx, &mut registry);
+
+        assert_eq!(result.unwrap(), (0, 1));
+        // 既存ファイルは上書きされていない
+        let after = std::fs::read(codex_dir.join("hooks.json")).unwrap();
+        assert_eq!(after, original);
+    }
 }

--- a/src/commands/deploy/import_test.rs
+++ b/src/commands/deploy/import_test.rs
@@ -271,3 +271,43 @@ mod filter_components_tests {
         assert_eq!(skipped.len(), 1);
     }
 }
+
+mod place_components_tests {
+    use super::*;
+    use crate::component::{Component, ComponentKind};
+    use crate::import::ImportRegistry;
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
+    fn make_hook(name: &str) -> Component {
+        Component {
+            kind: ComponentKind::Hook,
+            name: name.to_string(),
+            path: PathBuf::from(format!("hooks/{}.json", name)),
+        }
+    }
+
+    #[test]
+    fn codex_rejects_multiple_hook_components() {
+        let project_dir = TempDir::new().unwrap();
+        let plugin_dir = TempDir::new().unwrap();
+        let registry_dir = TempDir::new().unwrap();
+        let origin = PluginOrigin::from_marketplace("test-marketplace", "test-plugin");
+        let ctx = ImportContext {
+            origin: &origin,
+            scope: Scope::Project,
+            project_root: project_dir.path(),
+            plugin_root: plugin_dir.path(),
+            source_repo: "owner/repo",
+            git_ref: "main",
+            commit_sha: "abc123",
+        };
+        let components = vec![make_hook("first"), make_hook("second")];
+        let mut registry = ImportRegistry::with_path(registry_dir.path().join("imports.json"));
+
+        let result = place_components(&["codex".to_string()], &components, &ctx, &mut registry);
+
+        assert_eq!(result.unwrap(), (0, 2));
+        assert!(!project_dir.path().join(".codex/hooks.json").exists());
+    }
+}

--- a/src/commands/deploy/install.rs
+++ b/src/commands/deploy/install.rs
@@ -11,8 +11,9 @@
 use crate::commands::args::{InteractiveScopeArgs, MultiTargetArgs};
 use crate::component::ComponentKind;
 use crate::install::format::render_hook_success;
-use crate::install::{self, PlaceRequest, PlaceSuccess};
+use crate::install::{self, PlaceRequest, PlaceResult, PlaceSuccess};
 use crate::output::CommandSummary;
+use crate::plugin::meta;
 use crate::target::{all_targets, parse_target, Scope};
 use crate::tui;
 use clap::Parser;
@@ -157,6 +158,7 @@ pub async fn run(args: Args) -> std::result::Result<(), String> {
         scope,
         project_root: &project_root,
     });
+    update_status_after_install(package.path(), &result);
 
     // Results are grouped by target to stay compatible with the legacy layout.
     println!("\nPlacement Results:");
@@ -189,6 +191,28 @@ pub async fn run(args: Args) -> std::result::Result<(), String> {
     println!("\n{} {}", summary.prefix, summary.message);
 
     Ok(())
+}
+
+/// install 後のステータス更新
+///
+/// 配置スキャンではプラグイン名を復元できないターゲット固有ファイル
+/// （例: Codex の `.codex/hooks.json`）もあるため、成功した target は
+/// `.plm-meta.json` の `statusByTarget` に記録して enabled 判定を安定させる。
+///
+/// # Arguments
+///
+/// * `plugin_path` - Filesystem path of the cached plugin.
+/// * `result` - Outcome returned by `place_plugin`.
+fn update_status_after_install(plugin_path: &std::path::Path, result: &PlaceResult) {
+    let mut plugin_meta = meta::load_meta(plugin_path).unwrap_or_default();
+
+    for success in &result.successes {
+        plugin_meta.set_status(&success.target, "enabled");
+    }
+
+    if let Err(e) = meta::write_meta(plugin_path, &plugin_meta) {
+        eprintln!("Warning: Failed to update .plm-meta.json: {}", e);
+    }
 }
 
 #[cfg(test)]

--- a/src/commands/deploy/install.rs
+++ b/src/commands/deploy/install.rs
@@ -11,13 +11,11 @@
 use crate::commands::args::{InteractiveScopeArgs, MultiTargetArgs};
 use crate::component::ComponentKind;
 use crate::install::format::{render_hook_success, HookRenderInput};
-use crate::install::{self, PlaceRequest, PlaceResult, PlaceSuccess};
+use crate::install::{self, PlaceRequest, PlaceSuccess};
 use crate::output::CommandSummary;
-use crate::plugin::meta;
 use crate::target::{all_targets, parse_target, Scope};
 use crate::tui;
 use clap::Parser;
-use std::collections::HashSet;
 use std::env;
 
 /// `PlaceSuccess` を表示用の `(stdout 行, stderr ブロック群)` に変換する pure function。
@@ -160,7 +158,7 @@ pub async fn run(args: Args) -> std::result::Result<(), String> {
         scope,
         project_root: &project_root,
     });
-    update_status_after_install(package.path(), &result);
+    install::update_meta_after_place(package.path(), &result);
 
     // Results are grouped by target to stay compatible with the legacy layout.
     println!("\nPlacement Results:");
@@ -193,45 +191,6 @@ pub async fn run(args: Args) -> std::result::Result<(), String> {
     println!("\n{} {}", summary.prefix, summary.message);
 
     Ok(())
-}
-
-/// install 後のステータス更新
-///
-/// 配置スキャンではプラグイン名を復元できないターゲット固有ファイル
-/// （例: Codex の `.codex/hooks.json`）もあるため、target 全体が成功した場合だけ
-/// `.plm-meta.json` の `statusByTarget` に記録して enabled 判定を安定させる。
-///
-/// 実際にステータス更新が発生しなかった場合（全 target が失敗した、`successes`
-/// が空など）は `.plm-meta.json` を書き換えない。失敗 install で不要な
-/// メタデータ更新を避け、ファイル mtime の汚染も防ぐ。
-///
-/// # Arguments
-///
-/// * `plugin_path` - Filesystem path of the cached plugin.
-/// * `result` - Outcome returned by `place_plugin`.
-fn update_status_after_install(plugin_path: &std::path::Path, result: &PlaceResult) {
-    let mut plugin_meta = meta::load_meta(plugin_path).unwrap_or_default();
-    let failed_targets: HashSet<&str> = result
-        .failures
-        .iter()
-        .map(|failure| failure.target.as_str())
-        .collect();
-
-    let mut updated = false;
-    for success in &result.successes {
-        if !failed_targets.contains(success.target.as_str()) {
-            plugin_meta.set_status(&success.target, "enabled");
-            updated = true;
-        }
-    }
-
-    if !updated {
-        return;
-    }
-
-    if let Err(e) = meta::write_meta(plugin_path, &plugin_meta) {
-        eprintln!("Warning: Failed to update .plm-meta.json: {}", e);
-    }
 }
 
 #[cfg(test)]

--- a/src/commands/deploy/install.rs
+++ b/src/commands/deploy/install.rs
@@ -32,6 +32,7 @@ use std::env;
 pub fn render_place_success_to_strings(success: &PlaceSuccess) -> (String, Vec<String>) {
     let rendered = render_hook_success(
         success.component_kind,
+        success.target_kind,
         success.hook_source_format,
         &success.hook_warnings,
         success.script_count,

--- a/src/commands/deploy/install.rs
+++ b/src/commands/deploy/install.rs
@@ -33,6 +33,7 @@ pub fn render_place_success_to_strings(success: &PlaceSuccess) -> (String, Vec<S
         success.hook_source_format,
         &success.hook_warnings,
         success.script_count,
+        success.hook_count,
     );
 
     let suffix = match rendered.stdout_suffix {

--- a/src/commands/deploy/install.rs
+++ b/src/commands/deploy/install.rs
@@ -201,6 +201,10 @@ pub async fn run(args: Args) -> std::result::Result<(), String> {
 /// （例: Codex の `.codex/hooks.json`）もあるため、target 全体が成功した場合だけ
 /// `.plm-meta.json` の `statusByTarget` に記録して enabled 判定を安定させる。
 ///
+/// 実際にステータス更新が発生しなかった場合（全 target が失敗した、`successes`
+/// が空など）は `.plm-meta.json` を書き換えない。失敗 install で不要な
+/// メタデータ更新を避け、ファイル mtime の汚染も防ぐ。
+///
 /// # Arguments
 ///
 /// * `plugin_path` - Filesystem path of the cached plugin.
@@ -213,10 +217,16 @@ fn update_status_after_install(plugin_path: &std::path::Path, result: &PlaceResu
         .map(|failure| failure.target.as_str())
         .collect();
 
+    let mut updated = false;
     for success in &result.successes {
         if !failed_targets.contains(success.target.as_str()) {
             plugin_meta.set_status(&success.target, "enabled");
+            updated = true;
         }
+    }
+
+    if !updated {
+        return;
     }
 
     if let Err(e) = meta::write_meta(plugin_path, &plugin_meta) {

--- a/src/commands/deploy/install.rs
+++ b/src/commands/deploy/install.rs
@@ -17,6 +17,7 @@ use crate::plugin::meta;
 use crate::target::{all_targets, parse_target, Scope};
 use crate::tui;
 use clap::Parser;
+use std::collections::HashSet;
 use std::env;
 
 /// `PlaceSuccess` を表示用の `(stdout 行, stderr ブロック群)` に変換する pure function。
@@ -196,7 +197,7 @@ pub async fn run(args: Args) -> std::result::Result<(), String> {
 /// install 後のステータス更新
 ///
 /// 配置スキャンではプラグイン名を復元できないターゲット固有ファイル
-/// （例: Codex の `.codex/hooks.json`）もあるため、成功した target は
+/// （例: Codex の `.codex/hooks.json`）もあるため、target 全体が成功した場合だけ
 /// `.plm-meta.json` の `statusByTarget` に記録して enabled 判定を安定させる。
 ///
 /// # Arguments
@@ -205,9 +206,16 @@ pub async fn run(args: Args) -> std::result::Result<(), String> {
 /// * `result` - Outcome returned by `place_plugin`.
 fn update_status_after_install(plugin_path: &std::path::Path, result: &PlaceResult) {
     let mut plugin_meta = meta::load_meta(plugin_path).unwrap_or_default();
+    let failed_targets: HashSet<&str> = result
+        .failures
+        .iter()
+        .map(|failure| failure.target.as_str())
+        .collect();
 
     for success in &result.successes {
-        plugin_meta.set_status(&success.target, "enabled");
+        if !failed_targets.contains(success.target.as_str()) {
+            plugin_meta.set_status(&success.target, "enabled");
+        }
     }
 
     if let Err(e) = meta::write_meta(plugin_path, &plugin_meta) {

--- a/src/commands/deploy/install.rs
+++ b/src/commands/deploy/install.rs
@@ -10,7 +10,7 @@
 
 use crate::commands::args::{InteractiveScopeArgs, MultiTargetArgs};
 use crate::component::ComponentKind;
-use crate::install::format::render_hook_success;
+use crate::install::format::{render_hook_success, HookRenderInput};
 use crate::install::{self, PlaceRequest, PlaceResult, PlaceSuccess};
 use crate::output::CommandSummary;
 use crate::plugin::meta;
@@ -30,14 +30,14 @@ use std::env;
 ///
 /// stderr ブロック群は Hook のみ `render_hook_success` の `stderr_blocks` を返す。
 pub fn render_place_success_to_strings(success: &PlaceSuccess) -> (String, Vec<String>) {
-    let rendered = render_hook_success(
-        success.component_kind,
-        success.target_kind,
-        success.hook_source_format,
-        &success.hook_warnings,
-        success.script_count,
-        success.hook_count,
-    );
+    let rendered = render_hook_success(HookRenderInput {
+        component_kind: success.component_kind,
+        target_kind: success.target_kind,
+        hook_source_format: success.hook_source_format,
+        hook_warnings: &success.hook_warnings,
+        script_count: success.script_count,
+        hook_count: success.hook_count,
+    });
 
     let suffix = match rendered.stdout_suffix {
         Some(s) => s,

--- a/src/commands/deploy/install_test.rs
+++ b/src/commands/deploy/install_test.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::component::ComponentKind;
 use crate::hooks::converter::{ConversionWarning, SourceFormat};
-use crate::install::{PlaceResult, PlaceSuccess};
+use crate::install::{PlaceFailure, PlaceFailureStage, PlaceResult, PlaceSuccess};
 use std::path::PathBuf;
 use tempfile::TempDir;
 
@@ -231,4 +231,36 @@ fn update_status_after_install_marks_successful_targets_enabled() {
 
     let plugin_meta = crate::plugin::meta::load_meta(temp.path()).unwrap();
     assert_eq!(plugin_meta.get_status("codex"), Some("enabled"));
+}
+
+#[test]
+fn update_status_after_install_skips_targets_with_failures() {
+    let temp = TempDir::new().unwrap();
+    let result = PlaceResult {
+        plugin_name: "test-plugin".to_string(),
+        successes: vec![make_success(
+            ComponentKind::Hook,
+            "test-plugin_hooks",
+            "codex",
+            "/dest/codex/hooks.json",
+            None,
+            None,
+            vec![],
+            0,
+            1,
+            Some(SourceFormat::ClaudeCode),
+        )],
+        failures: vec![PlaceFailure {
+            target: "codex".to_string(),
+            component_name: "test-plugin_skill".to_string(),
+            component_kind: ComponentKind::Skill,
+            error: "failed".to_string(),
+            stage: PlaceFailureStage::Deployment,
+        }],
+    };
+
+    update_status_after_install(temp.path(), &result);
+
+    let plugin_meta = crate::plugin::meta::load_meta(temp.path()).unwrap();
+    assert_eq!(plugin_meta.get_status("codex"), None);
 }

--- a/src/commands/deploy/install_test.rs
+++ b/src/commands/deploy/install_test.rs
@@ -284,7 +284,10 @@ fn update_meta_after_place_skips_managed_file_for_non_hook_codex_success() {
 }
 
 #[test]
-fn update_status_after_install_skips_targets_with_failures() {
+fn update_status_after_install_skips_status_when_target_has_failures() {
+    // 同 target 内に failure がある場合、Hook+Codex 成功のファイル所有権
+    // (managedFiles) は「実際に書かれた」事実として記録する一方、
+    // statusByTarget = "enabled" は target 全体成功時のみ昇格させる。
     let temp = TempDir::new().unwrap();
     let result = PlaceResult {
         plugin_name: "test-plugin".to_string(),
@@ -311,11 +314,16 @@ fn update_status_after_install_skips_targets_with_failures() {
 
     crate::install::update_meta_after_place(temp.path(), &result);
 
-    // 同 target 内に failure があるとステータス更新は発生しないため、
-    // .plm-meta.json は新規作成されない（不要な書き込みを避ける）。
+    let plugin_meta = crate::plugin::meta::load_meta(temp.path())
+        .expect("Hook+Codex 成功時は managedFiles 記録のため .plm-meta.json が書かれる");
     assert!(
-        crate::plugin::meta::load_meta(temp.path()).is_none(),
-        "failed-target install must not create .plm-meta.json"
+        plugin_meta.manages_file("codex", std::path::Path::new("/dest/codex/hooks.json")),
+        "実配置済みファイルは failure ゲートとは独立に managedFiles に記録される"
+    );
+    assert_ne!(
+        plugin_meta.get_status("codex"),
+        Some("enabled"),
+        "target に failure があれば statusByTarget は enabled 昇格しない"
     );
 }
 

--- a/src/commands/deploy/install_test.rs
+++ b/src/commands/deploy/install_test.rs
@@ -24,6 +24,7 @@ fn make_success(
         dest_format: dest_format.map(|s| s.to_string()),
         hook_warnings,
         script_count,
+        hook_count: script_count,
         hook_source_format,
     }
 }

--- a/src/commands/deploy/install_test.rs
+++ b/src/commands/deploy/install_test.rs
@@ -1,8 +1,9 @@
 use super::*;
 use crate::component::ComponentKind;
 use crate::hooks::converter::{ConversionWarning, SourceFormat};
-use crate::install::PlaceSuccess;
+use crate::install::{PlaceResult, PlaceSuccess};
 use std::path::PathBuf;
+use tempfile::TempDir;
 
 fn make_success(
     component_kind: ComponentKind,
@@ -177,4 +178,29 @@ fn render_place_success_instruction_no_suffix_no_stderr() {
     assert!(!stdout.contains("(Converted:"));
     assert!(!stdout.contains("(converted from Claude Code format)"));
     assert!(stderr.is_empty());
+}
+
+#[test]
+fn update_status_after_install_marks_successful_targets_enabled() {
+    let temp = TempDir::new().unwrap();
+    let result = PlaceResult {
+        plugin_name: "test-plugin".to_string(),
+        successes: vec![make_success(
+            ComponentKind::Hook,
+            "test-plugin_hooks",
+            "codex",
+            "/dest/codex/hooks.json",
+            None,
+            None,
+            vec![],
+            0,
+            Some(SourceFormat::ClaudeCode),
+        )],
+        failures: vec![],
+    };
+
+    update_status_after_install(temp.path(), &result);
+
+    let plugin_meta = crate::plugin::meta::load_meta(temp.path()).unwrap();
+    assert_eq!(plugin_meta.get_status("codex"), Some("enabled"));
 }

--- a/src/commands/deploy/install_test.rs
+++ b/src/commands/deploy/install_test.rs
@@ -14,6 +14,7 @@ fn make_success(
     dest_format: Option<&str>,
     hook_warnings: Vec<ConversionWarning>,
     script_count: usize,
+    hook_count: usize,
     hook_source_format: Option<SourceFormat>,
 ) -> PlaceSuccess {
     PlaceSuccess {
@@ -25,7 +26,7 @@ fn make_success(
         dest_format: dest_format.map(|s| s.to_string()),
         hook_warnings,
         script_count,
-        hook_count: script_count,
+        hook_count,
         hook_source_format,
     }
 }
@@ -51,6 +52,7 @@ fn render_place_success_hook_claude_code_with_unsupported_events() {
             },
         ],
         1,
+        1,
         Some(SourceFormat::ClaudeCode),
     );
     let (stdout, stderr) = render_place_success_to_strings(&success);
@@ -70,6 +72,7 @@ fn render_place_success_hook_target_format_with_missing_version() {
         None,
         None,
         vec![ConversionWarning::MissingVersion],
+        0,
         0,
         Some(SourceFormat::TargetFormat),
     );
@@ -95,6 +98,7 @@ fn render_place_success_hook_passthrough_copied_no_warnings() {
         None,
         vec![],
         0,
+        0,
         None,
     );
     let (stdout, stderr) = render_place_success_to_strings(&success);
@@ -113,6 +117,7 @@ fn render_place_success_command_keeps_legacy_converted_suffix() {
         Some("ClaudeCode"),
         Some("Copilot"),
         vec![],
+        0,
         0,
         None,
     );
@@ -133,6 +138,7 @@ fn render_place_success_agent_keeps_legacy_converted_suffix() {
         Some("Copilot"),
         vec![],
         0,
+        0,
         None,
     );
     let (stdout, stderr) = render_place_success_to_strings(&success);
@@ -151,6 +157,7 @@ fn render_place_success_skill_no_suffix_no_stderr() {
         None,
         None,
         vec![],
+        0,
         0,
         None,
     );
@@ -172,12 +179,32 @@ fn render_place_success_instruction_no_suffix_no_stderr() {
         None,
         vec![],
         0,
+        0,
         None,
     );
     let (stdout, stderr) = render_place_success_to_strings(&success);
     assert!(!stdout.contains("(Converted:"));
     assert!(!stdout.contains("(converted from Claude Code format)"));
     assert!(stderr.is_empty());
+}
+
+#[test]
+fn make_success_keeps_hook_count_independent_from_script_count() {
+    let success = make_success(
+        ComponentKind::Hook,
+        "codex-hook",
+        "codex",
+        "/dest/codex/hooks.json",
+        None,
+        None,
+        vec![],
+        0,
+        1,
+        Some(SourceFormat::ClaudeCode),
+    );
+
+    assert_eq!(success.script_count, 0);
+    assert_eq!(success.hook_count, 1);
 }
 
 #[test]
@@ -194,6 +221,7 @@ fn update_status_after_install_marks_successful_targets_enabled() {
             None,
             vec![],
             0,
+            1,
             Some(SourceFormat::ClaudeCode),
         )],
         failures: vec![],

--- a/src/commands/deploy/install_test.rs
+++ b/src/commands/deploy/install_test.rs
@@ -243,6 +243,44 @@ fn update_status_after_install_marks_successful_targets_enabled() {
 
     let plugin_meta = crate::plugin::meta::load_meta(temp.path()).unwrap();
     assert_eq!(plugin_meta.get_status("codex"), Some("enabled"));
+    // Hook + Codex は所有権としても記録される
+    assert!(plugin_meta.manages_file("codex", std::path::Path::new("/dest/codex/hooks.json")));
+}
+
+#[test]
+fn update_meta_after_place_skips_managed_file_for_non_hook_codex_success() {
+    // Skill のみ Codex に配置されたケースは statusByTarget は enabled になるが、
+    // managedFiles には記録されない（hook_overwrite_error が誤って通過しないため）。
+    let temp = TempDir::new().unwrap();
+    let result = PlaceResult {
+        plugin_name: "test-plugin".to_string(),
+        successes: vec![make_success(
+            ComponentKind::Skill,
+            "test-plugin_skill",
+            "codex",
+            "/dest/codex/skills/test-plugin_skill",
+            None,
+            None,
+            vec![],
+            0,
+            0,
+            None,
+        )],
+        failures: vec![],
+    };
+
+    crate::install::update_meta_after_place(temp.path(), &result);
+
+    let plugin_meta = crate::plugin::meta::load_meta(temp.path()).unwrap();
+    assert_eq!(plugin_meta.get_status("codex"), Some("enabled"));
+    assert!(
+        !plugin_meta.manages_file("codex", std::path::Path::new("/dest/codex/hooks.json")),
+        "Skill 配置のみで hooks.json の所有権を獲得してはならない"
+    );
+    assert!(plugin_meta
+        .managed_files
+        .get("codex")
+        .is_none_or(|v| v.is_empty()));
 }
 
 #[test]

--- a/src/commands/deploy/install_test.rs
+++ b/src/commands/deploy/install_test.rs
@@ -248,6 +248,46 @@ fn update_status_after_install_marks_successful_targets_enabled() {
 }
 
 #[test]
+fn update_meta_after_place_does_not_rewrite_when_meta_already_up_to_date() {
+    // 既に enabled かつ managedFiles 登録済みの状態で再実行した場合、
+    // .plm-meta.json の mtime を更新してはならない。
+    let temp = TempDir::new().unwrap();
+    let mut prepared = crate::plugin::meta::PluginMeta::default();
+    prepared.set_status("codex", "enabled");
+    prepared.add_managed_file("codex", std::path::Path::new("/dest/codex/hooks.json"));
+    crate::plugin::meta::write_meta(temp.path(), &prepared).unwrap();
+
+    let meta_path = temp.path().join(".plm-meta.json");
+    let mtime_before = std::fs::metadata(&meta_path).unwrap().modified().unwrap();
+    std::thread::sleep(std::time::Duration::from_millis(50));
+
+    let result = PlaceResult {
+        plugin_name: "test-plugin".to_string(),
+        successes: vec![make_success(
+            ComponentKind::Hook,
+            "test-plugin_hooks",
+            "codex",
+            "/dest/codex/hooks.json",
+            None,
+            None,
+            vec![],
+            0,
+            1,
+            Some(SourceFormat::ClaudeCode),
+        )],
+        failures: vec![],
+    };
+
+    crate::install::update_meta_after_place(temp.path(), &result);
+
+    let mtime_after = std::fs::metadata(&meta_path).unwrap().modified().unwrap();
+    assert_eq!(
+        mtime_before, mtime_after,
+        "内容変化なしの場合は .plm-meta.json を書き換えない"
+    );
+}
+
+#[test]
 fn update_meta_after_place_skips_managed_file_for_non_hook_codex_success() {
     // Skill のみ Codex に配置されたケースは statusByTarget は enabled になるが、
     // managedFiles には記録されない（hook_overwrite_error が誤って通過しないため）。

--- a/src/commands/deploy/install_test.rs
+++ b/src/commands/deploy/install_test.rs
@@ -273,6 +273,34 @@ fn update_status_after_install_skips_targets_with_failures() {
 
     update_status_after_install(temp.path(), &result);
 
-    let plugin_meta = crate::plugin::meta::load_meta(temp.path()).unwrap();
-    assert_eq!(plugin_meta.get_status("codex"), None);
+    // 同 target 内に failure があるとステータス更新は発生しないため、
+    // .plm-meta.json は新規作成されない（不要な書き込みを避ける）。
+    assert!(
+        crate::plugin::meta::load_meta(temp.path()).is_none(),
+        "failed-target install must not create .plm-meta.json"
+    );
+}
+
+#[test]
+fn update_status_after_install_skips_write_when_all_failed() {
+    // 全 target が失敗（successes が空）の場合、.plm-meta.json を書き換えない。
+    let temp = TempDir::new().unwrap();
+    let result = PlaceResult {
+        plugin_name: "test-plugin".to_string(),
+        successes: vec![],
+        failures: vec![PlaceFailure {
+            target: "codex".to_string(),
+            component_name: "test-plugin_hook".to_string(),
+            component_kind: ComponentKind::Hook,
+            error: "failed".to_string(),
+            stage: PlaceFailureStage::Deployment,
+        }],
+    };
+
+    update_status_after_install(temp.path(), &result);
+
+    assert!(
+        crate::plugin::meta::load_meta(temp.path()).is_none(),
+        "fully-failed install must not create .plm-meta.json"
+    );
 }

--- a/src/commands/deploy/install_test.rs
+++ b/src/commands/deploy/install_test.rs
@@ -2,8 +2,19 @@ use super::*;
 use crate::component::ComponentKind;
 use crate::hooks::converter::{ConversionWarning, SourceFormat};
 use crate::install::{PlaceFailure, PlaceFailureStage, PlaceResult, PlaceSuccess};
+use crate::target::TargetKind;
 use std::path::PathBuf;
 use tempfile::TempDir;
+
+fn target_kind_from_name(name: &str) -> TargetKind {
+    match name {
+        "antigravity" => TargetKind::Antigravity,
+        "codex" => TargetKind::Codex,
+        "copilot" => TargetKind::Copilot,
+        "gemini" => TargetKind::GeminiCli,
+        other => panic!("unknown target name in test fixture: {}", other),
+    }
+}
 
 fn make_success(
     component_kind: ComponentKind,
@@ -19,6 +30,7 @@ fn make_success(
 ) -> PlaceSuccess {
     PlaceSuccess {
         target: target.to_string(),
+        target_kind: target_kind_from_name(target),
         component_name: component_name.to_string(),
         component_kind,
         target_path: PathBuf::from(target_path),

--- a/src/commands/deploy/install_test.rs
+++ b/src/commands/deploy/install_test.rs
@@ -239,7 +239,7 @@ fn update_status_after_install_marks_successful_targets_enabled() {
         failures: vec![],
     };
 
-    update_status_after_install(temp.path(), &result);
+    crate::install::update_meta_after_place(temp.path(), &result);
 
     let plugin_meta = crate::plugin::meta::load_meta(temp.path()).unwrap();
     assert_eq!(plugin_meta.get_status("codex"), Some("enabled"));
@@ -271,7 +271,7 @@ fn update_status_after_install_skips_targets_with_failures() {
         }],
     };
 
-    update_status_after_install(temp.path(), &result);
+    crate::install::update_meta_after_place(temp.path(), &result);
 
     // 同 target 内に failure があるとステータス更新は発生しないため、
     // .plm-meta.json は新規作成されない（不要な書き込みを避ける）。
@@ -297,7 +297,7 @@ fn update_status_after_install_skips_write_when_all_failed() {
         }],
     };
 
-    update_status_after_install(temp.path(), &result);
+    crate::install::update_meta_after_place(temp.path(), &result);
 
     assert!(
         crate::plugin::meta::load_meta(temp.path()).is_none(),

--- a/src/component/deployment/hook_deploy.rs
+++ b/src/component/deployment/hook_deploy.rs
@@ -13,6 +13,28 @@ use std::fs;
 use std::path::Path;
 
 impl ComponentDeployment {
+    /// 変換後 JSON に残った hook 定義数を数える。
+    ///
+    /// Copilot は `hooks.<event>[]` のフラット構造、Codex は
+    /// `hooks.<event>[].hooks[]` の matcher group 構造を使うため両方を扱う。
+    fn count_hooks_in_json(json: &serde_json::Value) -> usize {
+        let Some(hooks) = json.get("hooks").and_then(|h| h.as_object()) else {
+            return 0;
+        };
+
+        hooks
+            .values()
+            .filter_map(|event_hooks| event_hooks.as_array())
+            .flat_map(|event_hooks| event_hooks.iter())
+            .map(|entry| {
+                entry
+                    .get("hooks")
+                    .and_then(|nested| nested.as_array())
+                    .map_or(1, |nested| nested.len())
+            })
+            .sum()
+    }
+
     /// JSON 内の hooks[].bash パスを名前空間付きに書き換える
     ///
     /// # Arguments
@@ -99,6 +121,7 @@ impl ComponentDeployment {
 
         let json_str = serde_json::to_string_pretty(&convert_result.json)
             .map_err(|e| PlmError::HookConversion(format!("Failed to serialize JSON: {}", e)))?;
+        let hook_count = Self::count_hooks_in_json(&convert_result.json);
 
         if let Some(parent) = self.target_path.parent() {
             fs::create_dir_all(parent)?;
@@ -111,6 +134,7 @@ impl ComponentDeployment {
             return Ok(DeploymentOutput::HookConverted(HookConvertOutput {
                 warnings: convert_result.warnings,
                 script_count: 0,
+                hook_count,
                 source_format: convert_result.source_format,
             }));
         }
@@ -149,6 +173,7 @@ impl ComponentDeployment {
         Ok(DeploymentOutput::HookConverted(HookConvertOutput {
             warnings: convert_result.warnings,
             script_count,
+            hook_count,
             source_format: convert_result.source_format,
         }))
     }

--- a/src/component/deployment/output.rs
+++ b/src/component/deployment/output.rs
@@ -25,6 +25,7 @@ pub enum DeploymentOutput {
 pub struct HookConvertOutput {
     pub warnings: Vec<ConversionWarning>,
     pub script_count: usize,
+    pub hook_count: usize,
     /// 入力 JSON が Claude Code 形式だったか Copilot 形式（passthrough）だったか。
     /// `(converted from Claude Code format)` サフィックスの判定に使う。
     pub source_format: SourceFormat,

--- a/src/component/deployment/output_test.rs
+++ b/src/component/deployment/output_test.rs
@@ -12,11 +12,13 @@ fn test_hook_convert_result_has_expected_fields() {
     let result = HookConvertOutput {
         warnings: vec![ConversionWarning::MissingVersion],
         script_count: 2,
+        hook_count: 2,
         source_format: SourceFormat::ClaudeCode,
     };
 
     assert_eq!(result.warnings.len(), 1);
     assert_eq!(result.script_count, 2);
+    assert_eq!(result.hook_count, 2);
     assert_eq!(result.source_format, SourceFormat::ClaudeCode);
 }
 
@@ -25,6 +27,7 @@ fn test_deployment_result_hook_converted_variant() {
     let hook_result = HookConvertOutput {
         warnings: vec![],
         script_count: 0,
+        hook_count: 0,
         source_format: SourceFormat::ClaudeCode,
     };
     let result = DeploymentOutput::HookConverted(hook_result);
@@ -93,6 +96,7 @@ fn test_display_hook_converted() {
     let result = DeploymentOutput::HookConverted(HookConvertOutput {
         warnings: vec![ConversionWarning::MissingVersion],
         script_count: 3,
+        hook_count: 3,
         source_format: SourceFormat::ClaudeCode,
     });
     assert_eq!(result.to_string(), "Hook converted (3 scripts, 1 warning)");

--- a/src/hooks/converter/codex.rs
+++ b/src/hooks/converter/codex.rs
@@ -1,8 +1,8 @@
-//! Codex skeleton implementation of the hook conversion layers.
+//! Codex implementation of the hook conversion layers.
 //!
 //! EventMap is in `event/codex.rs`; ToolMap is in `tool/codex.rs`.
-//! KeyMap passes through as-is, StructureConverter performs no transformation,
-//! and ScriptGenerator returns empty stubs (or errors for http).
+//! Codex Hooks keep the Claude Code-style PascalCase event and matcher-group
+//! structure, so this layer mostly validates and strips unsupported fields.
 
 use serde_json::Value;
 
@@ -12,11 +12,51 @@ use crate::hooks::converter::{ConversionWarning, ScriptInfo, SourceFormat};
 
 use super::converter::{KeyMap, ScriptGenerator, StructureConverter};
 
+pub(crate) use super::super::event::codex::CodexEventMap;
+
 pub(crate) struct CodexKeyMap;
 
 impl KeyMap for CodexKeyMap {
-    fn map_keys(&self, hook: &Value, _hook_type: &str) -> (Value, Vec<ConversionWarning>) {
-        (hook.clone(), vec![])
+    fn map_keys(&self, hook: &Value, hook_type: &str) -> (Value, Vec<ConversionWarning>) {
+        let Some(hook_obj) = hook.as_object() else {
+            return (hook.clone(), vec![]);
+        };
+
+        let mut output = serde_json::Map::new();
+        let mut warnings = Vec::new();
+
+        for (key, value) in hook_obj {
+            match key.as_str() {
+                "async" => warnings.push(ConversionWarning::RemovedField {
+                    field: "async".to_string(),
+                    reason: "Codex hooks do not support async hooks".to_string(),
+                }),
+                "once" => warnings.push(ConversionWarning::RemovedField {
+                    field: "once".to_string(),
+                    reason: "Codex hooks do not support once hooks".to_string(),
+                }),
+                // Copilot-specific fields should not leak into Codex hooks.
+                "bash" => warnings.push(ConversionWarning::RemovedField {
+                    field: "bash".to_string(),
+                    reason: "Codex hooks use command, not bash wrapper paths".to_string(),
+                }),
+                "timeoutSec" => {
+                    output.insert("timeout".to_string(), value.clone());
+                }
+                "comment" => {
+                    output.insert("statusMessage".to_string(), value.clone());
+                }
+                _ => {
+                    output.insert(key.clone(), value.clone());
+                }
+            }
+        }
+
+        if hook_type == "command" {
+            output.insert("type".to_string(), Value::from("command"));
+        }
+
+        (Value::Object(output), warnings)
     }
 }
 
@@ -35,7 +75,28 @@ impl StructureConverter for CodexStructureConverter {
     }
 
     fn convert_top_level(&self, value: &Value) -> (Value, Vec<ConversionWarning>) {
-        (value.clone(), vec![])
+        let mut result = value.clone();
+        let mut warnings = Vec::new();
+
+        let Some(obj) = result.as_object_mut() else {
+            return (result, warnings);
+        };
+
+        if obj.remove("version").is_some() {
+            warnings.push(ConversionWarning::RemovedField {
+                field: "version".to_string(),
+                reason: "Codex hooks do not use Copilot CLI's version field".to_string(),
+            });
+        }
+
+        if obj.remove("disableAllHooks").is_some() {
+            warnings.push(ConversionWarning::RemovedField {
+                field: "disableAllHooks".to_string(),
+                reason: "Codex hooks do not support disableAllHooks".to_string(),
+            });
+        }
+
+        (result, warnings)
     }
 }
 
@@ -44,7 +105,7 @@ pub(crate) struct CodexScriptGenerator;
 impl ScriptGenerator for CodexScriptGenerator {
     fn generate_command_script(
         &self,
-        _hook: &CommandHook<'_>,
+        hook: &CommandHook<'_>,
         _event: &str,
         _matcher: Option<&str>,
         _index: usize,
@@ -52,35 +113,38 @@ impl ScriptGenerator for CodexScriptGenerator {
         ScriptInfo {
             path: String::new(),
             content: String::new(),
-            original_config: Value::Null,
+            original_config: hook.raw.clone(),
             matcher: None,
         }
     }
 
     fn generate_http_script(
         &self,
-        _hook: &HttpHook<'_>,
+        hook: &HttpHook<'_>,
         _event: &str,
-        _matcher: Option<&str>,
+        matcher: Option<&str>,
         _index: usize,
     ) -> Result<ScriptInfo, PlmError> {
-        Err(PlmError::HookConversion(
-            "Codex hook conversion is not yet implemented".to_string(),
-        ))
+        Ok(ScriptInfo {
+            path: String::new(),
+            content: String::new(),
+            original_config: hook.raw.clone(),
+            matcher: matcher.map(|s| s.to_string()),
+        })
     }
 
     fn generate_stub_script(
         &self,
-        _hook: &StubHook<'_>,
+        hook: &StubHook<'_>,
         _event: &str,
-        _matcher: Option<&str>,
+        matcher: Option<&str>,
         _index: usize,
     ) -> ScriptInfo {
         ScriptInfo {
             path: String::new(),
             content: String::new(),
-            original_config: Value::Null,
-            matcher: None,
+            original_config: hook.raw.clone(),
+            matcher: matcher.map(|s| s.to_string()),
         }
     }
 }

--- a/src/hooks/converter/codex.rs
+++ b/src/hooks/converter/codex.rs
@@ -40,9 +40,10 @@ impl KeyMap for CodexKeyMap {
                     field: "bash".to_string(),
                     reason: "Codex hooks use command, not bash wrapper paths".to_string(),
                 }),
-                "timeoutSec" => {
+                "timeoutSec" if !output.contains_key("timeout") => {
                     output.insert("timeout".to_string(), value.clone());
                 }
+                "timeoutSec" => {}
                 "comment" => {
                     output.insert("statusMessage".to_string(), value.clone());
                 }

--- a/src/hooks/converter/codex_test.rs
+++ b/src/hooks/converter/codex_test.rs
@@ -1,26 +1,62 @@
-//! Unit tests for Codex skeleton conversion layers.
+//! Unit tests for Codex hook conversion layers.
 
 use serde_json::json;
 
 use super::super::event::codex::CodexEventMap;
-use super::super::model::HttpHook;
+use super::super::model::{CommandHook, HttpHook};
 use super::codex::{CodexKeyMap, CodexScriptGenerator, CodexStructureConverter};
-use super::converter::{EventMap, KeyMap, ScriptGenerator, SourceFormat, StructureConverter};
+use super::converter::{
+    convert, ConversionWarning, EventMap, KeyMap, ScriptGenerator, SourceFormat, StructureConverter,
+};
+use crate::target::TargetKind;
 
 #[test]
-fn test_codex_event_map_returns_none() {
+fn test_codex_event_map_keeps_supported_events() {
     let map = CodexEventMap;
-    assert_eq!(map.map_event("SessionStart"), None);
-    assert_eq!(map.map_event("PreToolUse"), None);
+    assert_eq!(map.map_event("SessionStart"), Some("SessionStart"));
+    assert_eq!(map.map_event("PreToolUse"), Some("PreToolUse"));
+    assert_eq!(map.map_event("PostToolUse"), Some("PostToolUse"));
+    assert_eq!(map.map_event("UserPromptSubmit"), Some("UserPromptSubmit"));
+    assert_eq!(map.map_event("Stop"), Some("Stop"));
+    assert_eq!(
+        map.map_event("PermissionRequest"),
+        Some("PermissionRequest")
+    );
+    assert_eq!(map.map_event("SubagentStop"), None);
 }
 
 #[test]
-fn test_codex_key_map_passthrough() {
+fn test_codex_key_map_keeps_command_fields() {
     let map = CodexKeyMap;
     let hook = json!({"type": "command", "command": "echo hi", "timeout": 10});
     let (mapped, warnings) = map.map_keys(&hook, "command");
     assert_eq!(mapped, hook);
     assert!(warnings.is_empty());
+}
+
+#[test]
+fn test_codex_key_map_removes_unsupported_fields() {
+    let map = CodexKeyMap;
+    let hook = json!({
+        "type": "command",
+        "command": "echo hi",
+        "async": true,
+        "once": true,
+        "bash": "./wrappers/hook.sh",
+        "timeoutSec": 3,
+        "comment": "checking"
+    });
+
+    let (mapped, warnings) = map.map_keys(&hook, "command");
+
+    assert_eq!(mapped["type"], "command");
+    assert_eq!(mapped["command"], "echo hi");
+    assert_eq!(mapped["timeout"], 3);
+    assert_eq!(mapped["statusMessage"], "checking");
+    assert!(mapped.get("async").is_none());
+    assert!(mapped.get("once").is_none());
+    assert!(mapped.get("bash").is_none());
+    assert_eq!(warnings.len(), 3);
 }
 
 #[test]
@@ -34,20 +70,97 @@ fn test_codex_structure_converter_detects_claude_code() {
 }
 
 #[test]
-fn test_codex_structure_converter_top_level_passthrough() {
+fn test_codex_structure_converter_removes_non_codex_top_level_fields() {
     let conv = CodexStructureConverter;
-    let value = json!({"hooks": {"SessionStart": []}});
+    let value = json!({"version": 1, "disableAllHooks": true, "hooks": {"SessionStart": []}});
     let (result, warnings) = conv.convert_top_level(&value);
-    assert_eq!(result, value);
-    assert!(warnings.is_empty());
+    assert!(result.get("version").is_none());
+    assert!(result.get("disableAllHooks").is_none());
+    assert_eq!(result["hooks"], json!({"SessionStart": []}));
+    assert_eq!(warnings.len(), 2);
 }
 
 #[test]
-fn test_codex_script_generator_http_returns_error() {
+fn test_codex_script_generator_command_returns_inline_marker() {
+    let gen = CodexScriptGenerator;
+    let hook_value = json!({"type": "command", "command": "echo hi"});
+    let hook_obj = hook_value.as_object().unwrap();
+    let command = CommandHook::new(hook_obj, &hook_value).unwrap();
+    let result = gen.generate_command_script(&command, "SessionStart", None, 0);
+    assert!(result.path.is_empty());
+    assert!(result.content.is_empty());
+    assert_eq!(result.original_config, hook_value);
+}
+
+#[test]
+fn test_codex_script_generator_http_returns_inline_exclusion_marker() {
     let gen = CodexScriptGenerator;
     let hook_value = json!({"type": "http", "url": "https://example.com"});
     let hook_obj = hook_value.as_object().unwrap();
     let http = HttpHook::new(hook_obj, &hook_value).unwrap();
     let result = gen.generate_http_script(&http, "sessionStart", None, 0);
-    assert!(result.is_err());
+    let info = result.unwrap();
+    assert!(info.path.is_empty());
+}
+
+#[test]
+fn test_codex_convert_keeps_command_hook_inline() {
+    let input = r#"{
+        "hooks": {
+            "PreToolUse": [
+                {
+                    "matcher": "Bash",
+                    "hooks": [
+                        {"type": "command", "command": "echo hi", "timeout": 5}
+                    ]
+                }
+            ]
+        }
+    }"#;
+
+    let result = convert(input, TargetKind::Codex).unwrap();
+
+    assert!(result.scripts.is_empty());
+    assert_eq!(result.json["hooks"]["PreToolUse"][0]["matcher"], "Bash");
+    assert_eq!(
+        result.json["hooks"]["PreToolUse"][0]["hooks"][0]["type"],
+        "command"
+    );
+    assert_eq!(
+        result.json["hooks"]["PreToolUse"][0]["hooks"][0]["command"],
+        "echo hi"
+    );
+    assert!(result.json["hooks"]["PreToolUse"][0]["hooks"][0]
+        .get("bash")
+        .is_none());
+}
+
+#[test]
+fn test_codex_convert_excludes_unsupported_hook_types() {
+    let input = r#"{
+        "hooks": {
+            "PreToolUse": [
+                {
+                    "matcher": "Bash",
+                    "hooks": [
+                        {"type": "http", "url": "https://example.com"},
+                        {"type": "prompt", "prompt": "check this"}
+                    ]
+                }
+            ]
+        }
+    }"#;
+
+    let result = convert(input, TargetKind::Codex).unwrap();
+
+    assert!(result.scripts.is_empty());
+    assert!(result.json["hooks"].as_object().unwrap().is_empty());
+    assert!(result.warnings.iter().any(|w| matches!(
+        w,
+        ConversionWarning::UnsupportedHookType { hook_type, .. } if hook_type == "http"
+    )));
+    assert!(result.warnings.iter().any(|w| matches!(
+        w,
+        ConversionWarning::UnsupportedHookType { hook_type, .. } if hook_type == "prompt"
+    )));
 }

--- a/src/hooks/converter/codex_test.rs
+++ b/src/hooks/converter/codex_test.rs
@@ -60,6 +60,23 @@ fn test_codex_key_map_removes_unsupported_fields() {
 }
 
 #[test]
+fn test_codex_key_map_prefers_timeout_over_timeout_sec() {
+    let map = CodexKeyMap;
+    let hook = json!({
+        "type": "command",
+        "command": "echo hi",
+        "timeout": 10,
+        "timeoutSec": 3
+    });
+
+    let (mapped, warnings) = map.map_keys(&hook, "command");
+
+    assert_eq!(mapped["timeout"], 10);
+    assert!(mapped.get("timeoutSec").is_none());
+    assert!(warnings.is_empty());
+}
+
+#[test]
 fn test_codex_structure_converter_detects_claude_code() {
     let conv = CodexStructureConverter;
     let value = json!({"hooks": {"SessionStart": []}});

--- a/src/hooks/converter/converter.rs
+++ b/src/hooks/converter/converter.rs
@@ -70,7 +70,7 @@ impl fmt::Display for ConversionWarning {
             ConversionWarning::UnsupportedEvent { event } => {
                 write!(
                     f,
-                    "Event '{}' is not supported in Copilot CLI and was excluded",
+                    "Event '{}' is not supported by the target hook format and was excluded",
                     event
                 )
             }

--- a/src/hooks/converter/converter.rs
+++ b/src/hooks/converter/converter.rs
@@ -240,6 +240,7 @@ pub(crate) struct HookConversionLayers {
     pub key_map: Box<dyn KeyMap>,
     pub structure: Box<dyn StructureConverter>,
     pub script_gen: Box<dyn ScriptGenerator>,
+    pub preserve_matcher_groups: bool,
 }
 
 /// Create conversion layers for the given target.
@@ -255,6 +256,15 @@ pub(crate) fn create_layers(target: TargetKind) -> Result<HookConversionLayers, 
             key_map: Box::new(super::copilot::CopilotKeyMap),
             structure: Box::new(super::copilot::CopilotStructureConverter),
             script_gen: Box::new(super::copilot::CopilotScriptGenerator),
+            preserve_matcher_groups: false,
+        }),
+        TargetKind::Codex => Ok(HookConversionLayers {
+            event_map: Box::new(super::codex::CodexEventMap),
+            tool_map: Some(Box::new(super::super::tool::codex::CodexToolMap)),
+            key_map: Box::new(super::codex::CodexKeyMap),
+            structure: Box::new(super::codex::CodexStructureConverter),
+            script_gen: Box::new(super::codex::CodexScriptGenerator),
+            preserve_matcher_groups: true,
         }),
         other => Err(PlmError::HookConversion(format!(
             "Hook conversion is not yet implemented for target: {}",
@@ -385,7 +395,11 @@ fn convert_event_hooks(
     for (event_name, event_value) in hooks_obj {
         match layers.event_map.map_event(event_name) {
             Some(target_event) => {
-                let converted_hooks = flatten_matchers(event_value, target_event, layers, out)?;
+                let converted_hooks = if layers.preserve_matcher_groups {
+                    preserve_matcher_groups(event_value, target_event, layers, out)?
+                } else {
+                    flatten_matchers(event_value, target_event, layers, out)?
+                };
                 if !converted_hooks.is_empty() {
                     output.insert(target_event.to_string(), Value::Array(converted_hooks));
                 }
@@ -399,6 +413,82 @@ fn convert_event_hooks(
     }
 
     Ok(Value::Object(output))
+}
+
+/// Convert matcher groups while preserving the Claude Code/Codex nested shape.
+///
+/// This is used for Codex, whose native `hooks.json` format keeps event values
+/// as arrays of matcher groups containing `hooks[]`.
+fn preserve_matcher_groups(
+    groups: &Value,
+    event: &str,
+    layers: &HookConversionLayers,
+    out: &mut ConvertOutput<'_>,
+) -> Result<Vec<Value>, PlmError> {
+    let mut result = Vec::new();
+
+    let groups_arr = match groups.as_array() {
+        Some(arr) => arr,
+        None => {
+            out.warnings.push(ConversionWarning::RemovedField {
+                field: event.to_string(),
+                reason: format!(
+                    "Event '{}' value is not an array; expected matcher group structure",
+                    event
+                ),
+            });
+            return Ok(result);
+        }
+    };
+
+    for group in groups_arr {
+        let Some(group_obj) = group.as_object() else {
+            out.warnings.push(ConversionWarning::RemovedField {
+                field: event.to_string(),
+                reason: format!(
+                    "Matcher group in event '{}' is not an object; skipped",
+                    event
+                ),
+            });
+            continue;
+        };
+
+        let matcher = group_obj
+            .get("matcher")
+            .and_then(|m| m.as_str())
+            .filter(|s| !s.is_empty());
+
+        let hooks = match group_obj.get("hooks").and_then(|h| h.as_array()) {
+            Some(arr) => arr,
+            None => {
+                out.warnings.push(ConversionWarning::RemovedField {
+                    field: "hooks".to_string(),
+                    reason: format!(
+                        "Matcher group in event '{}' is missing 'hooks' array; skipped",
+                        event
+                    ),
+                });
+                continue;
+            }
+        };
+
+        let mut converted_hooks = Vec::new();
+        for hook in hooks {
+            if let Some(converted) = convert_hook_definition(hook, matcher, event, layers, out)? {
+                converted_hooks.push(converted);
+            }
+        }
+
+        if converted_hooks.is_empty() {
+            continue;
+        }
+
+        let mut converted_group = group_obj.clone();
+        converted_group.insert("hooks".to_string(), Value::Array(converted_hooks));
+        result.push(Value::Object(converted_group));
+    }
+
+    Ok(result)
 }
 
 /// Flatten matcher groups into a flat array of hook definitions.
@@ -553,6 +643,23 @@ fn convert_hook_definition(
 
     if matches!(action, HookDefinition::Command(_)) && script_info.original_config.is_null() {
         script_info.original_config = hook.clone();
+    }
+
+    if script_info.path.is_empty() {
+        let hook_type = action.hook_type_str().to_string();
+        match action {
+            HookDefinition::Command(_) => {
+                out.warnings.extend(extra_warnings);
+                return Ok(Some(mapped));
+            }
+            HookDefinition::Http(_) | HookDefinition::Stub(_) => {
+                out.warnings.push(ConversionWarning::UnsupportedHookType {
+                    hook_type,
+                    event: event.to_string(),
+                });
+                return Ok(None);
+            }
+        }
     }
 
     let script_path = format!("./{}", script_info.path);

--- a/src/hooks/converter/converter_test.rs
+++ b/src/hooks/converter/converter_test.rs
@@ -16,7 +16,7 @@ fn test_warning_display_unsupported_event() {
     };
     assert_eq!(
         w.to_string(),
-        "Event 'PreCompact' is not supported in Copilot CLI and was excluded"
+        "Event 'PreCompact' is not supported by the target hook format and was excluded"
     );
 }
 

--- a/src/hooks/event/codex.rs
+++ b/src/hooks/event/codex.rs
@@ -1,10 +1,19 @@
 use crate::hooks::converter::EventMap;
 
-/// Codex skeleton: returns `None` for all events.
+/// Codex Hooks use PascalCase event names, matching the Claude Code shape for
+/// the events that both runtimes support.
 pub(crate) struct CodexEventMap;
 
 impl EventMap for CodexEventMap {
-    fn map_event(&self, _event: &str) -> Option<&'static str> {
-        None
+    fn map_event(&self, event: &str) -> Option<&'static str> {
+        match event {
+            "SessionStart" => Some("SessionStart"),
+            "PreToolUse" => Some("PreToolUse"),
+            "PostToolUse" => Some("PostToolUse"),
+            "UserPromptSubmit" => Some("UserPromptSubmit"),
+            "Stop" => Some("Stop"),
+            "PermissionRequest" => Some("PermissionRequest"),
+            _ => None,
+        }
     }
 }

--- a/src/hooks/event/codex_test.rs
+++ b/src/hooks/event/codex_test.rs
@@ -1,15 +1,26 @@
-//! Tests for CodexEventMap (skeleton).
+//! Tests for CodexEventMap.
 
 use super::codex::CodexEventMap;
 use crate::hooks::converter::EventMap;
 
 #[test]
-fn test_codex_event_map_returns_none_for_all() {
+fn test_codex_event_map_keeps_supported_events() {
     let map = CodexEventMap;
-    assert_eq!(map.map_event("SessionStart"), None);
-    assert_eq!(map.map_event("PreToolUse"), None);
-    assert_eq!(map.map_event("PostToolUse"), None);
-    assert_eq!(map.map_event("Stop"), None);
+    assert_eq!(map.map_event("SessionStart"), Some("SessionStart"));
+    assert_eq!(map.map_event("PreToolUse"), Some("PreToolUse"));
+    assert_eq!(map.map_event("PostToolUse"), Some("PostToolUse"));
+    assert_eq!(map.map_event("UserPromptSubmit"), Some("UserPromptSubmit"));
+    assert_eq!(map.map_event("Stop"), Some("Stop"));
+    assert_eq!(
+        map.map_event("PermissionRequest"),
+        Some("PermissionRequest")
+    );
+}
+
+#[test]
+fn test_codex_event_map_rejects_unsupported_events() {
+    let map = CodexEventMap;
+    assert_eq!(map.map_event("SubagentStop"), None);
     assert_eq!(map.map_event("unknown"), None);
     assert_eq!(map.map_event(""), None);
 }

--- a/src/install.rs
+++ b/src/install.rs
@@ -402,6 +402,35 @@ pub fn update_meta_after_place(plugin_path: &Path, result: &PlaceResult) {
     }
 }
 
+/// 単発の Codex Hook 配置成功時に所有権を `.plm-meta.json` に記録する。
+///
+/// `plm import` は `place_plugin` を経由しないため `update_meta_after_place`
+/// で所有権が記録されない。同じプラグインを再 import すると
+/// `CodexTarget::hook_overwrite_error` が「未管理ファイル」と判定して
+/// 拒否してしまうので、import の deploy 成功時に明示的に呼び出して
+/// `managedFiles["codex"]` に絶対パスを追記する。
+///
+/// # Arguments
+///
+/// * `plugin_path` - Filesystem path of the cached plugin (`.plm-meta.json` のディレクトリ).
+/// * `hook_path` - 実際に書き込んだ `hooks.json` の絶対パス.
+pub fn record_codex_hook_ownership(plugin_path: &Path, hook_path: &Path) {
+    let mut plugin_meta = meta::load_meta(plugin_path).unwrap_or_default();
+    let was_managed = plugin_meta.manages_file("codex", hook_path);
+    let was_enabled = plugin_meta.get_status("codex") == Some("enabled");
+
+    if was_managed && was_enabled {
+        return;
+    }
+
+    plugin_meta.set_status("codex", "enabled");
+    plugin_meta.add_managed_file("codex", hook_path);
+
+    if let Err(e) = meta::write_meta(plugin_path, &plugin_meta) {
+        eprintln!("Warning: Failed to update .plm-meta.json: {}", e);
+    }
+}
+
 #[cfg(test)]
 #[path = "install_test.rs"]
 mod tests;

--- a/src/install.rs
+++ b/src/install.rs
@@ -223,6 +223,21 @@ pub fn place_plugin(request: &PlaceRequest) -> PlaceResult {
                 None => continue,
             };
 
+            if component.kind == ComponentKind::Hook && target.kind() == TargetKind::Codex {
+                if let Some(error) =
+                    CodexTarget::hook_overwrite_error(&target_path, request.scanned.plugin_root())
+                {
+                    failures.push(PlaceFailure {
+                        target: target.name().to_string(),
+                        component_name: component.name.clone(),
+                        component_kind: component.kind,
+                        error,
+                        stage: PlaceFailureStage::Resolution,
+                    });
+                    continue;
+                }
+            }
+
             let conversion = match component.kind {
                 ComponentKind::Command => ConversionConfig::Command {
                     source: request.scanned.command_format(),

--- a/src/install.rs
+++ b/src/install.rs
@@ -1,10 +1,11 @@
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 use crate::component::{AgentFormat, CommandFormat, ComponentKind, Scope};
 use crate::component::{Component, ComponentDeployment, ConversionConfig, DeploymentOutput};
 use crate::component::{ComponentRef, PlacementContext, PlacementScope, ProjectContext};
 use crate::plugin::{
-    cleanup_legacy_hierarchy, MarketplaceContent, PackageCache, PackageCacheAccess,
+    cleanup_legacy_hierarchy, meta, MarketplaceContent, PackageCache, PackageCacheAccess,
 };
 use crate::source::parse_source;
 use crate::target::{CodexTarget, PluginOrigin, Target, TargetKind};
@@ -346,6 +347,46 @@ pub fn place_plugin(request: &PlaceRequest) -> PlaceResult {
         plugin_name: request.scanned.name().to_string(),
         successes,
         failures,
+    }
+}
+
+/// place_plugin 後のステータス更新（CLI / TUI 共通）
+///
+/// 配置スキャンではプラグイン名を復元できないターゲット固有ファイル
+/// （例: Codex の `.codex/hooks.json`）もあるため、target 全体が成功した場合だけ
+/// `.plm-meta.json` の `statusByTarget` に記録して enabled 判定と
+/// 上書きガード（`CodexTarget::hook_overwrite_error`）を安定させる。
+///
+/// 実際にステータス更新が発生しなかった場合（全 target が失敗した、`successes`
+/// が空など）は `.plm-meta.json` を書き換えない。失敗 install で不要な
+/// メタデータ更新を避け、ファイル mtime の汚染も防ぐ。
+///
+/// # Arguments
+///
+/// * `plugin_path` - Filesystem path of the cached plugin.
+/// * `result` - Outcome returned by `place_plugin`.
+pub fn update_meta_after_place(plugin_path: &Path, result: &PlaceResult) {
+    let mut plugin_meta = meta::load_meta(plugin_path).unwrap_or_default();
+    let failed_targets: HashSet<&str> = result
+        .failures
+        .iter()
+        .map(|failure| failure.target.as_str())
+        .collect();
+
+    let mut updated = false;
+    for success in &result.successes {
+        if !failed_targets.contains(success.target.as_str()) {
+            plugin_meta.set_status(&success.target, "enabled");
+            updated = true;
+        }
+    }
+
+    if !updated {
+        return;
+    }
+
+    if let Err(e) = meta::write_meta(plugin_path, &plugin_meta) {
+        eprintln!("Warning: Failed to update .plm-meta.json: {}", e);
     }
 }
 

--- a/src/install.rs
+++ b/src/install.rs
@@ -381,15 +381,21 @@ pub fn update_meta_after_place(plugin_path: &Path, result: &PlaceResult) {
 
     let mut updated = false;
     for success in &result.successes {
-        if failed_targets.contains(success.target.as_str()) {
-            continue;
-        }
-        plugin_meta.set_status(&success.target, "enabled");
-        updated = true;
-
+        // managedFiles は「実際にファイルが書かれた」事実そのものを記録する。
+        // 同一 target 内で別コンポーネントが失敗しても書き込み済みファイルは
+        // 残るため、所有権記録もそれと同期させなければ次回 install/import で
+        // hook_overwrite_error が「未管理」と判定して再配置を拒否してしまう。
         if success.component_kind == ComponentKind::Hook && success.target_kind == TargetKind::Codex
         {
             plugin_meta.add_managed_file(&success.target, &success.target_path);
+            updated = true;
+        }
+
+        // statusByTarget = "enabled" は「target 全体として成功した」状態を表す
+        // ため、同じ target に failure があれば enabled に昇格させない。
+        if !failed_targets.contains(success.target.as_str()) {
+            plugin_meta.set_status(&success.target, "enabled");
+            updated = true;
         }
     }
 

--- a/src/install.rs
+++ b/src/install.rs
@@ -7,7 +7,7 @@ use crate::plugin::{
     cleanup_legacy_hierarchy, MarketplaceContent, PackageCache, PackageCacheAccess,
 };
 use crate::source::parse_source;
-use crate::target::{PluginOrigin, Target, TargetKind};
+use crate::target::{CodexTarget, PluginOrigin, Target, TargetKind};
 
 pub mod format;
 pub use crate::hooks::converter::{ConversionWarning, SourceFormat};
@@ -186,10 +186,28 @@ pub fn place_plugin(request: &PlaceRequest) -> PlaceResult {
 
     for target in request.targets {
         let failures_before = failures.len();
+        let codex_hook_conflict = if target.kind() == TargetKind::Codex {
+            CodexTarget::hook_component_conflict_error(&request.scanned.components)
+        } else {
+            None
+        };
 
         for component in &request.scanned.components {
             if !target.supports(component.kind) {
                 continue;
+            }
+
+            if component.kind == ComponentKind::Hook {
+                if let Some(error) = &codex_hook_conflict {
+                    failures.push(PlaceFailure {
+                        target: target.name().to_string(),
+                        component_name: component.name.clone(),
+                        component_kind: component.kind,
+                        error: error.clone(),
+                        stage: PlaceFailureStage::Resolution,
+                    });
+                    continue;
+                }
             }
 
             let ctx = PlacementContext {

--- a/src/install.rs
+++ b/src/install.rs
@@ -354,8 +354,14 @@ pub fn place_plugin(request: &PlaceRequest) -> PlaceResult {
 ///
 /// 配置スキャンではプラグイン名を復元できないターゲット固有ファイル
 /// （例: Codex の `.codex/hooks.json`）もあるため、target 全体が成功した場合だけ
-/// `.plm-meta.json` の `statusByTarget` に記録して enabled 判定と
-/// 上書きガード（`CodexTarget::hook_overwrite_error`）を安定させる。
+/// `.plm-meta.json` の `statusByTarget` に記録して enabled 判定を安定させる。
+///
+/// さらに、Codex Hook のように複数プラグイン間で書き合いが起こりうる
+/// 共有 destination ファイルについては、絶対パスを `managedFiles[target]`
+/// に追記しておく（`CodexTarget::hook_overwrite_error` がこの値で
+/// 所有権を判定する）。`statusByTarget` の `enabled` を所有権チェックに
+/// 流用すると scope/種別を区別できないため、Hook 配置時のみ実パスを
+/// 別フィールドへ記録する設計とする。
 ///
 /// 実際にステータス更新が発生しなかった場合（全 target が失敗した、`successes`
 /// が空など）は `.plm-meta.json` を書き換えない。失敗 install で不要な
@@ -375,9 +381,15 @@ pub fn update_meta_after_place(plugin_path: &Path, result: &PlaceResult) {
 
     let mut updated = false;
     for success in &result.successes {
-        if !failed_targets.contains(success.target.as_str()) {
-            plugin_meta.set_status(&success.target, "enabled");
-            updated = true;
+        if failed_targets.contains(success.target.as_str()) {
+            continue;
+        }
+        plugin_meta.set_status(&success.target, "enabled");
+        updated = true;
+
+        if success.component_kind == ComponentKind::Hook && success.target_kind == TargetKind::Codex
+        {
+            plugin_meta.add_managed_file(&success.target, &success.target_path);
         }
     }
 

--- a/src/install.rs
+++ b/src/install.rs
@@ -396,7 +396,11 @@ pub fn update_meta_after_place(plugin_path: &Path, result: &PlaceResult) {
 
         // statusByTarget = "enabled" は「target 全体として成功した」状態を表す
         // ため、同じ target に failure があれば enabled に昇格させない。
-        if !failed_targets.contains(success.target.as_str()) {
+        // 既に "enabled" の場合は内容変化なしの no-op 書き込みを避けるため
+        // set_status を呼ばずに skip する（mtime 汚染を防ぐ）。
+        if !failed_targets.contains(success.target.as_str())
+            && plugin_meta.get_status(&success.target) != Some("enabled")
+        {
             plugin_meta.set_status(&success.target, "enabled");
             updated = true;
         }

--- a/src/install.rs
+++ b/src/install.rs
@@ -385,9 +385,12 @@ pub fn update_meta_after_place(plugin_path: &Path, result: &PlaceResult) {
         // 同一 target 内で別コンポーネントが失敗しても書き込み済みファイルは
         // 残るため、所有権記録もそれと同期させなければ次回 install/import で
         // hook_overwrite_error が「未管理」と判定して再配置を拒否してしまう。
-        if success.component_kind == ComponentKind::Hook && success.target_kind == TargetKind::Codex
+        // add_managed_file は重複時 false を返すので、内容変化なしの no-op
+        // 書き込み（mtime 汚染）を避けるため戻り値で updated を立てる。
+        if success.component_kind == ComponentKind::Hook
+            && success.target_kind == TargetKind::Codex
+            && plugin_meta.add_managed_file(&success.target, &success.target_path)
         {
-            plugin_meta.add_managed_file(&success.target, &success.target_path);
             updated = true;
         }
 

--- a/src/install.rs
+++ b/src/install.rs
@@ -81,14 +81,9 @@ pub struct PlaceSuccess {
     /// Hook 変換時の警告（`HookConverted` 以外は空）。
     pub hook_warnings: Vec<ConversionWarning>,
     /// `HookConverted` 時に生成されたスクリプト数（それ以外は 0）。
-    ///
-    /// ClaudeCode 入力では各 hook が必ず 1 つのスクリプト（command / http / stub）を
-    /// 生成するため、`script_count == 0` ⇔ 変換後の `hooks.json` が空、という
-    /// 不変条件が成立する。`format::format_empty_hooks_warning` はこの不変条件と
-    /// `hook_source_format == Some(SourceFormat::ClaudeCode)` の組み合わせで
-    /// 「空 `hooks.json` 配置警告」を出す。除外の主因が `UnsupportedEvent` /
-    /// `UnsupportedHookType` / `RemovedField` のいずれかは問わない。
     pub script_count: usize,
+    /// `HookConverted` 時に変換後 JSON に残った hook 定義数（それ以外は 0）。
+    pub hook_count: usize,
     /// Hook 変換時の入力形式。`Some(SourceFormat::ClaudeCode)` のときのみ
     /// `(converted from Claude Code format)` サフィックスを表示する。
     ///
@@ -218,7 +213,9 @@ pub fn place_plugin(request: &PlaceRequest) -> PlaceResult {
                     source: request.scanned.agent_format(),
                     dest: target.agent_format(),
                 },
-                ComponentKind::Hook if target.kind() == TargetKind::Copilot => {
+                ComponentKind::Hook
+                    if matches!(target.kind(), TargetKind::Codex | TargetKind::Copilot) =>
+                {
                     ConversionConfig::Hook {
                         target_kind: target.kind(),
                         plugin_root: Some(request.scanned.plugin_root().to_path_buf()),
@@ -261,12 +258,16 @@ pub fn place_plugin(request: &PlaceRequest) -> PlaceResult {
                         _ => (None, None),
                     };
 
-                    let (hook_warnings, script_count, hook_source_format) = match &result {
-                        DeploymentOutput::HookConverted(hr) => {
-                            (hr.warnings.clone(), hr.script_count, Some(hr.source_format))
-                        }
-                        _ => (Vec::new(), 0, None),
-                    };
+                    let (hook_warnings, script_count, hook_count, hook_source_format) =
+                        match &result {
+                            DeploymentOutput::HookConverted(hr) => (
+                                hr.warnings.clone(),
+                                hr.script_count,
+                                hr.hook_count,
+                                Some(hr.source_format),
+                            ),
+                            _ => (Vec::new(), 0, 0, None),
+                        };
 
                     successes.push(PlaceSuccess {
                         target: target.name().to_string(),
@@ -277,6 +278,7 @@ pub fn place_plugin(request: &PlaceRequest) -> PlaceResult {
                         dest_format,
                         hook_warnings,
                         script_count,
+                        hook_count,
                         hook_source_format,
                     });
                 }

--- a/src/install.rs
+++ b/src/install.rs
@@ -73,6 +73,7 @@ pub struct PlaceResult {
 #[derive(Debug)]
 pub struct PlaceSuccess {
     pub target: String,
+    pub target_kind: TargetKind,
     pub component_name: String,
     pub component_kind: ComponentKind,
     pub target_path: PathBuf,
@@ -289,6 +290,7 @@ pub fn place_plugin(request: &PlaceRequest) -> PlaceResult {
 
                     successes.push(PlaceSuccess {
                         target: target.name().to_string(),
+                        target_kind: target.kind(),
                         component_name: component.name.clone(),
                         component_kind: component.kind,
                         target_path: deployment.path().to_path_buf(),

--- a/src/install/format.rs
+++ b/src/install/format.rs
@@ -149,10 +149,10 @@ pub fn format_manual_rewrite_section(stubs: &[(String, String)]) -> Option<Strin
 /// script_count と一致するが、Codex 変換では command hook を inline のまま残すため
 /// script_count が 0 でも hook_count は 1 以上になり得る。
 ///
-/// **`source_format == Some(TargetFormat)` の扱い**: passthrough では入力 JSON が
-/// そのまま配置され `script_count == 0` でも `hooks.json` は空ではない（例:
-/// `MissingVersion` 警告つきの Copilot 形式入力）。誤検知を避けるためここでは
-/// 警告を出さない。
+/// **`source_format == Some(TargetFormat)` の扱い**: passthrough では変換後の
+/// `hook_count` を算出しないため 0 になり得るが、入力 JSON はそのまま配置され
+/// `hooks.json` が空とは限らない（例: `MissingVersion` 警告つきの Copilot
+/// 形式入力）。誤検知を避けるためここでは警告を出さない。
 ///
 /// **`source_format == None` の扱い**: Hook 以外（Skill / Agent / ...）または
 /// `DeploymentOutput::Copied` 経路の Hook（version 付き Copilot 完全 passthrough）。

--- a/src/install/format.rs
+++ b/src/install/format.rs
@@ -149,10 +149,12 @@ pub fn format_manual_rewrite_section(stubs: &[(String, String)]) -> Option<Strin
 /// script_count と一致するが、Codex 変換では command hook を inline のまま残すため
 /// script_count が 0 でも hook_count は 1 以上になり得る。
 ///
-/// **`source_format == Some(TargetFormat)` の扱い**: passthrough では変換後の
-/// `hook_count` を算出しないため 0 になり得るが、入力 JSON はそのまま配置され
-/// `hooks.json` が空とは限らない（例: `MissingVersion` 警告つきの Copilot
-/// 形式入力）。誤検知を避けるためここでは警告を出さない。
+/// **`source_format == Some(TargetFormat)` の扱い**: passthrough でも
+/// `deploy_hook_converted()` 側で `hook_count` は常に算出されるが、入力 JSON が
+/// そのまま配置されるため変換による消失は起こり得ない。`hook_count == 0` でも
+/// それは入力時点の状態（例: `MissingVersion` 警告つきの Copilot 形式で
+/// `hooks` が空）であり「変換で消えた」ことを意味しないため、誤検知を避けて
+/// ここでは警告を出さない。
 ///
 /// **`source_format == None` の扱い**: Hook 以外（Skill / Agent / ...）または
 /// `DeploymentOutput::Copied` 経路の Hook（version 付き Copilot 完全 passthrough）。

--- a/src/install/format.rs
+++ b/src/install/format.rs
@@ -142,15 +142,12 @@ pub fn format_manual_rewrite_section(stubs: &[(String, String)]) -> Option<Strin
 /// 変換結果として hook が 1 件も残らなかった場合の追加警告（stderr / yellow）。
 ///
 /// 「空 `hooks.json` を放置したまま気づかれない」状況を防ぐためのセーフティネット。
-/// `source_format == Some(SourceFormat::ClaudeCode) && script_count == 0` のとき返す。
+/// `source_format == Some(SourceFormat::ClaudeCode) && hook_count == 0` のとき返す。
 /// それ以外は `None`。
 ///
-/// **判定方針**: ClaudeCode 入力時は各 hook が必ずスクリプトを生成するため、
-/// `script_count == 0` ⇔「変換後の `hooks.json` が空」という不変条件が成立する。
-/// この単一の条件で、除外の主因が `UnsupportedEvent` / `UnsupportedHookType` /
-/// `RemovedField`（イベント値が配列でない、matcher group の `hooks` 配列欠落 など、
-/// 詳細は `src/hooks/converter.rs::flatten_matchers`）のいずれであっても取りこぼさず
-/// 警告を出せる。
+/// **判定方針**: 変換後 JSON に残った hook 定義数で判定する。Copilot 変換では
+/// script_count と一致するが、Codex 変換では command hook を inline のまま残すため
+/// script_count が 0 でも hook_count は 1 以上になり得る。
 ///
 /// **`source_format == Some(TargetFormat)` の扱い**: passthrough では入力 JSON が
 /// そのまま配置され `script_count == 0` でも `hooks.json` は空ではない（例:
@@ -161,10 +158,10 @@ pub fn format_manual_rewrite_section(stubs: &[(String, String)]) -> Option<Strin
 /// `DeploymentOutput::Copied` 経路の Hook（version 付き Copilot 完全 passthrough）。
 /// どちらも警告対象外。
 pub fn format_empty_hooks_warning(
-    script_count: usize,
+    hook_count: usize,
     source_format: Option<SourceFormat>,
 ) -> Option<String> {
-    if script_count == 0 && source_format == Some(SourceFormat::ClaudeCode) {
+    if hook_count == 0 && source_format == Some(SourceFormat::ClaudeCode) {
         Some(format!(
             "  {} An empty hooks.json was placed; no hooks remained after conversion.",
             "Warning:".yellow()
@@ -204,7 +201,8 @@ pub fn render_hook_success(
     component_kind: ComponentKind,
     hook_source_format: Option<SourceFormat>,
     hook_warnings: &[ConversionWarning],
-    script_count: usize,
+    _script_count: usize,
+    hook_count: usize,
 ) -> HookRenderOutput {
     if component_kind != ComponentKind::Hook {
         return HookRenderOutput {
@@ -228,10 +226,8 @@ pub fn render_hook_success(
     if let Some(section) = format_manual_rewrite_section(&classified.stubs) {
         stderr_blocks.push(section);
     }
-    // 空 `hooks.json` 警告は ClaudeCode 入力時の `script_count == 0` だけで判定する
-    // （除外の主因が `UnsupportedEvent` / `UnsupportedHookType` / `RemovedField` の
-    // どれであっても 1 つの不変条件で取りこぼさない）。
-    if let Some(line) = format_empty_hooks_warning(script_count, hook_source_format) {
+    // 空 `hooks.json` 警告は変換後に残った hook 定義数で判定する。
+    if let Some(line) = format_empty_hooks_warning(hook_count, hook_source_format) {
         stderr_blocks.push(line);
     }
     for w in &classified.others {

--- a/src/install/format.rs
+++ b/src/install/format.rs
@@ -207,6 +207,19 @@ pub struct HookRenderOutput {
     pub stderr_blocks: Vec<String>,
 }
 
+/// `render_hook_success` の入力。
+///
+/// `script_count` は将来の表示拡張のために保持する（現状は未使用だが、
+/// inline hook と generated script の比率を出したくなったときに参照する）。
+pub struct HookRenderInput<'a> {
+    pub component_kind: ComponentKind,
+    pub target_kind: TargetKind,
+    pub hook_source_format: Option<SourceFormat>,
+    pub hook_warnings: &'a [ConversionWarning],
+    pub script_count: usize,
+    pub hook_count: usize,
+}
+
 /// Hook の success データから表示用の `HookRenderOutput` を組み立てる pure function。
 ///
 /// 分岐仕様:
@@ -215,14 +228,16 @@ pub struct HookRenderOutput {
 /// - `stderr_blocks`: `component_kind == Hook` かつ各カテゴリ非空のときのみ追加。
 ///   `source_format` 非依存（Copilot 形式 + `MissingVersion` でも warning は出る）
 /// - Hook 以外の `component_kind` では空の `HookRenderOutput` を返す
-pub fn render_hook_success(
-    component_kind: ComponentKind,
-    target_kind: TargetKind,
-    hook_source_format: Option<SourceFormat>,
-    hook_warnings: &[ConversionWarning],
-    _script_count: usize,
-    hook_count: usize,
-) -> HookRenderOutput {
+pub fn render_hook_success(input: HookRenderInput<'_>) -> HookRenderOutput {
+    let HookRenderInput {
+        component_kind,
+        target_kind,
+        hook_source_format,
+        hook_warnings,
+        script_count: _,
+        hook_count,
+    } = input;
+
     if component_kind != ComponentKind::Hook {
         return HookRenderOutput {
             stdout_suffix: None,

--- a/src/install/format.rs
+++ b/src/install/format.rs
@@ -6,6 +6,7 @@
 
 use crate::component::ComponentKind;
 use crate::hooks::converter::{ConversionWarning, SourceFormat};
+use crate::target::TargetKind;
 use owo_colors::OwoColorize;
 use std::collections::BTreeSet;
 
@@ -101,7 +102,11 @@ pub fn format_converted_hook_suffix() -> String {
 ///
 /// 文言: 件数に応じて単数形 `1 event skipped` / 複数形 `N events skipped` を
 /// 切り替える（user-facing CLI なので英語の単複は正確に出す）。
-pub fn format_skipped_events_warning(events: &BTreeSet<String>) -> Option<String> {
+/// `target_kind` でターゲットを示す文言（`Copilot CLI` / `Codex CLI`）を切り替える。
+pub fn format_skipped_events_warning(
+    events: &BTreeSet<String>,
+    target_kind: TargetKind,
+) -> Option<String> {
     if events.is_empty() {
         return None;
     }
@@ -109,12 +114,23 @@ pub fn format_skipped_events_warning(events: &BTreeSet<String>) -> Option<String
     let noun = if count == 1 { "event" } else { "events" };
     let list = events.iter().cloned().collect::<Vec<_>>().join(", ");
     Some(format!(
-        "  {} {} {} skipped (not supported in Copilot CLI): {}",
+        "  {} {} {} skipped (not supported in {}): {}",
         "Warning:".yellow(),
         count,
         noun,
+        target_display_name(target_kind),
         list
     ))
+}
+
+/// ターゲット向け表示名（user-facing CLI の警告文言用）。
+fn target_display_name(target_kind: TargetKind) -> &'static str {
+    match target_kind {
+        TargetKind::Copilot => "Copilot CLI",
+        TargetKind::Codex => "Codex CLI",
+        TargetKind::Antigravity => "Antigravity",
+        TargetKind::GeminiCli => "Gemini CLI",
+    }
 }
 
 /// prompt/agent フックの手動書き換え案内（stderr / magenta + bold 見出し）。
@@ -201,6 +217,7 @@ pub struct HookRenderOutput {
 /// - Hook 以外の `component_kind` では空の `HookRenderOutput` を返す
 pub fn render_hook_success(
     component_kind: ComponentKind,
+    target_kind: TargetKind,
     hook_source_format: Option<SourceFormat>,
     hook_warnings: &[ConversionWarning],
     _script_count: usize,
@@ -222,7 +239,7 @@ pub fn render_hook_success(
     let classified = classify_hook_warnings(hook_warnings);
     let mut stderr_blocks: Vec<String> = Vec::new();
 
-    if let Some(line) = format_skipped_events_warning(&classified.skipped) {
+    if let Some(line) = format_skipped_events_warning(&classified.skipped, target_kind) {
         stderr_blocks.push(line);
     }
     if let Some(section) = format_manual_rewrite_section(&classified.stubs) {

--- a/src/install/format_test.rs
+++ b/src/install/format_test.rs
@@ -320,14 +320,14 @@ fn render_hook_success_claude_code_with_unsupported_events_emits_suffix_and_one_
             event: "SubagentStart".to_string(),
         },
     ];
-    let rendered = render_hook_success(
-        ComponentKind::Hook,
-        TargetKind::Copilot,
-        Some(SourceFormat::ClaudeCode),
-        &warnings,
-        1,
-        1,
-    );
+    let rendered = render_hook_success(HookRenderInput {
+        component_kind: ComponentKind::Hook,
+        target_kind: TargetKind::Copilot,
+        hook_source_format: Some(SourceFormat::ClaudeCode),
+        hook_warnings: &warnings,
+        script_count: 1,
+        hook_count: 1,
+    });
     assert!(rendered.stdout_suffix.is_some());
     assert_eq!(rendered.stderr_blocks.len(), 1);
     assert!(rendered.stderr_blocks[0].contains("3 events skipped"));
@@ -337,14 +337,14 @@ fn render_hook_success_claude_code_with_unsupported_events_emits_suffix_and_one_
 fn render_hook_success_copilot_format_with_missing_version_no_suffix_only_individual_warning() {
     // Copilot 形式 + MissingVersion 1 件 → suffix なし、stderr_blocks に individual warning のみ
     let warnings = vec![ConversionWarning::MissingVersion];
-    let rendered = render_hook_success(
-        ComponentKind::Hook,
-        TargetKind::Copilot,
-        Some(SourceFormat::TargetFormat),
-        &warnings,
-        0,
-        0,
-    );
+    let rendered = render_hook_success(HookRenderInput {
+        component_kind: ComponentKind::Hook,
+        target_kind: TargetKind::Copilot,
+        hook_source_format: Some(SourceFormat::TargetFormat),
+        hook_warnings: &warnings,
+        script_count: 0,
+        hook_count: 0,
+    });
     assert!(rendered.stdout_suffix.is_none());
     assert_eq!(rendered.stderr_blocks.len(), 1);
     assert_eq!(
@@ -355,14 +355,14 @@ fn render_hook_success_copilot_format_with_missing_version_no_suffix_only_indivi
 
 #[test]
 fn render_hook_success_skill_returns_empty_output() {
-    let rendered = render_hook_success(
-        ComponentKind::Skill,
-        TargetKind::Copilot,
-        Some(SourceFormat::ClaudeCode),
-        &[ConversionWarning::MissingVersion],
-        1,
-        1,
-    );
+    let rendered = render_hook_success(HookRenderInput {
+        component_kind: ComponentKind::Skill,
+        target_kind: TargetKind::Copilot,
+        hook_source_format: Some(SourceFormat::ClaudeCode),
+        hook_warnings: &[ConversionWarning::MissingVersion],
+        script_count: 1,
+        hook_count: 1,
+    });
     assert!(rendered.stdout_suffix.is_none());
     assert!(rendered.stderr_blocks.is_empty());
 }
@@ -377,14 +377,14 @@ fn render_hook_success_all_events_skipped_includes_empty_hooks_warning() {
             event: "PreCompact".to_string(),
         },
     ];
-    let rendered = render_hook_success(
-        ComponentKind::Hook,
-        TargetKind::Copilot,
-        Some(SourceFormat::ClaudeCode),
-        &warnings,
-        0,
-        0,
-    );
+    let rendered = render_hook_success(HookRenderInput {
+        component_kind: ComponentKind::Hook,
+        target_kind: TargetKind::Copilot,
+        hook_source_format: Some(SourceFormat::ClaudeCode),
+        hook_warnings: &warnings,
+        script_count: 0,
+        hook_count: 0,
+    });
     assert!(rendered.stdout_suffix.is_some());
     // skipped events warning + empty hooks warning の 2 ブロック
     assert_eq!(rendered.stderr_blocks.len(), 2);
@@ -394,14 +394,14 @@ fn render_hook_success_all_events_skipped_includes_empty_hooks_warning() {
 
 #[test]
 fn render_hook_success_inline_hooks_do_not_emit_empty_hooks_warning() {
-    let rendered = render_hook_success(
-        ComponentKind::Hook,
-        TargetKind::Copilot,
-        Some(SourceFormat::ClaudeCode),
-        &[],
-        0,
-        1,
-    );
+    let rendered = render_hook_success(HookRenderInput {
+        component_kind: ComponentKind::Hook,
+        target_kind: TargetKind::Copilot,
+        hook_source_format: Some(SourceFormat::ClaudeCode),
+        hook_warnings: &[],
+        script_count: 0,
+        hook_count: 1,
+    });
     assert!(rendered.stdout_suffix.is_some());
     assert!(
         !rendered
@@ -428,14 +428,14 @@ fn render_hook_success_all_unsupported_hook_types_emits_empty_hooks_warning() {
             event: "PostToolUse".to_string(),
         },
     ];
-    let rendered = render_hook_success(
-        ComponentKind::Hook,
-        TargetKind::Copilot,
-        Some(SourceFormat::ClaudeCode),
-        &warnings,
-        0,
-        0,
-    );
+    let rendered = render_hook_success(HookRenderInput {
+        component_kind: ComponentKind::Hook,
+        target_kind: TargetKind::Copilot,
+        hook_source_format: Some(SourceFormat::ClaudeCode),
+        hook_warnings: &warnings,
+        script_count: 0,
+        hook_count: 0,
+    });
     assert!(rendered.stdout_suffix.is_some());
     // 空配置警告 + 個別 warning 2 件 = 3 ブロック
     assert_eq!(rendered.stderr_blocks.len(), 3);
@@ -473,14 +473,14 @@ fn render_hook_success_only_removed_field_warnings_still_emits_empty_hooks_warni
                 .to_string(),
         },
     ];
-    let rendered = render_hook_success(
-        ComponentKind::Hook,
-        TargetKind::Copilot,
-        Some(SourceFormat::ClaudeCode),
-        &warnings,
-        0,
-        0,
-    );
+    let rendered = render_hook_success(HookRenderInput {
+        component_kind: ComponentKind::Hook,
+        target_kind: TargetKind::Copilot,
+        hook_source_format: Some(SourceFormat::ClaudeCode),
+        hook_warnings: &warnings,
+        script_count: 0,
+        hook_count: 0,
+    });
     assert!(rendered.stdout_suffix.is_some());
     // 空配置警告 + 個別 warning 2 件 = 3 ブロック
     assert_eq!(rendered.stderr_blocks.len(), 3);
@@ -498,14 +498,14 @@ fn render_hook_success_target_format_with_zero_scripts_does_not_emit_empty_hooks
     // TargetFormat passthrough は入力 JSON がそのまま配置されるので `script_count == 0`
     // でも空配置警告は出してはいけない（false positive 防止）。
     let warnings = vec![ConversionWarning::MissingVersion];
-    let rendered = render_hook_success(
-        ComponentKind::Hook,
-        TargetKind::Copilot,
-        Some(SourceFormat::TargetFormat),
-        &warnings,
-        0,
-        0,
-    );
+    let rendered = render_hook_success(HookRenderInput {
+        component_kind: ComponentKind::Hook,
+        target_kind: TargetKind::Copilot,
+        hook_source_format: Some(SourceFormat::TargetFormat),
+        hook_warnings: &warnings,
+        script_count: 0,
+        hook_count: 0,
+    });
     assert!(rendered.stdout_suffix.is_none());
     assert!(
         !rendered
@@ -520,7 +520,14 @@ fn render_hook_success_target_format_with_zero_scripts_does_not_emit_empty_hooks
 fn render_hook_success_hook_with_none_source_format_and_no_warnings_returns_empty() {
     // version 付き Copilot 形式 Hook は DeploymentOutput::Copied 経路で
     // hook_source_format == None / warnings 0 になる。既存挙動の固定。
-    let rendered = render_hook_success(ComponentKind::Hook, TargetKind::Copilot, None, &[], 0, 0);
+    let rendered = render_hook_success(HookRenderInput {
+        component_kind: ComponentKind::Hook,
+        target_kind: TargetKind::Copilot,
+        hook_source_format: None,
+        hook_warnings: &[],
+        script_count: 0,
+        hook_count: 0,
+    });
     assert!(rendered.stdout_suffix.is_none());
     assert!(rendered.stderr_blocks.is_empty());
 }
@@ -540,14 +547,14 @@ fn render_hook_success_prompt_agent_stub_emits_manual_rewrite_section() {
             event: "postToolUse".to_string(),
         },
     ];
-    let rendered = render_hook_success(
-        ComponentKind::Hook,
-        TargetKind::Copilot,
-        Some(SourceFormat::ClaudeCode),
-        &warnings,
-        2,
-        2,
-    );
+    let rendered = render_hook_success(HookRenderInput {
+        component_kind: ComponentKind::Hook,
+        target_kind: TargetKind::Copilot,
+        hook_source_format: Some(SourceFormat::ClaudeCode),
+        hook_warnings: &warnings,
+        script_count: 2,
+        hook_count: 2,
+    });
     assert!(rendered.stdout_suffix.is_some());
     assert_eq!(rendered.stderr_blocks.len(), 1);
     assert!(rendered.stderr_blocks[0].contains("Manual rewrite required (2 hooks):"));

--- a/src/install/format_test.rs
+++ b/src/install/format_test.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::component::ComponentKind;
 use crate::hooks::converter::{ConversionWarning, SourceFormat};
+use crate::target::TargetKind;
 use owo_colors::OwoColorize;
 use std::collections::BTreeSet;
 
@@ -166,7 +167,7 @@ fn classify_hook_warnings_routes_others_for_removed_field_and_missing_version() 
 #[test]
 fn format_skipped_events_warning_returns_none_for_empty() {
     let events: BTreeSet<String> = BTreeSet::new();
-    assert!(format_skipped_events_warning(&events).is_none());
+    assert!(format_skipped_events_warning(&events, TargetKind::Copilot).is_none());
 }
 
 #[test]
@@ -174,7 +175,7 @@ fn format_skipped_events_warning_uses_singular_for_one_event() {
     // user-facing CLI の英文として「1 events」は誤りなので、件数 1 のとき "event" を使う。
     let mut events = BTreeSet::new();
     events.insert("Notification".to_string());
-    let actual = format_skipped_events_warning(&events).unwrap();
+    let actual = format_skipped_events_warning(&events, TargetKind::Copilot).unwrap();
     let expected = format!(
         "  {} 1 event skipped (not supported in Copilot CLI): Notification",
         "Warning:".yellow()
@@ -188,9 +189,22 @@ fn format_skipped_events_warning_lists_three_events_alphabetically() {
     events.insert("PreCompact".to_string());
     events.insert("Notification".to_string());
     events.insert("SubagentStart".to_string());
-    let actual = format_skipped_events_warning(&events).unwrap();
+    let actual = format_skipped_events_warning(&events, TargetKind::Copilot).unwrap();
     let expected = format!(
         "  {} 3 events skipped (not supported in Copilot CLI): Notification, PreCompact, SubagentStart",
+        "Warning:".yellow()
+    );
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn format_skipped_events_warning_uses_codex_label_for_codex_target() {
+    // Codex 向け出力では Copilot 固有の文言ではなく Codex CLI を表示する。
+    let mut events = BTreeSet::new();
+    events.insert("Notification".to_string());
+    let actual = format_skipped_events_warning(&events, TargetKind::Codex).unwrap();
+    let expected = format!(
+        "  {} 1 event skipped (not supported in Codex CLI): Notification",
         "Warning:".yellow()
     );
     assert_eq!(actual, expected);
@@ -308,6 +322,7 @@ fn render_hook_success_claude_code_with_unsupported_events_emits_suffix_and_one_
     ];
     let rendered = render_hook_success(
         ComponentKind::Hook,
+        TargetKind::Copilot,
         Some(SourceFormat::ClaudeCode),
         &warnings,
         1,
@@ -324,6 +339,7 @@ fn render_hook_success_copilot_format_with_missing_version_no_suffix_only_indivi
     let warnings = vec![ConversionWarning::MissingVersion];
     let rendered = render_hook_success(
         ComponentKind::Hook,
+        TargetKind::Copilot,
         Some(SourceFormat::TargetFormat),
         &warnings,
         0,
@@ -341,6 +357,7 @@ fn render_hook_success_copilot_format_with_missing_version_no_suffix_only_indivi
 fn render_hook_success_skill_returns_empty_output() {
     let rendered = render_hook_success(
         ComponentKind::Skill,
+        TargetKind::Copilot,
         Some(SourceFormat::ClaudeCode),
         &[ConversionWarning::MissingVersion],
         1,
@@ -362,6 +379,7 @@ fn render_hook_success_all_events_skipped_includes_empty_hooks_warning() {
     ];
     let rendered = render_hook_success(
         ComponentKind::Hook,
+        TargetKind::Copilot,
         Some(SourceFormat::ClaudeCode),
         &warnings,
         0,
@@ -378,6 +396,7 @@ fn render_hook_success_all_events_skipped_includes_empty_hooks_warning() {
 fn render_hook_success_inline_hooks_do_not_emit_empty_hooks_warning() {
     let rendered = render_hook_success(
         ComponentKind::Hook,
+        TargetKind::Copilot,
         Some(SourceFormat::ClaudeCode),
         &[],
         0,
@@ -411,6 +430,7 @@ fn render_hook_success_all_unsupported_hook_types_emits_empty_hooks_warning() {
     ];
     let rendered = render_hook_success(
         ComponentKind::Hook,
+        TargetKind::Copilot,
         Some(SourceFormat::ClaudeCode),
         &warnings,
         0,
@@ -455,6 +475,7 @@ fn render_hook_success_only_removed_field_warnings_still_emits_empty_hooks_warni
     ];
     let rendered = render_hook_success(
         ComponentKind::Hook,
+        TargetKind::Copilot,
         Some(SourceFormat::ClaudeCode),
         &warnings,
         0,
@@ -479,6 +500,7 @@ fn render_hook_success_target_format_with_zero_scripts_does_not_emit_empty_hooks
     let warnings = vec![ConversionWarning::MissingVersion];
     let rendered = render_hook_success(
         ComponentKind::Hook,
+        TargetKind::Copilot,
         Some(SourceFormat::TargetFormat),
         &warnings,
         0,
@@ -498,7 +520,7 @@ fn render_hook_success_target_format_with_zero_scripts_does_not_emit_empty_hooks
 fn render_hook_success_hook_with_none_source_format_and_no_warnings_returns_empty() {
     // version 付き Copilot 形式 Hook は DeploymentOutput::Copied 経路で
     // hook_source_format == None / warnings 0 になる。既存挙動の固定。
-    let rendered = render_hook_success(ComponentKind::Hook, None, &[], 0, 0);
+    let rendered = render_hook_success(ComponentKind::Hook, TargetKind::Copilot, None, &[], 0, 0);
     assert!(rendered.stdout_suffix.is_none());
     assert!(rendered.stderr_blocks.is_empty());
 }
@@ -520,6 +542,7 @@ fn render_hook_success_prompt_agent_stub_emits_manual_rewrite_section() {
     ];
     let rendered = render_hook_success(
         ComponentKind::Hook,
+        TargetKind::Copilot,
         Some(SourceFormat::ClaudeCode),
         &warnings,
         2,

--- a/src/install/format_test.rs
+++ b/src/install/format_test.rs
@@ -311,6 +311,7 @@ fn render_hook_success_claude_code_with_unsupported_events_emits_suffix_and_one_
         Some(SourceFormat::ClaudeCode),
         &warnings,
         1,
+        1,
     );
     assert!(rendered.stdout_suffix.is_some());
     assert_eq!(rendered.stderr_blocks.len(), 1);
@@ -325,6 +326,7 @@ fn render_hook_success_copilot_format_with_missing_version_no_suffix_only_indivi
         ComponentKind::Hook,
         Some(SourceFormat::TargetFormat),
         &warnings,
+        0,
         0,
     );
     assert!(rendered.stdout_suffix.is_none());
@@ -341,6 +343,7 @@ fn render_hook_success_skill_returns_empty_output() {
         ComponentKind::Skill,
         Some(SourceFormat::ClaudeCode),
         &[ConversionWarning::MissingVersion],
+        1,
         1,
     );
     assert!(rendered.stdout_suffix.is_none());
@@ -362,12 +365,32 @@ fn render_hook_success_all_events_skipped_includes_empty_hooks_warning() {
         Some(SourceFormat::ClaudeCode),
         &warnings,
         0,
+        0,
     );
     assert!(rendered.stdout_suffix.is_some());
     // skipped events warning + empty hooks warning の 2 ブロック
     assert_eq!(rendered.stderr_blocks.len(), 2);
     assert!(rendered.stderr_blocks[0].contains("2 events skipped"));
     assert!(rendered.stderr_blocks[1].contains("no hooks remained after conversion"));
+}
+
+#[test]
+fn render_hook_success_inline_hooks_do_not_emit_empty_hooks_warning() {
+    let rendered = render_hook_success(
+        ComponentKind::Hook,
+        Some(SourceFormat::ClaudeCode),
+        &[],
+        0,
+        1,
+    );
+    assert!(rendered.stdout_suffix.is_some());
+    assert!(
+        !rendered
+            .stderr_blocks
+            .iter()
+            .any(|b| b.contains("no hooks remained after conversion")),
+        "inline Codex hooks should not be treated as an empty hooks.json"
+    );
 }
 
 #[test]
@@ -390,6 +413,7 @@ fn render_hook_success_all_unsupported_hook_types_emits_empty_hooks_warning() {
         ComponentKind::Hook,
         Some(SourceFormat::ClaudeCode),
         &warnings,
+        0,
         0,
     );
     assert!(rendered.stdout_suffix.is_some());
@@ -434,6 +458,7 @@ fn render_hook_success_only_removed_field_warnings_still_emits_empty_hooks_warni
         Some(SourceFormat::ClaudeCode),
         &warnings,
         0,
+        0,
     );
     assert!(rendered.stdout_suffix.is_some());
     // 空配置警告 + 個別 warning 2 件 = 3 ブロック
@@ -457,6 +482,7 @@ fn render_hook_success_target_format_with_zero_scripts_does_not_emit_empty_hooks
         Some(SourceFormat::TargetFormat),
         &warnings,
         0,
+        0,
     );
     assert!(rendered.stdout_suffix.is_none());
     assert!(
@@ -472,7 +498,7 @@ fn render_hook_success_target_format_with_zero_scripts_does_not_emit_empty_hooks
 fn render_hook_success_hook_with_none_source_format_and_no_warnings_returns_empty() {
     // version 付き Copilot 形式 Hook は DeploymentOutput::Copied 経路で
     // hook_source_format == None / warnings 0 になる。既存挙動の固定。
-    let rendered = render_hook_success(ComponentKind::Hook, None, &[], 0);
+    let rendered = render_hook_success(ComponentKind::Hook, None, &[], 0, 0);
     assert!(rendered.stdout_suffix.is_none());
     assert!(rendered.stderr_blocks.is_empty());
 }
@@ -496,6 +522,7 @@ fn render_hook_success_prompt_agent_stub_emits_manual_rewrite_section() {
         ComponentKind::Hook,
         Some(SourceFormat::ClaudeCode),
         &warnings,
+        2,
         2,
     );
     assert!(rendered.stdout_suffix.is_some());

--- a/src/install_test.rs
+++ b/src/install_test.rs
@@ -575,3 +575,54 @@ fn test_place_plugin_codex_rejects_multiple_hook_components() {
         .all(|failure| failure.error.contains("would overwrite each other")));
     assert!(!project_dir.path().join(".codex/hooks.json").exists());
 }
+
+#[test]
+fn record_codex_hook_ownership_writes_managed_file_and_status() {
+    let plugin_dir = TempDir::new().unwrap();
+    let hook_dest = TempDir::new().unwrap();
+    let hook_path = hook_dest.path().join(".codex/hooks.json");
+
+    record_codex_hook_ownership(plugin_dir.path(), &hook_path);
+
+    let plugin_meta = crate::plugin::meta::load_meta(plugin_dir.path()).unwrap();
+    assert_eq!(plugin_meta.get_status("codex"), Some("enabled"));
+    assert!(plugin_meta.manages_file("codex", &hook_path));
+}
+
+#[test]
+fn record_codex_hook_ownership_is_idempotent() {
+    let plugin_dir = TempDir::new().unwrap();
+    let hook_dest = TempDir::new().unwrap();
+    let hook_path = hook_dest.path().join(".codex/hooks.json");
+
+    record_codex_hook_ownership(plugin_dir.path(), &hook_path);
+    record_codex_hook_ownership(plugin_dir.path(), &hook_path);
+
+    let plugin_meta = crate::plugin::meta::load_meta(plugin_dir.path()).unwrap();
+    let codex_files = plugin_meta.managed_files.get("codex").unwrap();
+    assert_eq!(
+        codex_files.len(),
+        1,
+        "同じパスを 2 回登録しても重複してはならない"
+    );
+}
+
+#[test]
+fn record_codex_hook_ownership_unblocks_re_import() {
+    // import 経路で同じプラグインを再 import するときに、過去の deploy で
+    // 記録した managedFiles エントリにより hook_overwrite_error が
+    // 既存ファイルを許容することを確認する。
+    let plugin_dir = TempDir::new().unwrap();
+    let hook_dest = TempDir::new().unwrap();
+    let hook_path = hook_dest.path().join("hooks.json");
+    fs::write(&hook_path, "{}").unwrap();
+
+    // 過去の deploy 成功時に呼ばれるはずの記録を再現
+    record_codex_hook_ownership(plugin_dir.path(), &hook_path);
+
+    // 同プラグインによる再 import → 上書きガードを通過すべき
+    assert!(
+        CodexTarget::hook_overwrite_error(&hook_path, plugin_dir.path()).is_none(),
+        "managedFiles に記録された path への再 import は許可されるべき"
+    );
+}

--- a/src/install_test.rs
+++ b/src/install_test.rs
@@ -444,3 +444,64 @@ fn test_place_plugin_copilot_hook_with_missing_version_propagates_target_format(
     );
     assert_eq!(success.script_count, 0);
 }
+
+#[test]
+fn test_place_plugin_codex_hook_installs_inline_hooks_json() {
+    let temp = TempDir::new().unwrap();
+    let project_dir = TempDir::new().unwrap();
+
+    let claude_code_hook = r#"{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo 'pre check'",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}"#;
+    let cached = create_test_hook_package(temp.path(), "my-hook", claude_code_hook);
+    let package = MarketplaceContent::try_from(cached).unwrap();
+    let scanned = scan_plugin(&package, None).unwrap();
+
+    let targets: Vec<Box<dyn crate::target::Target>> = vec![Box::new(CodexTarget::new())];
+
+    let result = place_plugin(&PlaceRequest {
+        scanned: &scanned,
+        targets: &targets,
+        scope: crate::component::Scope::Project,
+        project_root: project_dir.path(),
+    });
+
+    assert_eq!(result.successes.len(), 1, "failures: {:?}", result.failures);
+    let success = &result.successes[0];
+    assert_eq!(success.target, "codex");
+    assert_eq!(success.component_kind, ComponentKind::Hook);
+    assert_eq!(
+        success.target_path,
+        project_dir.path().join(".codex/hooks.json")
+    );
+    assert_eq!(success.hook_source_format, Some(SourceFormat::ClaudeCode));
+    assert_eq!(
+        success.script_count, 0,
+        "Codex command hooks stay inline and do not generate wrapper scripts"
+    );
+    assert_eq!(success.hook_count, 1);
+
+    let rendered = fs::read_to_string(&success.target_path).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&rendered).unwrap();
+    assert_eq!(json["hooks"]["PreToolUse"][0]["matcher"], "Bash");
+    assert_eq!(
+        json["hooks"]["PreToolUse"][0]["hooks"][0]["command"],
+        "echo 'pre check'"
+    );
+    assert!(json["hooks"]["PreToolUse"][0]["hooks"][0]
+        .get("bash")
+        .is_none());
+}

--- a/src/install_test.rs
+++ b/src/install_test.rs
@@ -505,3 +505,73 @@ fn test_place_plugin_codex_hook_installs_inline_hooks_json() {
         .get("bash")
         .is_none());
 }
+
+#[test]
+fn test_place_plugin_codex_rejects_multiple_hook_components() {
+    let temp = TempDir::new().unwrap();
+    let project_dir = TempDir::new().unwrap();
+    let hook_json = r#"{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo 'pre check'"
+          }
+        ]
+      }
+    ]
+  }
+}"#;
+
+    let manifest_content = serde_json::json!({
+        "name": "test-plugin",
+        "version": "1.0.0",
+        "description": "A test plugin"
+    });
+    fs::write(
+        temp.path().join("plugin.json"),
+        manifest_content.to_string(),
+    )
+    .unwrap();
+    let hooks_dir = temp.path().join("hooks");
+    fs::create_dir_all(&hooks_dir).unwrap();
+    fs::write(hooks_dir.join("first.json"), hook_json).unwrap();
+    fs::write(hooks_dir.join("second.json"), hook_json).unwrap();
+
+    let manifest = PluginManifest::load(&temp.path().join("plugin.json")).unwrap();
+    let cached = CachedPackage {
+        name: "test-plugin".to_string(),
+        id: None,
+        marketplace: Some("test-marketplace".to_string()),
+        path: temp.path().to_path_buf(),
+        manifest,
+        git_ref: "main".to_string(),
+        commit_sha: "abc123".to_string(),
+        marketplace_manifest: None,
+    };
+    let package = MarketplaceContent::try_from(cached).unwrap();
+    let scanned = scan_plugin(&package, None).unwrap();
+
+    let targets: Vec<Box<dyn crate::target::Target>> = vec![Box::new(CodexTarget::new())];
+    let result = place_plugin(&PlaceRequest {
+        scanned: &scanned,
+        targets: &targets,
+        scope: crate::component::Scope::Project,
+        project_root: project_dir.path(),
+    });
+
+    assert!(result.successes.is_empty());
+    assert_eq!(result.failures.len(), 2);
+    assert!(result
+        .failures
+        .iter()
+        .all(|failure| failure.component_kind == ComponentKind::Hook));
+    assert!(result
+        .failures
+        .iter()
+        .all(|failure| failure.error.contains("would overwrite each other")));
+    assert!(!project_dir.path().join(".codex/hooks.json").exists());
+}

--- a/src/plugin/meta/meta.rs
+++ b/src/plugin/meta/meta.rs
@@ -59,6 +59,22 @@ pub struct PluginMeta {
         skip_serializing_if = "Option::is_none"
     )]
     pub marketplace: Option<String>,
+
+    /// プラグインが管理する「shared destination ファイル」の絶対パス一覧
+    /// （ターゲット別）。
+    ///
+    /// `.codex/hooks.json` のように複数のソースで上書き合戦になりうるファイルの
+    /// 所有権追跡に用いる。`statusByTarget` は scope 非依存かつコンポーネント
+    /// 種別非依存なので、上書きガードの根拠としては不正確になる
+    /// （Skill のみ配置したケースでも `enabled` になる、personal で enable した
+    /// 状態で project の同名ファイルを上書きしうる）。`managed_files` は
+    /// 絶対パス単位で記録するため、scope と配置種別の双方を区別できる。
+    #[serde(
+        default,
+        rename = "managedFiles",
+        skip_serializing_if = "HashMap::is_empty"
+    )]
+    pub managed_files: HashMap<String, Vec<String>>,
 }
 
 impl PluginMeta {
@@ -135,6 +151,34 @@ impl PluginMeta {
     /// GitHub プラグインかどうか
     pub fn is_github(&self) -> bool {
         self.marketplace.as_deref() == Some("github") || self.marketplace.is_none()
+    }
+
+    /// `target` の管理ファイル一覧に `path` を追加する（重複は無視）。
+    ///
+    /// # Arguments
+    ///
+    /// * `target` - Target name (e.g. `"codex"`).
+    /// * `path` - Absolute destination path the plugin owns (e.g.
+    ///   `/home/user/.codex/hooks.json`).
+    pub fn add_managed_file(&mut self, target: &str, path: &Path) {
+        let path_str = path.to_string_lossy().into_owned();
+        let entry = self.managed_files.entry(target.to_string()).or_default();
+        if !entry.iter().any(|p| p == &path_str) {
+            entry.push(path_str);
+        }
+    }
+
+    /// 指定 `(target, path)` をこのプラグインが管理しているか。
+    ///
+    /// # Arguments
+    ///
+    /// * `target` - Target name.
+    /// * `path` - Absolute destination path being checked.
+    pub fn manages_file(&self, target: &str, path: &Path) -> bool {
+        let path_str = path.to_string_lossy();
+        self.managed_files
+            .get(target)
+            .is_some_and(|paths| paths.iter().any(|p| p.as_str() == path_str.as_ref()))
     }
 }
 

--- a/src/plugin/meta/meta.rs
+++ b/src/plugin/meta/meta.rs
@@ -153,19 +153,26 @@ impl PluginMeta {
         self.marketplace.as_deref() == Some("github") || self.marketplace.is_none()
     }
 
-    /// `target` の管理ファイル一覧に `path` を追加する（重複は無視）。
+    /// `target` の管理ファイル一覧に `path` を追加する。
+    ///
+    /// # Returns
+    /// 新たに追加した場合は `true`、既に登録済みで何もしなかった場合は `false`。
+    /// 戻り値で no-op を判定し、不要な `.plm-meta.json` 書き換え（mtime 汚染）を
+    /// 防ぐために使う。
     ///
     /// # Arguments
     ///
     /// * `target` - Target name (e.g. `"codex"`).
     /// * `path` - Absolute destination path the plugin owns (e.g.
     ///   `/home/user/.codex/hooks.json`).
-    pub fn add_managed_file(&mut self, target: &str, path: &Path) {
+    pub fn add_managed_file(&mut self, target: &str, path: &Path) -> bool {
         let path_str = path.to_string_lossy().into_owned();
         let entry = self.managed_files.entry(target.to_string()).or_default();
-        if !entry.iter().any(|p| p == &path_str) {
-            entry.push(path_str);
+        if entry.iter().any(|p| p == &path_str) {
+            return false;
         }
+        entry.push(path_str);
+        true
     }
 
     /// 指定 `(target, path)` をこのプラグインが管理しているか。

--- a/src/plugin/meta/meta_test.rs
+++ b/src/plugin/meta/meta_test.rs
@@ -634,3 +634,29 @@ fn test_is_enabled_indexed_falls_back_to_index() {
         &deployed_plugins
     ));
 }
+
+// =============================================================================
+// managed_files tests
+// =============================================================================
+
+#[test]
+fn add_managed_file_returns_true_when_inserting_new_path() {
+    let mut meta = PluginMeta::default();
+    let added = meta.add_managed_file("codex", std::path::Path::new("/dest/codex/hooks.json"));
+    assert!(added);
+    assert!(meta.manages_file("codex", std::path::Path::new("/dest/codex/hooks.json")));
+}
+
+#[test]
+fn add_managed_file_returns_false_when_path_already_present() {
+    let mut meta = PluginMeta::default();
+    meta.add_managed_file("codex", std::path::Path::new("/dest/codex/hooks.json"));
+
+    let added = meta.add_managed_file("codex", std::path::Path::new("/dest/codex/hooks.json"));
+    assert!(!added, "重複登録は no-op として false を返す必要がある");
+    assert_eq!(
+        meta.managed_files.get("codex").unwrap().len(),
+        1,
+        "重複時は配列が増えない"
+    );
+}

--- a/src/target/env/codex.rs
+++ b/src/target/env/codex.rs
@@ -53,6 +53,39 @@ impl CodexTarget {
         })
     }
 
+    /// 配置先 `hooks.json` がすでに存在し、現在のプラグインが過去に同 target を
+    /// enable していない場合にエラー文字列を返す。
+    ///
+    /// 共有パス（`.codex/hooks.json` / `~/.codex/hooks.json`）を上書きしてしまう
+    /// ことで、ユーザーが手書きした hooks や別プラグインが配置した hooks を
+    /// 黙って消してしまうのを防ぐ。再 install（同プラグイン）の場合は
+    /// `.plm-meta.json` の `statusByTarget["codex"] == "enabled"` を見て許可する。
+    ///
+    /// # Arguments
+    ///
+    /// * `target_path` - Resolved destination path (e.g. `.codex/hooks.json`).
+    /// * `plugin_root` - Cached plugin directory; `.plm-meta.json` lives here.
+    pub fn hook_overwrite_error(target_path: &Path, plugin_root: &Path) -> Option<String> {
+        if !target_path.exists() {
+            return None;
+        }
+
+        let already_owned = crate::plugin::meta::load_meta(plugin_root)
+            .and_then(|meta| meta.get_status("codex").map(|s| s.to_string()))
+            .map(|status| status == "enabled")
+            .unwrap_or(false);
+
+        if already_owned {
+            return None;
+        }
+
+        Some(format!(
+            "{} already exists and is not managed by this plugin. \
+             Refusing to overwrite; remove the file or merge it manually before re-installing.",
+            target_path.display()
+        ))
+    }
+
     /// コンポーネント種別に応じたフィルタリング
     ///
     /// # Arguments

--- a/src/target/env/codex.rs
+++ b/src/target/env/codex.rs
@@ -34,7 +34,7 @@ impl CodexTarget {
     ///
     /// * `kind` - Component kind to check.
     fn can_place(kind: ComponentKind) -> bool {
-        kind != ComponentKind::Command && kind != ComponentKind::Hook
+        kind != ComponentKind::Command
     }
 
     /// コンポーネント種別に応じたフィルタリング
@@ -54,6 +54,7 @@ impl CodexTarget {
             ComponentKind::Agent if !c.is_dir && c.name.ends_with(".agent.md") => {
                 Some(c.name.trim_end_matches(".agent.md").to_string())
             }
+            ComponentKind::Hook if !c.is_dir && c.name == "hooks.json" => Some("hooks".to_string()),
             _ => None,
         }
     }
@@ -83,6 +84,7 @@ impl Target for CodexTarget {
             ComponentKind::Skill,
             ComponentKind::Agent,
             ComponentKind::Instruction,
+            ComponentKind::Hook,
         ]
     }
 
@@ -109,7 +111,8 @@ impl Target for CodexTarget {
                 Scope::Project => PlacementLocation::file(project_root.join("AGENTS.md")),
                 Scope::Personal => PlacementLocation::file(base.join("AGENTS.md")),
             },
-            ComponentKind::Command | ComponentKind::Hook => return None,
+            ComponentKind::Hook => PlacementLocation::file(base.join("hooks.json")),
+            ComponentKind::Command => return None,
         })
     }
 
@@ -136,6 +139,7 @@ impl Target for CodexTarget {
         let dir_path = match kind {
             ComponentKind::Skill => base.join("skills"),
             ComponentKind::Agent => base.join("agents"),
+            ComponentKind::Hook => base.clone(),
             _ => return Ok(vec![]),
         };
 

--- a/src/target/env/codex.rs
+++ b/src/target/env/codex.rs
@@ -53,13 +53,21 @@ impl CodexTarget {
         })
     }
 
-    /// 配置先 `hooks.json` がすでに存在し、現在のプラグインが過去に同 target を
-    /// enable していない場合にエラー文字列を返す。
+    /// 配置先 `hooks.json` がすでに存在し、`target_path` が現在のプラグインの
+    /// 管理下に無い場合にエラー文字列を返す。
     ///
-    /// 共有パス（`.codex/hooks.json` / `~/.codex/hooks.json`）を上書きしてしまう
-    /// ことで、ユーザーが手書きした hooks や別プラグインが配置した hooks を
-    /// 黙って消してしまうのを防ぐ。再 install（同プラグイン）の場合は
-    /// `.plm-meta.json` の `statusByTarget["codex"] == "enabled"` を見て許可する。
+    /// 共有パス（`.codex/hooks.json` / `~/.codex/hooks.json`）を上書きして
+    /// しまうことで、ユーザーが手書きした hooks や別プラグインが配置した
+    /// hooks を黙って消してしまうのを防ぐ。再 install（同プラグイン）の場合は
+    /// `.plm-meta.json` の `managedFiles["codex"]` に `target_path` が
+    /// 含まれている場合のみ許可する。
+    ///
+    /// 旧実装は `statusByTarget["codex"] == "enabled"` を所有権の根拠に
+    /// していたが、この値は scope 非依存かつコンポーネント種別非依存で、
+    /// (a) personal で enable された状態が project 側 `.codex/hooks.json`
+    /// の上書きを許してしまう、(b) Skill のみ配置したプラグインでも
+    /// 上書きガードを通過してしまう、という不整合があった。
+    /// 絶対パス単位の `managedFiles` でこの両方を解消する。
     ///
     /// # Arguments
     ///
@@ -71,8 +79,7 @@ impl CodexTarget {
         }
 
         let already_owned = crate::plugin::meta::load_meta(plugin_root)
-            .and_then(|meta| meta.get_status("codex").map(|s| s.to_string()))
-            .map(|status| status == "enabled")
+            .map(|meta| meta.manages_file("codex", target_path))
             .unwrap_or(false);
 
         if already_owned {

--- a/src/target/env/codex.rs
+++ b/src/target/env/codex.rs
@@ -1,6 +1,6 @@
 //! OpenAI Codex ターゲット実装
 
-use crate::component::{ComponentKind, PlacementContext, PlacementLocation, Scope};
+use crate::component::{Component, ComponentKind, PlacementContext, PlacementLocation, Scope};
 use crate::error::Result;
 use crate::target::paths::base_dir;
 use crate::target::placed_common;
@@ -35,6 +35,22 @@ impl CodexTarget {
     /// * `kind` - Component kind to check.
     fn can_place(kind: ComponentKind) -> bool {
         kind != ComponentKind::Command
+    }
+
+    /// Codex は 1 スコープにつき単一の `hooks.json` を読むため、複数 Hook を
+    /// 個別配置すると同じファイルを上書きする。マージ未実装の間は拒否する。
+    pub fn hook_component_conflict_error(components: &[Component]) -> Option<String> {
+        let hook_count = components
+            .iter()
+            .filter(|component| component.kind == ComponentKind::Hook)
+            .count();
+
+        (hook_count > 1).then(|| {
+            format!(
+                "Codex target supports a single hooks.json per scope; {} Hook components would overwrite each other. Select one Hook component or wait for merge support.",
+                hook_count
+            )
+        })
     }
 
     /// コンポーネント種別に応じたフィルタリング

--- a/src/target/env/codex_test.rs
+++ b/src/target/env/codex_test.rs
@@ -197,3 +197,45 @@ fn test_codex_placement_location_hook_personal_scope() {
     assert!(location.is_file());
     assert_eq!(location.as_path(), home_dir().join(".codex/hooks.json"));
 }
+
+#[test]
+fn hook_overwrite_error_returns_none_when_target_does_not_exist() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let target_path = temp.path().join("hooks.json"); // 存在しない
+    let plugin_root = temp.path();
+
+    assert!(CodexTarget::hook_overwrite_error(&target_path, plugin_root).is_none());
+}
+
+#[test]
+fn hook_overwrite_error_returns_error_when_target_exists_and_not_managed() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let target_path = temp.path().join("hooks.json");
+    std::fs::write(&target_path, "{}").unwrap();
+
+    let plugin_root_dir = tempfile::TempDir::new().unwrap();
+    // .plm-meta.json は無いので、過去 install 履歴なし → error
+    let result = CodexTarget::hook_overwrite_error(&target_path, plugin_root_dir.path());
+    assert!(result.is_some());
+    let msg = result.unwrap();
+    assert!(msg.contains("already exists"));
+    assert!(msg.contains("not managed by this plugin"));
+}
+
+#[test]
+fn hook_overwrite_error_returns_none_when_plugin_already_owns_codex() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let target_path = temp.path().join("hooks.json");
+    std::fs::write(&target_path, "{}").unwrap();
+
+    let plugin_root_dir = tempfile::TempDir::new().unwrap();
+    let mut meta = crate::plugin::meta::PluginMeta::default();
+    meta.set_status("codex", "enabled");
+    crate::plugin::meta::write_meta(plugin_root_dir.path(), &meta).unwrap();
+
+    // 同プラグインの再 install は許可される
+    assert!(
+        CodexTarget::hook_overwrite_error(&target_path, plugin_root_dir.path()).is_none(),
+        "re-install of the same plugin must be allowed when codex was previously enabled"
+    );
+}

--- a/src/target/env/codex_test.rs
+++ b/src/target/env/codex_test.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::component::{ComponentRef, PlacementScope, ProjectContext};
+use crate::target::paths::home_dir;
 use crate::target::PluginOrigin;
 
 #[test]
@@ -15,8 +16,8 @@ fn test_codex_supported_components() {
     assert!(target.supports(ComponentKind::Skill));
     assert!(target.supports(ComponentKind::Agent));
     assert!(target.supports(ComponentKind::Instruction));
+    assert!(target.supports(ComponentKind::Hook));
     assert!(!target.supports(ComponentKind::Command));
-    assert!(!target.supports(ComponentKind::Hook));
 }
 
 #[test]
@@ -159,4 +160,40 @@ fn test_codex_command_not_supported() {
         project: ProjectContext::new(project_root),
     };
     assert!(target.placement_location(&ctx).is_none());
+}
+
+#[test]
+fn test_codex_placement_location_hook_project_scope() {
+    let target = CodexTarget::new();
+    let project_root = Path::new("/project");
+    let origin = PluginOrigin::from_marketplace("test", "test");
+
+    let ctx = PlacementContext {
+        component: ComponentRef::new(ComponentKind::Hook, "test_pre-tool-use"),
+        origin: &origin,
+        scope: PlacementScope::new(Scope::Project),
+        project: ProjectContext::new(project_root),
+    };
+    let location = target.placement_location(&ctx).unwrap();
+
+    assert!(location.is_file());
+    assert_eq!(location.as_path(), Path::new("/project/.codex/hooks.json"));
+}
+
+#[test]
+fn test_codex_placement_location_hook_personal_scope() {
+    let target = CodexTarget::new();
+    let project_root = Path::new("/project");
+    let origin = PluginOrigin::from_marketplace("test", "test");
+
+    let ctx = PlacementContext {
+        component: ComponentRef::new(ComponentKind::Hook, "test_pre-tool-use"),
+        origin: &origin,
+        scope: PlacementScope::new(Scope::Personal),
+        project: ProjectContext::new(project_root),
+    };
+    let location = target.placement_location(&ctx).unwrap();
+
+    assert!(location.is_file());
+    assert_eq!(location.as_path(), home_dir().join(".codex/hooks.json"));
 }

--- a/src/target/env/codex_test.rs
+++ b/src/target/env/codex_test.rs
@@ -223,7 +223,28 @@ fn hook_overwrite_error_returns_error_when_target_exists_and_not_managed() {
 }
 
 #[test]
-fn hook_overwrite_error_returns_none_when_plugin_already_owns_codex() {
+fn hook_overwrite_error_returns_none_when_plugin_already_owns_target_path() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let target_path = temp.path().join("hooks.json");
+    std::fs::write(&target_path, "{}").unwrap();
+
+    let plugin_root_dir = tempfile::TempDir::new().unwrap();
+    let mut meta = crate::plugin::meta::PluginMeta::default();
+    meta.add_managed_file("codex", &target_path);
+    crate::plugin::meta::write_meta(plugin_root_dir.path(), &meta).unwrap();
+
+    // 同プラグインによる同 destination への再 install は許可される
+    assert!(
+        CodexTarget::hook_overwrite_error(&target_path, plugin_root_dir.path()).is_none(),
+        "re-install of the same plugin must be allowed for a managed file path"
+    );
+}
+
+#[test]
+fn hook_overwrite_error_rejects_when_status_enabled_but_path_not_managed() {
+    // statusByTarget["codex"] == "enabled" だけでは所有権としては不十分。
+    // 例: personal で先に enable した後、project の同名ファイルを書こうとした場合は
+    // managedFiles に project 側の path が無いので拒否されるべき。
     let temp = tempfile::TempDir::new().unwrap();
     let target_path = temp.path().join("hooks.json");
     std::fs::write(&target_path, "{}").unwrap();
@@ -231,11 +252,14 @@ fn hook_overwrite_error_returns_none_when_plugin_already_owns_codex() {
     let plugin_root_dir = tempfile::TempDir::new().unwrap();
     let mut meta = crate::plugin::meta::PluginMeta::default();
     meta.set_status("codex", "enabled");
+    // 別の path のみ管理対象として登録（Skill 配置等で enable はされたが、
+    // 実際の hooks.json は別プラグインの所有という想定）
+    meta.add_managed_file("codex", std::path::Path::new("/somewhere/else/hooks.json"));
     crate::plugin::meta::write_meta(plugin_root_dir.path(), &meta).unwrap();
 
-    // 同プラグインの再 install は許可される
+    let result = CodexTarget::hook_overwrite_error(&target_path, plugin_root_dir.path());
     assert!(
-        CodexTarget::hook_overwrite_error(&target_path, plugin_root_dir.path()).is_none(),
-        "re-install of the same plugin must be allowed when codex was previously enabled"
+        result.is_some(),
+        "must reject when target_path is not in managedFiles even if target is enabled"
     );
 }

--- a/src/tui/manager/screens/marketplaces/actions.rs
+++ b/src/tui/manager/screens/marketplaces/actions.rs
@@ -332,6 +332,8 @@ fn install_single_plugin(
         project_root: ctx.project_root,
     });
 
+    install::update_meta_after_place(scanned.plugin_root(), &place_result);
+
     if !place_result.failures.is_empty() {
         let errors: Vec<String> = place_result
             .failures


### PR DESCRIPTION
## 概要

Claude Code形式のHookコンポーネントをCodexターゲットへインストールできるようにしました。Codex向けはmatcher group構造を保持し、`command` hookはwrapperを生成せずinlineのまま `.codex/hooks.json` / `~/.codex/hooks.json` に配置します。

## 変更内容

### 🎯 変更の種類

- [ ] 🐛 バグ修正 (Bug fix)
- [x] ✨ 新機能 (New feature)
- [ ] ♻️ リファクタリング (Refactoring)
- [ ] 🎨 UI/UX 改善 (UI/UX improvement)
- [ ] 🐎 パフォーマンス改善 (Performance improvement)
- [x] 🚨 テスト追加/修正 (Tests)
- [x] 📖 ドキュメント更新 (Documentation)
- [ ] 🔧 設定変更 (Configuration)
- [ ] 🗑️ 削除 (Removal)

### 📝 詳細な変更内容

#### 追加された機能・修正

- Codex targetで`ComponentKind::Hook`をサポート
- `TargetKind::Codex`向けHooks converter layerを登録
- Codex向けにPascalCase eventとmatcher group構造を保持する変換経路を追加
- `command` hookをinlineで保持し、`http` / `prompt` / `agent`は警告付きで除外
- Codex inline hookを空配置と誤判定しないよう`hook_count`を追加
- install/import経路でCodexにもHook変換設定を渡すよう修正

#### 変更されたファイル

- `src/hooks/converter/*`
- `src/hooks/event/codex.rs`
- `src/target/env/codex.rs`
- `src/component/deployment/*`
- `src/install*.rs`
- `src/commands/deploy/*`
- `docs/codex-hooks-conversion-implementation-plan-2026-05-06.md`

#### 削除されたファイル・機能

- なし

## 📋 関連 Issue

- なし

## 🧪 テスト

### テスト実行方法

```bash
cargo test
cargo clippy
```

### テスト項目

- [x] 単体テスト (Unit tests)
- [x] 統合テスト (Integration tests)
- [ ] E2E テスト (End-to-end tests)
- [ ] 手動テスト (Manual testing)

### テスト結果

- `cargo test`: 1615 passed
- `cargo clippy`: passed

## 🔍 レビューポイント

- Codex Hooksの配置先を公式パスの `.codex/hooks.json` / `~/.codex/hooks.json` にしている点
- Copilot向けflatten変換を維持しつつ、Codex向けだけmatcher groupを保持する分岐
- `script_count`ではなく`hook_count`で空hooks警告を判定する変更
- `http` / `prompt` / `agent`を初期対応では除外する判断

## ⚠️ 破壊的変更

- [ ] この変更は既存の API に破壊的変更を含みます

## 📚 追加情報

### 参考資料

- https://developers.openai.com/codex/hooks
- https://developers.openai.com/codex/plugins/build

### 注意事項

- Codex Hooksのfeature flag設定補助や複数Hookコンポーネントのマージは、今回の実装範囲外です。

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [x] ドキュメントが更新されている（必要に応じて）
- [x] コミットメッセージが適切な形式で書かれている
- [ ] 関連する Issue が PR の「Development」に Linked されている
- [ ] PR 本文に `Closes #` / `Fixes #` / `Refs #` などで Issue が記載されている
- [x] セルフレビューを実施した
- [x] 破壊的変更がある場合は明記されている

## 🤝 レビュアーへのお願い

- Codex Hooks公式仕様との配置パス・JSON構造の整合性を重点的に確認してください。