### PR TITLE
♻️ [Refactoring]: split src/commands/args.rs into per-purpose submodules and add MarketplaceArgs

### DIFF
--- a/src/commands/args.rs
+++ b/src/commands/args.rs
@@ -3,10 +3,13 @@
 //! 用途別にサブモジュールへ分割し、本ファイルは再エクスポートのみを行う。
 //! 旧パス `crate::commands::args::{ListOutputArgs, ...}` は `pub use` 経由で維持する。
 
+mod marketplace;
 mod output;
 mod scope;
 mod target;
 
+#[allow(unused_imports)]
+pub use marketplace::MarketplaceArgs;
 pub use output::ListOutputArgs;
 pub use scope::{InteractiveScopeArgs, SyncScopeArgs};
 pub use target::{MultiTargetArgs, SingleTargetArgs};

--- a/src/commands/args.rs
+++ b/src/commands/args.rs
@@ -1,53 +1,12 @@
 //! サブコマンド間で共有するCLI引数部品。
+//!
+//! 用途別にサブモジュールへ分割し、本ファイルは再エクスポートのみを行う。
+//! 旧パス `crate::commands::args::{ListOutputArgs, ...}` は `pub use` 経由で維持する。
 
-use crate::target::{Scope, TargetKind};
-use clap::Args as ClapArgs;
+mod output;
+mod scope;
+mod target;
 
-#[derive(Debug, Clone, ClapArgs)]
-pub struct ListOutputArgs {
-    /// Output in JSON format
-    #[arg(long, conflicts_with = "simple")]
-    pub json: bool,
-
-    /// Output only plugin names
-    #[arg(long, conflicts_with = "json")]
-    pub simple: bool,
-
-    /// Show only plugins with available updates. Note: --json includes all plugins with update info.
-    #[arg(long, conflicts_with = "simple")]
-    pub outdated: bool,
-}
-
-#[derive(Debug, Clone, ClapArgs)]
-pub struct SingleTargetArgs {
-    /// Filter by target environment (currently filters by enabled status)
-    #[arg(long, value_enum)]
-    pub target: Option<TargetKind>,
-}
-
-#[derive(Debug, Clone, ClapArgs)]
-pub struct MultiTargetArgs {
-    /// Target environments to deploy to (if not specified, TUI selection)
-    #[arg(long, value_enum)]
-    pub target: Option<Vec<TargetKind>>,
-}
-
-#[derive(Debug, Clone, ClapArgs)]
-pub struct InteractiveScopeArgs {
-    #[arg(
-        long,
-        value_enum,
-        help = "Deployment scope (if not specified, TUI selection)"
-    )]
-    pub scope: Option<Scope>,
-}
-
-#[derive(Debug, Clone, ClapArgs)]
-pub struct SyncScopeArgs {
-    #[arg(
-        long,
-        value_enum,
-        help = "Scope to sync (if not specified, both personal and project)"
-    )]
-    pub scope: Option<Scope>,
-}
+pub use output::ListOutputArgs;
+pub use scope::{InteractiveScopeArgs, SyncScopeArgs};
+pub use target::{MultiTargetArgs, SingleTargetArgs};

--- a/src/commands/args/marketplace.rs
+++ b/src/commands/args/marketplace.rs
@@ -1,0 +1,22 @@
+//! `--marketplace` オプション用の共通 Args 部品。
+
+use clap::Args as ClapArgs;
+
+#[derive(Debug, Clone, ClapArgs)]
+pub struct MarketplaceArgs {
+    /// Marketplace identifier (defaults to "github" if omitted)
+    #[arg(long, short = 'm')]
+    pub marketplace: Option<String>,
+}
+
+impl MarketplaceArgs {
+    /// run 側で使うフォールバック付きアクセッサ。
+    /// 既存 enable/disable の `default_value = "github"` 互換を保つために提供する。
+    pub fn marketplace_or_default(&self) -> &str {
+        self.marketplace.as_deref().unwrap_or("github")
+    }
+}
+
+#[cfg(test)]
+#[path = "marketplace_test.rs"]
+mod tests;

--- a/src/commands/args/marketplace_test.rs
+++ b/src/commands/args/marketplace_test.rs
@@ -1,0 +1,15 @@
+use super::MarketplaceArgs;
+
+#[test]
+fn marketplace_or_default_returns_github_when_none() {
+    let args = MarketplaceArgs { marketplace: None };
+    assert_eq!(args.marketplace_or_default(), "github");
+}
+
+#[test]
+fn marketplace_or_default_returns_value_when_some() {
+    let args = MarketplaceArgs {
+        marketplace: Some("custom".into()),
+    };
+    assert_eq!(args.marketplace_or_default(), "custom");
+}

--- a/src/commands/args/output.rs
+++ b/src/commands/args/output.rs
@@ -1,0 +1,18 @@
+//! サブコマンド間で共有するCLI引数部品。
+
+use clap::Args as ClapArgs;
+
+#[derive(Debug, Clone, ClapArgs)]
+pub struct ListOutputArgs {
+    /// Output in JSON format
+    #[arg(long, conflicts_with = "simple")]
+    pub json: bool,
+
+    /// Output only plugin names
+    #[arg(long, conflicts_with = "json")]
+    pub simple: bool,
+
+    /// Show only plugins with available updates. Note: --json includes all plugins with update info.
+    #[arg(long, conflicts_with = "simple")]
+    pub outdated: bool,
+}

--- a/src/commands/args/scope.rs
+++ b/src/commands/args/scope.rs
@@ -1,0 +1,24 @@
+//! `--scope` オプション用の共通 Args 部品。
+
+use crate::target::Scope;
+use clap::Args as ClapArgs;
+
+#[derive(Debug, Clone, ClapArgs)]
+pub struct InteractiveScopeArgs {
+    #[arg(
+        long,
+        value_enum,
+        help = "Deployment scope (if not specified, TUI selection)"
+    )]
+    pub scope: Option<Scope>,
+}
+
+#[derive(Debug, Clone, ClapArgs)]
+pub struct SyncScopeArgs {
+    #[arg(
+        long,
+        value_enum,
+        help = "Scope to sync (if not specified, both personal and project)"
+    )]
+    pub scope: Option<Scope>,
+}

--- a/src/commands/args/target.rs
+++ b/src/commands/args/target.rs
@@ -1,0 +1,18 @@
+//! `--target` オプション用の共通 Args 部品。
+
+use crate::target::TargetKind;
+use clap::Args as ClapArgs;
+
+#[derive(Debug, Clone, ClapArgs)]
+pub struct SingleTargetArgs {
+    /// Filter by target environment (currently filters by enabled status)
+    #[arg(long, value_enum)]
+    pub target: Option<TargetKind>,
+}
+
+#[derive(Debug, Clone, ClapArgs)]
+pub struct MultiTargetArgs {
+    /// Target environments to deploy to (if not specified, TUI selection)
+    #[arg(long, value_enum)]
+    pub target: Option<Vec<TargetKind>>,
+}


### PR DESCRIPTION
## 概要

Spec #029 / Issue #267 の **Phase A（設計フェーズ）** を実装。`src/commands/args.rs` に集約されていた既存 5 型を用途別サブモジュールに分割し、新規 `MarketplaceArgs` 部品を型定義のみ追加する。**振る舞い不変**（`--help` 出力差分なし、既存テスト 19 件を含む全 1637 件パス）。各サブコマンドへの `#[command(flatten)]` 適用は Phase B (#268 系) で実施する。

## 変更の種類

- ♻️ Refactoring（既存 5 型のサブモジュール化）
- ✨ New Feature（`MarketplaceArgs` 型の追加 / Phase A 時点では未利用）

## 追加した内容

- `src/commands/args/output.rs` — `ListOutputArgs`（既存型を doc コメントごと移設）
- `src/commands/args/target.rs` — `SingleTargetArgs` / `MultiTargetArgs`（既存型を移設）
- `src/commands/args/scope.rs` — `InteractiveScopeArgs` / `SyncScopeArgs`（既存型を `help = ...` 文字列ごと移設）
- `src/commands/args/marketplace.rs` — **新規** `MarketplaceArgs` + `marketplace_or_default()`
- `src/commands/args/marketplace_test.rs` — `marketplace_or_default()` のフォールバック挙動テスト 2 件

## 変更した内容

- `src/commands/args.rs` を `mod` 宣言 + `pub use` のみに縮退（53 行 → 15 行）
  - 旧パス `crate::commands::args::{ListOutputArgs, SingleTargetArgs, MultiTargetArgs, InteractiveScopeArgs, SyncScopeArgs}` は `pub use` 経由で完全互換維持
  - `MarketplaceArgs` は Phase A 時点で利用先がないため `#[allow(unused_imports)]` を付与（Phase B で flatten 適用される予定）

## システム図

### Before / After のモジュール配置

```
Before:
src/commands/
└── args.rs   (5 型の本体定義 + use 文)

After:
src/commands/
├── args.rs   (mod 宣言 + pub use のみ)
└── args/
    ├── output.rs       [MOVE]   ListOutputArgs
    ├── target.rs       [MOVE]   SingleTargetArgs / MultiTargetArgs
    ├── scope.rs        [MOVE]   InteractiveScopeArgs / SyncScopeArgs
    ├── marketplace.rs  [NEW]    MarketplaceArgs
    └── marketplace_test.rs [NEW] フォールバックテスト 2 件
```

### 旧パスの再エクスポート経路（flowchart）

```mermaid
flowchart LR
    subgraph caller["呼び出し側 (変更なし)"]
        L[list.rs]
        I[install.rs]
        IM[import.rs]
        S[sync.rs]
    end

    L -->|use crate::commands::args::ListOutputArgs| ARGS
    I -->|use crate::commands::args::*| ARGS
    IM -->|use crate::commands::args::*| ARGS
    S -->|use crate::commands::args::*| ARGS

    subgraph args["src/commands/args.rs (mod + pub use only)"]
        ARGS{{pub use 再エクスポート}}
    end

    ARGS --> O[args/output.rs]
    ARGS --> T[args/target.rs]
    ARGS --> SC[args/scope.rs]
    ARGS -.Phase A 未使用.-> M[args/marketplace.rs]

    style M fill:#fff7cd,stroke:#c8aa00
    style ARGS fill:#e0f7e9,stroke:#2e8b57
```

## 関連 Spec / Issue

- Spec: `.plugin-workspace/.specs/029-common-cli-args-design/`
- Refs #267（Parent: #257、Epic: #254）
- Phase B 適用予定: #268 系

## 検証

サブエージェント経由で以下を実行（CLAUDE.md / MEMORY.md 規約準拠）:

- `cargo fmt`（Bash サブエージェント）→ クリーン
- `cargo check`（rust-workflow-plugin:type-check）→ エラー 0、新規警告 0（`MarketplaceArgs` 未使用警告は `#[allow(unused_imports)]` で抑制）
- `cargo test`（rust-workflow-plugin:test）→ **1637 passed / 0 failed**
  - うち `cli::tests` 19 ケース全パス（`--help` 出力 / `conflicts_with` メッセージの regression なし）
  - 新規 `commands::args::marketplace::tests` 2 ケースパス

## レビューポイント

- **公開 API の互換性**: `pub use` 経由で旧パスが完全に維持されており、`list.rs` / `install.rs` / `import.rs` / `sync.rs` / `list_test.rs` 等の呼び出し側は無変更。差分は `cargo check` 通過で確認済み。
- **`MarketplaceArgs` の未使用扱い**: Phase A 時点では flatten 適用箇所がないため `#[allow(unused_imports)]` で抑制。Phase B (#268 系) で `enable` / `disable` / `uninstall` に flatten した時点で抑制が不要になるため、その PR で削除する想定。
- **doc コメント / `help = ...` 文字列の保持**: `--help` 出力差分が出ないよう一字一句保って移設している（凍結対象は implementation-plan §「互換性 / regression 防止戦略」参照）。
- **`marketplace_or_default()` の追加根拠**: 既存 `enable` / `disable` の `default_value = "github"` 互換を Phase B で run 側フォールバックに置き換えるための準備。Phase A では型定義のみで未利用。

## チェックリスト

- [x] `cargo fmt` をサブエージェント経由で実行した
- [x] `cargo check` を rust-workflow-plugin:type-check で実行しグリーン
- [x] `cargo test` を rust-workflow-plugin:test で実行しグリーン（1637 passed）
- [x] 公開 API への破壊的変更なし（旧パス `pub use` で互換維持）
- [x] セルフレビュー実施
- [x] 関連 Spec / Issue を本文にリンク
- [x] 振る舞い不変を検証（cli::tests 19 ケース pass、`--help` 出力差分なし）