### PR TITLE
♻️ [Refactoring]: #271 Result 系ドメイン型を Outcome 接尾辞に統一 (#259-A/B/C)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,6 +182,15 @@ src/
 
 テストコードは本体コードと同じファイルに書かない。`foo.rs` のテストは `foo_test.rs` に分離する。
 
+### 型名の接尾辞 (Result / Outcome の使い分け)
+
+- `Result` 接尾辞は `std::result::Result<T, E>` および `crate::error::Result<T>` の予約とする
+- ドメイン処理の成果レポート型 (Ok/Err を内包しない値オブジェクト) は `*Outcome` を使う
+- 例: `SyncOutcome`, `OperationOutcome`, `UpdateOutcome`, `ConvertOutcome`
+- 既存型の継続的見直しは Issue #259 系で追跡する
+
+詳細は `docs/architecture/naming-conventions.md` を参照。
+
 ## 開発プロセス
 
 ### TDD（テスト駆動開発）

--- a/docs/architecture/naming-conventions.md
+++ b/docs/architecture/naming-conventions.md
@@ -1,0 +1,71 @@
+# 命名規約
+
+> 作成日: 2026-05-09
+> 関連 Issue: #259 / #271
+
+このドキュメントは PLM プロジェクトにおける Rust の型名・識別子の命名規約をまとめる。
+特に `Result` / `Outcome` 接尾辞の使い分けに重点を置く。
+
+---
+
+## 1. `Result` / `Outcome` 接尾辞
+
+| 接尾辞 | 用途 | 例 |
+|---|---|---|
+| `Result` | `std::result::Result<T, E>` および `crate::error::Result<T>` (= `Result<T, PlmError>`) のエイリアス専用 | `crate::error::Result<()>` |
+| `Outcome` | ドメイン処理の「成果レポート」。成功/部分成功/失敗の集計、影響範囲、副作用などをまとめた値オブジェクト | `SyncOutcome`, `OperationOutcome` |
+| `Status` / `Kind` / `Failure` 等 | enum や付随する区分・失敗詳細用に従来通り使用 | `UpdateStatus`, `SyncFailure` |
+
+### 1.1 規約の要点
+
+- **`Result` 接尾辞** はエラー型を内包する `Result<T, E>` 専用に予約する。型名から「エラー型を含む `Result<T,E>` か、ドメイン成果レポートか」が一目で識別できることを目的とする。
+- **`Outcome` 接尾辞** はドメインの操作結果 (成果レポート) を表す値オブジェクトに用いる。Ok/Err を内包しない通常の `struct` であり、フィールドとして処理の集計 (作成/更新/削除されたコンポーネント、失敗一覧、影響範囲、副作用フラグ等) を持つ。
+
+### 1.2 適用範囲
+
+- **新規追加するドメイン処理結果型**: 必ず `*Outcome` 接尾辞を使う。
+- **既存の `*Result` 型**: Issue #271 (Issue #259-A/B/C 一括対応) で以下 4 型 + tui 1 型を `*Outcome` に統一済み。
+  - `SyncOutcome` (旧 `SyncResult`)
+  - `ConvertOutcome` (旧 `ConvertResult`)
+  - `OperationOutcome` (旧 `OperationResult`、type alias 削除)
+  - `UpdateOutcome` (旧 `UpdateResult`、type alias 削除)
+  - `MarketplaceAddOutcome` (旧 `tui::manager::screens::marketplaces::actions::AddResult`)
+
+### 1.3 適用継続検討対象
+
+以下は本規約の適用を継続検討する。
+
+- **`target::AddResult` (enum)**: 名称が `*Result` だが「成功/失敗のバリアント」を持つ enum で、`Result` 接尾辞ながら例外的に存続。別 Issue で再検討する。
+- **横断利用度の低い `*Result` 型** (`PlaceResult` / `ConversionResult` / `MultiSelectResult` 等): 横断度が低いため Issue #271 では対象外とした。横断利用が増えた段階で本規約に従って再評価する。
+- **`type SyncResult = std::result::Result<T, SyncError>` のような alias** (もし新たに必要になる場合): `Result` 接尾辞を維持してよい (この用途こそが `Result` 接尾辞の本来の意味)。
+
+---
+
+## 2. 関連メソッド名
+
+`Outcome` を生成するファクトリメソッドや変換メソッドの命名は本規約の対象外とする。
+
+例:
+- `AffectedTargets::into_result(self) -> OperationOutcome` — メソッド名 `into_result` はそのまま維持。本規約は「ドメイン処理結果値の型名」のみが対象。
+- `OperationOutcome::error(msg)` / `UpdateOutcome::updated(...)` 等のファクトリメソッド名も従来通り。
+
+---
+
+## 3. その他の接尾辞
+
+- `Status`: 単純な状態を表す enum (例: `UpdateStatus { Updated, UpToDate, Failed, Skipped }`)
+- `Kind`: 種別を表す enum (例: `ComponentKind`)
+- `Failure`: 失敗の詳細を表す struct (例: `SyncFailure`)
+- `Error`: エラー型 (例: `PlmError`、`SyncError`)
+
+これらは従来通り意味に沿って使い分ける。
+
+---
+
+## 4. 参考
+
+- Issue #259: Result 系型名の整理 (親 Issue)
+- Issue #259-A: 棚卸し
+- Issue #259-B: 命名方針策定
+- Issue #259-C: リネーム実装
+- Issue #271: 上記 #259-A/B/C を一括対応した Issue

--- a/docs/architecture/naming-conventions.md
+++ b/docs/architecture/naming-conventions.md
@@ -53,7 +53,7 @@
 
 ## 3. その他の接尾辞
 
-- `Status`: 単純な状態を表す enum (例: `UpdateStatus { Updated, UpToDate, Failed, Skipped }`)
+- `Status`: 単純な状態を表す enum (例: `UpdateStatus { Updated, AlreadyUpToDate, Failed, Skipped }`)
 - `Kind`: 種別を表す enum (例: `ComponentKind`)
 - `Failure`: 失敗の詳細を表す struct (例: `SyncFailure`)
 - `Error`: エラー型 (例: `PlmError`、`SyncError`)

--- a/docs/architecture/naming-conventions.md
+++ b/docs/architecture/naming-conventions.md
@@ -24,12 +24,12 @@
 ### 1.2 適用範囲
 
 - **新規追加するドメイン処理結果型**: 必ず `*Outcome` 接尾辞を使う。
-- **既存の `*Result` 型**: Issue #271 (Issue #259-A/B/C 一括対応) で以下 4 型 + tui 1 型を `*Outcome` に統一済み。
-  - `SyncOutcome` (旧 `SyncResult`)
-  - `ConvertOutcome` (旧 `ConvertResult`)
-  - `OperationOutcome` (旧 `OperationResult`、type alias 削除)
-  - `UpdateOutcome` (旧 `UpdateResult`、type alias 削除)
-  - `MarketplaceAddOutcome` (旧 `tui::manager::screens::marketplaces::actions::AddResult`)
+- **既存のドメイン処理結果型**: Issue #271 (Issue #259-A/B/C 一括対応) で以下 5 型を `*Outcome` に統一済み。
+  - `SyncOutcome`
+  - `ConvertOutcome`
+  - `OperationOutcome` (type alias 削除済み)
+  - `UpdateOutcome` (type alias 削除済み)
+  - `MarketplaceAddOutcome` (tui::manager::screens::marketplaces::actions 配下)
 
 ### 1.3 適用継続検討対象
 
@@ -37,7 +37,7 @@
 
 - **`target::AddResult` (enum)**: 名称が `*Result` だが「成功/失敗のバリアント」を持つ enum で、`Result` 接尾辞ながら例外的に存続。別 Issue で再検討する。
 - **横断利用度の低い `*Result` 型** (`PlaceResult` / `ConversionResult` / `MultiSelectResult` 等): 横断度が低いため Issue #271 では対象外とした。横断利用が増えた段階で本規約に従って再評価する。
-- **`type SyncResult = std::result::Result<T, SyncError>` のような alias** (もし新たに必要になる場合): `Result` 接尾辞を維持してよい (この用途こそが `Result` 接尾辞の本来の意味)。
+- **`type SyncFooBar = std::result::Result<T, SyncError>` のような型エイリアス** (もし新たに必要になる場合): `Result` 接尾辞を維持してよい (この用途こそが `Result` 接尾辞の本来の意味)。
 
 ---
 

--- a/src/application.rs
+++ b/src/application.rs
@@ -7,7 +7,7 @@ mod info;
 mod lifecycle;
 
 pub use crate::plugin::InstalledPlugin;
-pub use crate::target::{OperationOutcome, OperationResult};
+pub use crate::target::OperationOutcome;
 pub use catalog::list_installed_plugins;
 pub use info::{get_plugin_info, PluginInfo, Source};
 pub use lifecycle::{

--- a/src/commands/deploy/sync.rs
+++ b/src/commands/deploy/sync.rs
@@ -2,7 +2,7 @@
 
 use crate::commands::args::SyncScopeArgs;
 use crate::sync::{
-    sync, PlacedComponent, SyncDestination, SyncOptions, SyncResult, SyncSource, SyncableKind,
+    sync, PlacedComponent, SyncDestination, SyncOptions, SyncOutcome, SyncSource, SyncableKind,
 };
 use crate::target::TargetKind;
 use clap::Parser;
@@ -67,7 +67,7 @@ pub async fn run(args: Args) -> Result<(), String> {
 /// * `result` - Outcome returned by the `sync` engine.
 /// * `from_name` - Display name of the source target.
 /// * `to_name` - Display name of the destination target.
-fn print_result(result: &SyncResult, from_name: &str, to_name: &str) {
+fn print_result(result: &SyncOutcome, from_name: &str, to_name: &str) {
     println!("Sync: {} -> {}\n", from_name.cyan(), to_name.cyan());
 
     let total = result.total_count();

--- a/src/commands/lifecycle/update.rs
+++ b/src/commands/lifecycle/update.rs
@@ -2,9 +2,7 @@
 //!
 //! プラグインを最新バージョンに更新する。
 
-use crate::plugin::{
-    update_all_plugins, update_plugin, PackageCache, UpdateOutcome, UpdateResult, UpdateStatus,
-};
+use crate::plugin::{update_all_plugins, update_plugin, PackageCache, UpdateOutcome, UpdateStatus};
 use clap::{Parser, ValueEnum};
 use std::env;
 
@@ -122,7 +120,7 @@ fn display_single_result(result: &UpdateOutcome) {
 /// # Arguments
 ///
 /// * `results` - Update outcomes from a batch run to summarize.
-fn display_batch_results(results: &[UpdateResult]) {
+fn display_batch_results(results: &[UpdateOutcome]) {
     let updated = results
         .iter()
         .filter(|r| matches!(r.status, UpdateStatus::Updated { .. }))

--- a/src/hooks/converter/converter.rs
+++ b/src/hooks/converter/converter.rs
@@ -47,7 +47,7 @@ pub(crate) fn namespace_script_path(path: &str, namespace: &str) -> String {
 
 /// Conversion result containing the transformed JSON, warnings, and script info.
 #[derive(Debug, Clone)]
-pub struct ConvertResult {
+pub struct ConvertOutcome {
     pub json: Value,
     pub warnings: Vec<ConversionWarning>,
     pub scripts: Vec<ScriptInfo>,
@@ -314,7 +314,7 @@ pub(crate) fn generate_matcher_filter(matcher: Option<&str>) -> String {
 ///
 /// * `input` - Raw JSON string containing the Claude Code or target-format hooks.
 /// * `target` - Target environment to convert for.
-pub fn convert(input: &str, target: TargetKind) -> Result<ConvertResult, PlmError> {
+pub fn convert(input: &str, target: TargetKind) -> Result<ConvertOutcome, PlmError> {
     let layers = create_layers(target)?;
 
     let value: Value = serde_json::from_str(input)
@@ -338,7 +338,7 @@ pub fn convert(input: &str, target: TargetKind) -> Result<ConvertResult, PlmErro
     match layers.structure.detect_format(&value) {
         SourceFormat::TargetFormat => {
             let (json, warnings) = layers.structure.handle_target_format(value)?;
-            Ok(ConvertResult {
+            Ok(ConvertOutcome {
                 json,
                 warnings,
                 scripts: vec![],
@@ -361,7 +361,7 @@ pub fn convert(input: &str, target: TargetKind) -> Result<ConvertResult, PlmErro
                 .unwrap()
                 .insert("hooks".to_string(), new_hooks);
 
-            Ok(ConvertResult {
+            Ok(ConvertOutcome {
                 json: result,
                 warnings,
                 scripts,

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -8,8 +8,7 @@ pub use cache::{CachedPackage, LegacyCacheCleaner, PackageCache, PackageCacheAcc
 pub(crate) use content::{load_plugin, Plugin};
 pub use content::{InstalledPlugin, MarketplaceContent};
 pub use lifecycle::{
-    update_all_plugins, update_plugin, PluginAction, PluginIntent, UpdateOutcome, UpdateResult,
-    UpdateStatus,
+    update_all_plugins, update_plugin, PluginAction, PluginIntent, UpdateOutcome, UpdateStatus,
 };
 pub use meta::manifest::{Author, PluginManifest};
 

--- a/src/plugin/lifecycle.rs
+++ b/src/plugin/lifecycle.rs
@@ -5,4 +5,4 @@ mod update;
 
 pub use action::PluginAction;
 pub use intent::PluginIntent;
-pub use update::{update_all_plugins, update_plugin, UpdateOutcome, UpdateResult, UpdateStatus};
+pub use update::{update_all_plugins, update_plugin, UpdateOutcome, UpdateStatus};

--- a/src/plugin/lifecycle/intent.rs
+++ b/src/plugin/lifecycle/intent.rs
@@ -14,7 +14,7 @@ use crate::component::{
 };
 use crate::fs::{FileSystem, RealFs};
 use crate::target::TargetId;
-use crate::target::{all_targets, AffectedTargets, OperationResult, PluginOrigin, Target};
+use crate::target::{all_targets, AffectedTargets, OperationOutcome, PluginOrigin, Target};
 use std::path::{Path, PathBuf};
 
 /// 単一コンポーネントの操作生成結果
@@ -189,7 +189,7 @@ impl PluginIntent {
     }
 
     /// Imperative Shell: 実行（副作用）
-    pub fn apply(self) -> OperationResult {
+    pub fn apply(self) -> OperationOutcome {
         let result = self.expand();
         execute_file_operations(result, &self.project_root)
     }
@@ -201,7 +201,7 @@ impl PluginIntent {
 ///
 /// * `expand_result` - pre-computed operations and validation errors from `expand`
 /// * `_project_root` - project root (currently unused but retained for future scoping needs)
-fn execute_file_operations(expand_result: ExpandResult, _project_root: &Path) -> OperationResult {
+fn execute_file_operations(expand_result: ExpandResult, _project_root: &Path) -> OperationOutcome {
     use crate::path_ext::PathExt;
 
     let fs = RealFs;

--- a/src/plugin/lifecycle/update.rs
+++ b/src/plugin/lifecycle/update.rs
@@ -32,7 +32,7 @@ pub enum UpdateStatus {
 
 /// 更新結果
 #[derive(Debug, Clone)]
-pub struct UpdateResult {
+pub struct UpdateOutcome {
     pub plugin_name: String,
     pub marketplace: String,
     pub status: UpdateStatus,
@@ -43,9 +43,7 @@ pub struct UpdateResult {
     pub failed_targets: Vec<String>,
 }
 
-pub type UpdateOutcome = UpdateResult;
-
-impl UpdateResult {
+impl UpdateOutcome {
     /// 更新成功
     ///
     /// # Arguments
@@ -298,11 +296,11 @@ pub async fn update_plugin(
     marketplace_hint: Option<&str>,
     project_root: &Path,
     target_filter: Option<&str>,
-) -> UpdateResult {
+) -> UpdateOutcome {
     let resolved = match resolve_update_target(cache, plugin_input, marketplace_hint) {
         Ok(r) => r,
         Err(PlmError::AmbiguousPluginName { name, candidates }) => {
-            return UpdateResult::failed(
+            return UpdateOutcome::failed(
                 &name,
                 format!(
                     "Ambiguous plugin name (matches: {}). \
@@ -313,9 +311,9 @@ pub async fn update_plugin(
             );
         }
         Err(PlmError::PluginNotFound(_)) => {
-            return UpdateResult::failed(plugin_input, "Plugin not found in cache".to_string());
+            return UpdateOutcome::failed(plugin_input, "Plugin not found in cache".to_string());
         }
-        Err(e) => return UpdateResult::failed(plugin_input, e.to_string()),
+        Err(e) => return UpdateOutcome::failed(plugin_input, e.to_string()),
     };
 
     if let Some(market) = resolved.marketplace.clone() {
@@ -331,13 +329,13 @@ async fn update_github_plugin(
     resolved: &ResolvedPlugin,
     project_root: &Path,
     target_filter: Option<&str>,
-) -> UpdateResult {
+) -> UpdateOutcome {
     let plugin_meta = &resolved.package_meta;
     let cache_id = resolved.cache_id.as_str();
     let display_name = resolved.display_name.as_str();
 
     if !plugin_meta.is_github() {
-        return UpdateResult::skipped(display_name, "Not a GitHub plugin".to_string());
+        return UpdateOutcome::skipped(display_name, "Not a GitHub plugin".to_string());
     }
 
     let git_ref = plugin_meta.git_ref.as_deref().unwrap_or("HEAD");
@@ -345,7 +343,7 @@ async fn update_github_plugin(
 
     let repo = match restore_repo(plugin_meta, cache_id, git_ref) {
         Ok(r) => r,
-        Err(e) => return UpdateResult::failed(display_name, e),
+        Err(e) => return UpdateOutcome::failed(display_name, e),
     };
 
     let factory = HostClientFactory::with_defaults();
@@ -354,12 +352,12 @@ async fn update_github_plugin(
     let latest_sha = match with_retry(|| client.get_commit_sha(&repo, git_ref), 3).await {
         Ok(sha) => sha,
         Err(e) => {
-            return UpdateResult::failed(display_name, format!("Failed to get latest SHA: {}", e));
+            return UpdateOutcome::failed(display_name, format!("Failed to get latest SHA: {}", e));
         }
     };
 
     if current_sha.as_deref() == Some(&latest_sha) {
-        return UpdateResult::up_to_date(display_name);
+        return UpdateOutcome::up_to_date(display_name);
     }
 
     if current_sha.is_none() {
@@ -391,29 +389,29 @@ async fn update_marketplace_plugin(
     resolved: &ResolvedPlugin,
     project_root: &Path,
     target_filter: Option<&str>,
-) -> UpdateResult {
+) -> UpdateOutcome {
     let display_name = resolved.display_name.as_str();
     let cache_id = resolved.cache_id.as_str();
     let plugin_meta = &resolved.package_meta;
 
     let registry = match MarketplaceRegistry::new() {
         Ok(r) => r,
-        Err(e) => return UpdateResult::failed(display_name, e.to_string()),
+        Err(e) => return UpdateOutcome::failed(display_name, e.to_string()),
     };
     let mp_cache = match registry.get(marketplace) {
         Ok(Some(c)) => c,
         Ok(None) => {
-            return UpdateResult::failed(
+            return UpdateOutcome::failed(
                 display_name,
                 format!("Marketplace not found: {}", marketplace),
             );
         }
-        Err(e) => return UpdateResult::failed(display_name, e.to_string()),
+        Err(e) => return UpdateOutcome::failed(display_name, e.to_string()),
     };
     let entry = match mp_cache.plugins.iter().find(|p| p.name == cache_id) {
         Some(e) => e.clone(),
         None => {
-            return UpdateResult::failed(
+            return UpdateOutcome::failed(
                 display_name,
                 format!("Plugin entry not found in marketplace: {}", cache_id),
             );
@@ -428,7 +426,7 @@ async fn update_marketplace_plugin(
 
     let repo = match parse_repo_from_mp_source(&mp_cache.source, &entry.source, Some(git_ref)) {
         Ok(r) => r,
-        Err(e) => return UpdateResult::failed(display_name, e.to_string()),
+        Err(e) => return UpdateOutcome::failed(display_name, e.to_string()),
     };
 
     let factory = HostClientFactory::with_defaults();
@@ -437,13 +435,13 @@ async fn update_marketplace_plugin(
     let latest_sha = match with_retry(|| client.get_commit_sha(&repo, git_ref), 3).await {
         Ok(sha) => sha,
         Err(e) => {
-            return UpdateResult::failed(display_name, format!("Failed to get latest SHA: {}", e));
+            return UpdateOutcome::failed(display_name, format!("Failed to get latest SHA: {}", e));
         }
     };
 
     let current_sha = plugin_meta.commit_sha.clone();
     if current_sha.as_deref() == Some(&latest_sha) {
-        return UpdateResult::up_to_date(display_name);
+        return UpdateOutcome::up_to_date(display_name);
     }
     if current_sha.is_none() {
         eprintln!(
@@ -488,7 +486,7 @@ async fn do_safe_update(
     source_path: Option<&str>,
     project_root: &Path,
     target_filter: Option<&str>,
-) -> UpdateResult {
+) -> UpdateOutcome {
     let current_sha = old_meta.commit_sha.clone();
     let git_ref_owned = old_meta
         .git_ref
@@ -498,7 +496,7 @@ async fn do_safe_update(
 
     println!("  Creating backup...");
     if let Err(e) = cache.backup(marketplace, cache_id) {
-        return UpdateResult::failed(display_name, format!("Backup failed: {}", e));
+        return UpdateOutcome::failed(display_name, format!("Backup failed: {}", e));
     }
 
     println!("  Downloading...");
@@ -507,7 +505,7 @@ async fn do_safe_update(
             Ok(triple) => triple,
             Err(e) => {
                 let _ = cache.restore(marketplace, cache_id);
-                return UpdateResult::failed(display_name, format!("Download failed: {}", e));
+                return UpdateOutcome::failed(display_name, format!("Download failed: {}", e));
             }
         };
 
@@ -517,7 +515,7 @@ async fn do_safe_update(
             Ok(p) => p,
             Err(e) => {
                 let _ = cache.restore(marketplace, cache_id);
-                return UpdateResult::failed(display_name, format!("Extraction failed: {}", e));
+                return UpdateOutcome::failed(display_name, format!("Extraction failed: {}", e));
             }
         };
 
@@ -537,12 +535,12 @@ async fn do_safe_update(
     }
     if let Err(e) = meta::write_meta(&plugin_path, &new_meta) {
         let _ = cache.restore(marketplace, cache_id);
-        return UpdateResult::failed(display_name, format!("Failed to write metadata: {}", e));
+        return UpdateOutcome::failed(display_name, format!("Failed to write metadata: {}", e));
     }
 
     let _ = cache.remove_backup(marketplace, cache_id);
 
-    UpdateResult::updated(display_name, current_sha, archive_sha, deployed, failed)
+    UpdateOutcome::updated(display_name, current_sha, archive_sha, deployed, failed)
 }
 
 /// ターゲットへの再デプロイ
@@ -596,7 +594,7 @@ pub async fn update_all_plugins(
     cache: &dyn PackageCacheAccess,
     project_root: &Path,
     target_filter: Option<&str>,
-) -> Vec<UpdateResult> {
+) -> Vec<UpdateOutcome> {
     let plugins = match cache.list() {
         Ok(p) => p,
         Err(e) => {
@@ -665,7 +663,7 @@ pub async fn update_all_plugins(
                 match result {
                     RemoteCheck::UpToDate => {
                         up_to_date_count += 1;
-                        results.push(UpdateResult::up_to_date(&display_name));
+                        results.push(UpdateOutcome::up_to_date(&display_name));
                     }
                     RemoteCheck::NeedsUpdate(latest) => {
                         let resolved = ResolvedPlugin {
@@ -706,7 +704,7 @@ pub async fn update_all_plugins(
                 None => {
                     // marketplace から消えたものは up_to_date 扱い
                     up_to_date_count += 1;
-                    results.push(UpdateResult::up_to_date(&display_name));
+                    results.push(UpdateOutcome::up_to_date(&display_name));
                     continue;
                 }
             };
@@ -731,7 +729,7 @@ pub async fn update_all_plugins(
 
             if !needs_update(plugin_meta.commit_sha.as_deref(), &latest_sha) {
                 up_to_date_count += 1;
-                results.push(UpdateResult::up_to_date(&display_name));
+                results.push(UpdateOutcome::up_to_date(&display_name));
                 continue;
             }
 
@@ -751,7 +749,7 @@ pub async fn update_all_plugins(
         match result {
             RemoteCheck::UpToDate => {
                 up_to_date_count += 1;
-                results.push(UpdateResult::up_to_date(&display_name));
+                results.push(UpdateOutcome::up_to_date(&display_name));
             }
             RemoteCheck::NeedsUpdate(latest) => {
                 let resolved = ResolvedPlugin {
@@ -764,7 +762,7 @@ pub async fn update_all_plugins(
                 updates_to_do.push((None, cache_id.clone(), latest, resolved));
             }
             RemoteCheck::Skipped(reason) => {
-                results.push(UpdateResult::skipped(&display_name, reason));
+                results.push(UpdateOutcome::skipped(&display_name, reason));
             }
             RemoteCheck::Failed(msg) => {
                 error_count += 1;

--- a/src/plugin/lifecycle/update_test.rs
+++ b/src/plugin/lifecycle/update_test.rs
@@ -31,7 +31,7 @@ fn test_restore_repo_invalid_name() {
 
 #[test]
 fn test_update_result_factories() {
-    let updated = UpdateResult::updated(
+    let updated = UpdateOutcome::updated(
         "test",
         Some("abc123".to_string()),
         "def456".to_string(),
@@ -40,12 +40,12 @@ fn test_update_result_factories() {
     );
     assert!(matches!(updated.status, UpdateStatus::Updated { .. }));
 
-    let up_to_date = UpdateResult::up_to_date("test");
+    let up_to_date = UpdateOutcome::up_to_date("test");
     assert!(matches!(up_to_date.status, UpdateStatus::AlreadyUpToDate));
 
-    let failed = UpdateResult::failed("test", "error".to_string());
+    let failed = UpdateOutcome::failed("test", "error".to_string());
     assert!(matches!(failed.status, UpdateStatus::Failed));
 
-    let skipped = UpdateResult::skipped("test", "reason".to_string());
+    let skipped = UpdateOutcome::skipped("test", "reason".to_string());
     assert!(matches!(skipped.status, UpdateStatus::Skipped { .. }));
 }

--- a/src/plugin/lifecycle/update_test.rs
+++ b/src/plugin/lifecycle/update_test.rs
@@ -30,7 +30,7 @@ fn test_restore_repo_invalid_name() {
 }
 
 #[test]
-fn test_update_result_factories() {
+fn test_update_outcome_factories() {
     let updated = UpdateOutcome::updated(
         "test",
         Some("abc123".to_string()),

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -27,7 +27,7 @@ mod model;
 pub use crate::fs::{FileSystem, RealFs};
 pub use endpoint::{SyncDestination, SyncSource};
 pub use model::{
-    PlacedComponent, PlacedRef, SyncAction, SyncFailure, SyncOptions, SyncResult, SyncableKind,
+    PlacedComponent, PlacedRef, SyncAction, SyncFailure, SyncOptions, SyncOutcome, SyncableKind,
 };
 
 use crate::component::{convert, ComponentKind};
@@ -38,7 +38,7 @@ use std::collections::HashMap;
 /// 同期を実行
 ///
 /// `dry_run: true` の場合は実際のファイル操作を行わず、
-/// 何が行われるかを `SyncResult` で返す。
+/// 何が行われるかを `SyncOutcome` で返す。
 ///
 /// # Arguments
 ///
@@ -49,7 +49,7 @@ pub fn sync(
     source: &SyncSource,
     dest: &SyncDestination,
     options: &SyncOptions,
-) -> Result<SyncResult> {
+) -> Result<SyncOutcome> {
     sync_with_fs(source, dest, options, &RealFs)
 }
 
@@ -66,7 +66,7 @@ pub(crate) fn sync_with_fs(
     dest: &SyncDestination,
     options: &SyncOptions,
     fs: &dyn FileSystem,
-) -> Result<SyncResult> {
+) -> Result<SyncOutcome> {
     let source_components = collect_components(Endpoint::Source(source), options)?;
     let dest_components = collect_components(Endpoint::Destination(dest), options)?;
 
@@ -109,7 +109,7 @@ pub(crate) fn sync_with_fs(
         .collect();
 
     if options.dry_run {
-        return Ok(SyncResult::dry_run(
+        return Ok(SyncOutcome::dry_run(
             to_create,
             to_update,
             to_delete,
@@ -181,8 +181,8 @@ fn execute_sync(
     dest: &SyncDestination,
     plan: SyncPlan,
     fs: &dyn FileSystem,
-) -> Result<SyncResult> {
-    let mut result = SyncResult::default();
+) -> Result<SyncOutcome> {
+    let mut result = SyncOutcome::default();
 
     for component in plan.to_create {
         match execute_create(source, dest, &component, fs) {

--- a/src/sync/model.rs
+++ b/src/sync/model.rs
@@ -14,4 +14,4 @@ mod result;
 pub use self::action::SyncAction;
 pub use self::options::{SyncOptions, SyncableKind};
 pub use self::placed::{PlacedComponent, PlacedRef};
-pub use self::result::{SyncFailure, SyncResult};
+pub use self::result::{SyncFailure, SyncOutcome};

--- a/src/sync/model/result.rs
+++ b/src/sync/model/result.rs
@@ -5,7 +5,7 @@ use super::placed::PlacedComponent;
 
 /// 同期結果
 #[derive(Debug, Clone, Default)]
-pub struct SyncResult {
+pub struct SyncOutcome {
     /// 作成されたコンポーネント
     pub created: Vec<PlacedComponent>,
     /// 更新されたコンポーネント
@@ -22,7 +22,7 @@ pub struct SyncResult {
     pub dry_run: bool,
 }
 
-impl SyncResult {
+impl SyncOutcome {
     /// dry_run 用の結果を作成
     ///
     /// # Arguments

--- a/src/sync/model/result_test.rs
+++ b/src/sync/model/result_test.rs
@@ -6,7 +6,7 @@ fn make_component(name: &str) -> PlacedComponent {
 }
 
 #[test]
-fn test_sync_result_counts() {
+fn test_sync_outcome_counts() {
     let result = SyncOutcome {
         created: vec![make_component("c1"), make_component("c2")],
         updated: vec![make_component("u1")],
@@ -32,14 +32,14 @@ fn test_sync_result_counts() {
 }
 
 #[test]
-fn test_sync_result_empty() {
+fn test_sync_outcome_empty() {
     let result = SyncOutcome::default();
     assert!(result.is_empty());
     assert!(result.is_success());
 }
 
 #[test]
-fn test_sync_result_dry_run() {
+fn test_sync_outcome_dry_run() {
     let result = SyncOutcome::dry_run(vec![make_component("c1")], vec![], vec![], vec![], vec![]);
 
     assert!(result.dry_run);

--- a/src/sync/model/result_test.rs
+++ b/src/sync/model/result_test.rs
@@ -7,7 +7,7 @@ fn make_component(name: &str) -> PlacedComponent {
 
 #[test]
 fn test_sync_result_counts() {
-    let result = SyncResult {
+    let result = SyncOutcome {
         created: vec![make_component("c1"), make_component("c2")],
         updated: vec![make_component("u1")],
         deleted: vec![make_component("d1")],
@@ -33,14 +33,14 @@ fn test_sync_result_counts() {
 
 #[test]
 fn test_sync_result_empty() {
-    let result = SyncResult::default();
+    let result = SyncOutcome::default();
     assert!(result.is_empty());
     assert!(result.is_success());
 }
 
 #[test]
 fn test_sync_result_dry_run() {
-    let result = SyncResult::dry_run(vec![make_component("c1")], vec![], vec![], vec![], vec![]);
+    let result = SyncOutcome::dry_run(vec![make_component("c1")], vec![], vec![], vec![], vec![]);
 
     assert!(result.dry_run);
     assert_eq!(result.create_count(), 1);

--- a/src/target.rs
+++ b/src/target.rs
@@ -26,7 +26,7 @@ mod placed;
 
 pub(crate) use core::paths;
 pub use core::{AddResult, RemoveResult, TargetId, TargetRegistry};
-pub use effect::{AffectedTargets, OperationOutcome, OperationResult};
+pub use effect::{AffectedTargets, OperationOutcome};
 pub use env::{AntigravityTarget, CodexTarget, CopilotTarget, GeminiCliTarget};
 pub use placed::scanner;
 pub(crate) use placed::{list_all_placed, placed_common};

--- a/src/target/effect.rs
+++ b/src/target/effect.rs
@@ -68,7 +68,7 @@ impl TargetError {
 
 /// 影響を受けたターゲット（値オブジェクト）
 ///
-/// 操作結果を記録し、最終的に OperationResult を生成する。
+/// 操作結果を記録し、最終的に OperationOutcome を生成する。
 #[derive(Debug, Clone, Default)]
 pub struct AffectedTargets {
     effects: Vec<TargetEffect>,
@@ -134,17 +134,17 @@ impl AffectedTargets {
         }
     }
 
-    /// OperationResult を生成（値オブジェクトがファクトリ）
-    pub fn into_result(self) -> OperationResult {
+    /// OperationOutcome を生成（値オブジェクトがファクトリ）
+    pub fn into_result(self) -> OperationOutcome {
         if self.errors.is_empty() {
-            OperationResult {
+            OperationOutcome {
                 success: true,
                 error: None,
                 affected_targets: self,
             }
         } else {
             let error = self.error_message();
-            OperationResult {
+            OperationOutcome {
                 success: false,
                 error,
                 affected_targets: self,
@@ -155,7 +155,7 @@ impl AffectedTargets {
 
 /// 操作結果
 #[derive(Debug, Clone)]
-pub struct OperationResult {
+pub struct OperationOutcome {
     /// 成功したか
     pub success: bool,
     /// エラーメッセージ（失敗時）
@@ -164,9 +164,7 @@ pub struct OperationResult {
     pub affected_targets: AffectedTargets,
 }
 
-pub type OperationOutcome = OperationResult;
-
-impl OperationResult {
+impl OperationOutcome {
     /// エラー結果を生成（事前検証失敗用）
     ///
     /// # Arguments

--- a/src/target/effect_test.rs
+++ b/src/target/effect_test.rs
@@ -54,7 +54,7 @@ fn test_affected_targets_zero_components_not_recorded() {
 
 #[test]
 fn test_operation_result_error() {
-    let result = OperationResult::error("Plugin not found");
+    let result = OperationOutcome::error("Plugin not found");
     assert!(!result.success);
     assert_eq!(result.error, Some("Plugin not found".to_string()));
     assert!(result.affected_targets.target_names().is_empty());

--- a/src/target/effect_test.rs
+++ b/src/target/effect_test.rs
@@ -53,7 +53,7 @@ fn test_affected_targets_zero_components_not_recorded() {
 }
 
 #[test]
-fn test_operation_result_error() {
+fn test_operation_outcome_error() {
     let result = OperationOutcome::error("Plugin not found");
     assert!(!result.success);
     assert_eq!(result.error, Some("Plugin not found".to_string()));

--- a/src/tui/manager/screens/installed/actions.rs
+++ b/src/tui/manager/screens/installed/actions.rs
@@ -20,8 +20,8 @@ pub enum ActionResult {
     Error(String),
 }
 
-impl From<application::OperationResult> for ActionResult {
-    fn from(result: application::OperationResult) -> Self {
+impl From<application::OperationOutcome> for ActionResult {
+    fn from(result: application::OperationOutcome) -> Self {
         if result.success {
             ActionResult::Success
         } else {

--- a/src/tui/manager/screens/marketplaces/actions.rs
+++ b/src/tui/manager/screens/marketplaces/actions.rs
@@ -19,7 +19,7 @@ use crate::tui::output_suppress::OutputSuppressGuard;
 use std::path::Path;
 
 /// マーケットプレイス追加の結果
-pub struct AddResult {
+pub struct MarketplaceAddOutcome {
     pub marketplace: MarketplaceItem,
 }
 
@@ -34,7 +34,7 @@ pub fn add_marketplace(
     source: &str,
     name: &str,
     source_path: Option<&str>,
-) -> Result<AddResult, String> {
+) -> Result<MarketplaceAddOutcome, String> {
     let handle = tokio::runtime::Handle::try_current()
         .map_err(|_| "No Tokio runtime available".to_string())?;
 
@@ -68,7 +68,7 @@ pub fn add_marketplace(
 
     registry.store(&cache).map_err(|e| e.to_string())?;
 
-    Ok(AddResult {
+    Ok(MarketplaceAddOutcome {
         marketplace: MarketplaceItem {
             name: name.to_string(),
             source: to_display_source(&internal_source),

--- a/src/tui/manager/screens/marketplaces/update.rs
+++ b/src/tui/manager/screens/marketplaces/update.rs
@@ -482,7 +482,7 @@ fn execute_add_with(
     entry: &AddEntry<'_>,
     model: &mut Model,
     data: &mut DataStore,
-    run_add: impl FnOnce(&str, &str) -> Result<actions::AddResult, String>,
+    run_add: impl FnOnce(&str, &str) -> Result<actions::MarketplaceAddOutcome, String>,
     reload: impl FnOnce(&mut DataStore),
 ) -> UpdateEffect {
     let source_owned = entry.source.to_string();

--- a/src/tui/manager/screens/marketplaces/update_test.rs
+++ b/src/tui/manager/screens/marketplaces/update_test.rs
@@ -1,6 +1,6 @@
 use super::{execute_add_with, execute_remove_with, execute_update_with, update, AddEntry};
 use crate::tui::manager::core::{DataStore, MarketplaceItem, SelectionState};
-use crate::tui::manager::screens::marketplaces::actions::AddResult;
+use crate::tui::manager::screens::marketplaces::actions::MarketplaceAddOutcome;
 use crate::tui::manager::screens::marketplaces::model::{
     AddFormModel, DetailAction, Model, Msg, OperationStatus,
 };
@@ -28,8 +28,8 @@ fn make_data(names: &[&str]) -> (tempfile::TempDir, DataStore) {
     )
 }
 
-fn make_add_result(name: &str) -> AddResult {
-    AddResult {
+fn make_add_result(name: &str) -> MarketplaceAddOutcome {
+    MarketplaceAddOutcome {
         marketplace: make_marketplace(name),
     }
 }

--- a/src/tui/manager/screens/marketplaces/update_test.rs
+++ b/src/tui/manager/screens/marketplaces/update_test.rs
@@ -28,7 +28,7 @@ fn make_data(names: &[&str]) -> (tempfile::TempDir, DataStore) {
     )
 }
 
-fn make_add_result(name: &str) -> MarketplaceAddOutcome {
+fn make_add_outcome(name: &str) -> MarketplaceAddOutcome {
     MarketplaceAddOutcome {
         marketplace: make_marketplace(name),
     }
@@ -1565,7 +1565,7 @@ fn execute_add_success_transitions_to_market_list() {
         &entry,
         &mut model,
         &mut data,
-        |_source, name| Ok(make_add_result(name)),
+        |_source, name| Ok(make_add_outcome(name)),
         |d| {
             d.marketplaces.push(make_marketplace("my-repo"));
         },


### PR DESCRIPTION
## 概要

ドメイン処理結果型 4 個 (`SyncResult` / `ConvertResult` / `OperationResult` / `UpdateResult`) と tui の `AddResult` (struct) を `*Outcome` 接尾辞へ一括リネームし、`Result` 接尾辞を `std::result::Result<T, E>` および `crate::error::Result<T>` 専用に整理しました。`OperationOutcome` / `UpdateOutcome` の type alias も削除し、二重露出を解消しています。

リネーム = 振る舞い不変が原則で、テスト件数は baseline / 完了時とも 1635 passed で完全一致しています。

## 変更の種類

- ♻️ Refactoring (リネーム)
- 📝 Doc (命名方針の明文化)

## 詳細な変更内容

### ドキュメント (新規 / 追記)
- `CLAUDE.md`: 「Rust コーディング規約」に「型名の接尾辞 (Result / Outcome の使い分け)」サブセクションを追加
- `docs/architecture/naming-conventions.md` (新規): Result / Outcome 規約の詳細解説、適用範囲、適用継続検討対象 (`target::AddResult` enum、横断度低の他 12 型) を整理

### Rust コード (リネーム)
- **SyncResult → SyncOutcome**: `src/sync/model/result.rs`, `src/sync/model.rs`, `src/sync.rs`, `src/commands/deploy/sync.rs`, `src/sync/model/result_test.rs`
- **ConvertResult → ConvertOutcome**: `src/hooks/converter/converter.rs`
- **OperationResult → OperationOutcome (alias 削除)**: `src/target/effect.rs`, `src/target.rs`, `src/application.rs`, `src/plugin/lifecycle/intent.rs`, `src/tui/manager/screens/installed/actions.rs`, `src/target/effect_test.rs`
  - `pub type OperationOutcome = OperationResult;` を削除
  - `From<application::OperationOutcome> for ActionResult` を更新
  - `AffectedTargets::into_result(self) -> OperationOutcome` の戻り値型を更新 (メソッド名 `into_result` は維持)
- **UpdateResult → UpdateOutcome (alias 削除)**: `src/plugin/lifecycle/update.rs`, `src/plugin/lifecycle.rs`, `src/plugin.rs`, `src/commands/lifecycle/update.rs`, `src/plugin/lifecycle/update_test.rs`
  - `pub type UpdateOutcome = UpdateResult;` を削除
  - ファクトリ呼び出し (`updated` / `up_to_date` / `failed` / `skipped`) を全件追従
- **tui::AddResult → MarketplaceAddOutcome**: `src/tui/manager/screens/marketplaces/actions.rs`, `src/tui/manager/screens/marketplaces/update.rs`, `src/tui/manager/screens/marketplaces/update_test.rs`
  - `target::AddResult` (enum) との同名衝突を解消 (target 側は触らない)

### コミット粒度 (Phase 別)
| # | コミット | 内容 |
|---|---|---|
| 1 | `472f9e5` :memo: [Docs] | Result/Outcome 命名方針の明文化 |
| 2 | `5926ba0` :recycle: | SyncResult → SyncOutcome |
| 3 | `8c2c415` :recycle: | ConvertResult → ConvertOutcome |
| 4 | `ef7ce05` :recycle: | OperationResult → OperationOutcome + alias 削除 |
| 5 | `054b596` :recycle: | UpdateResult → UpdateOutcome + alias 削除 |
| 6 | `ee22b28` :recycle: | tui AddResult → MarketplaceAddOutcome |

各コミットは単独で `cargo check` / `cargo test` が通る状態。

## システム図

```
   定義モジュール                          利用モジュール
   ──────────────                          ────────────────
   src/sync/model/result.rs                ┌─ src/sync.rs (re-export)
       SyncResult ─► SyncOutcome ────────┤
                                           └─ src/commands/deploy/sync.rs

   src/hooks/converter/converter.rs        ┌─ src/component/deployment/hook_deploy.rs
       ConvertResult ─► ConvertOutcome ──┤  (型推論経由で間接消費)

   src/target/effect.rs                    ┌─ src/target.rs (re-export)
       OperationResult ─► OperationOutcome ┤
       (type alias 削除)                   ├─ src/application.rs (re-export)
                                           ├─ src/plugin/lifecycle/intent.rs
                                           └─ src/tui/manager/screens/installed/actions.rs

   src/plugin/lifecycle/update.rs          ┌─ src/plugin/lifecycle.rs (re-export)
       UpdateResult ─► UpdateOutcome ─────┤
       (type alias 削除)                   ├─ src/plugin.rs (re-export)
                                           └─ src/commands/lifecycle/update.rs

   src/tui/manager/screens/marketplaces/actions.rs
       AddResult (struct) ─► MarketplaceAddOutcome
                                           └─ src/tui/manager/screens/marketplaces/update*.rs

   ※ target::AddResult (enum) は触らない (別 Issue)
```

## 命名方針

| 接尾辞 | 用途 |
|---|---|
| `Result` | `std::result::Result<T, E>` および `crate::error::Result<T>` 専用 |
| `Outcome` | ドメイン処理の成果レポート (Ok/Err を内包しない値オブジェクト) |
| `Status` / `Kind` / `Failure` | enum や付随する区分・失敗詳細 (従来通り) |

## 関連Issue

Closes #271
Refs #259, #259-A, #259-B, #259-C

## テスト

- [x] `cargo fmt` 適用済み
- [x] `cargo check` エラー 0 件
- [x] `cargo test` 全件パス (1635 passed / 0 failed / 0 ignored)
- [x] **テスト件数の不変確認**: リネーム前 1635 → リネーム後 1635 (完全一致)

### DoD grep 確認 (すべて 0 ヒット)
```bash
rg 'pub (struct|enum|type) (Sync|Convert|Operation|Update)Result\b' src/      # 0
rg 'pub type (Operation|Update)Outcome' src/                                  # 0
rg 'pub struct AddResult' src/tui/manager/screens/marketplaces/               # 0
rg '\b(SyncResult|ConvertResult|OperationResult|UpdateResult)\b' src/         # 0
rg '\bAddResult\b' src/tui/manager/screens/marketplaces/                      # 0
rg '\b(SyncResult|ConvertResult|OperationResult|UpdateResult)\b' docs/architecture/ CLAUDE.md  # 0
```

### 残存維持の確認 (ヒット OK)
```bash
rg '\bAddResult\b' src/target/      # target::AddResult enum (別 Issue)
rg '\bcrate::error::Result\b' src/  # エラー型は維持
```

### Codex レビュー
- review-001: hooks-conversion.md の ConvertResult 残存を指摘 → 修正
- review-002: **問題なし** (`cargo fmt --check` / `cargo check` / `cargo test 1635 passed` 確認)

## レビューポイント

1. **type alias 削除の影響範囲**: `pub type OperationOutcome = OperationResult;` および `pub type UpdateOutcome = UpdateResult;` を削除し、本体名を Outcome に一本化しました。`pub use` パスは `OperationOutcome` / `UpdateOutcome` で従来同様にアクセス可能です
2. **target::AddResult との衝突解消**: tui 側 (struct) のみ `MarketplaceAddOutcome` にリネームし、target 側 (enum) は別 Issue 対象として保持しています。誤置換が起きていないか確認してください (`src/target/` には `AddResult` がそのまま残ります)
3. **`AffectedTargets::into_result`**: メソッド名 `into_result` はリネーム規約 (型名のみ対象) に従い維持しています。戻り値型のみ `OperationOutcome` に変更
4. **振る舞い不変原則**: テスト件数の baseline 1635 完全一致が回帰の最終判定です。Serde derive を持つ型は対象 4 型に含まれず、JSON 出力スキーマへの影響はありません

## 残課題 (別 Issue)

- `target::AddResult` (enum) のリネーム検討
- 横断度の低い 12 型 (`PlaceResult` / `ConversionResult` / `MultiSelectResult` 等) の本方針適用判断