### PR TITLE
♻️ [Refactoring]: #268 enable/disable/uninstall に MarketplaceArgs を flatten 適用

### DIFF
--- a/src/commands/args.rs
+++ b/src/commands/args.rs
@@ -8,7 +8,6 @@ mod output;
 mod scope;
 mod target;
 
-#[allow(unused_imports)]
 pub use marketplace::MarketplaceArgs;
 pub use output::ListOutputArgs;
 pub use scope::{InteractiveScopeArgs, SyncScopeArgs};

--- a/src/commands/lifecycle/disable.rs
+++ b/src/commands/lifecycle/disable.rs
@@ -4,6 +4,7 @@
 //! `.plm-meta.json` の `statusByTarget` を更新する。
 
 use crate::application::{disable_plugin, OperationOutcome};
+use crate::commands::args::MarketplaceArgs;
 use crate::plugin::{meta, PackageCache, PackageCacheAccess};
 use clap::{Parser, ValueEnum};
 use std::env;
@@ -32,9 +33,8 @@ pub struct Args {
     #[arg(long, value_enum)]
     pub target: Option<TargetKind>,
 
-    /// Marketplace name (default: github)
-    #[arg(long, short = 'm', default_value = "github")]
-    pub marketplace: String,
+    #[command(flatten)]
+    pub marketplace: MarketplaceArgs,
 }
 
 /// # Arguments
@@ -42,12 +42,13 @@ pub struct Args {
 /// * `args` - Parsed CLI arguments for `plm disable`.
 pub async fn run(args: Args) -> Result<(), String> {
     let cache = PackageCache::new().map_err(|e| format!("Failed to access cache: {}", e))?;
+    let marketplace = args.marketplace.marketplace_or_default();
 
     // Cache is required to identify components to remove from the manifest.
-    if !cache.is_cached(Some(&args.marketplace), &args.name) {
+    if !cache.is_cached(Some(marketplace), &args.name) {
         return Err(format!(
             "Error: Plugin '{}' not found in cache (marketplace: {})\nHint: Cache is required to identify components to remove.",
-            args.name, args.marketplace
+            args.name, marketplace
         ));
     }
 
@@ -57,12 +58,12 @@ pub async fn run(args: Args) -> Result<(), String> {
     let result = disable_plugin(
         &cache,
         &args.name,
-        Some(&args.marketplace),
+        Some(marketplace),
         &project_root,
         target_filter,
     );
 
-    let plugin_path = cache.plugin_path(Some(&args.marketplace), &args.name);
+    let plugin_path = cache.plugin_path(Some(marketplace), &args.name);
     update_status_after_disable(&plugin_path, &result);
 
     if result.success {

--- a/src/commands/lifecycle/enable.rs
+++ b/src/commands/lifecycle/enable.rs
@@ -4,6 +4,7 @@
 //! `.plm-meta.json` の `statusByTarget` を更新する。
 
 use crate::application::{enable_plugin, OperationOutcome};
+use crate::commands::args::MarketplaceArgs;
 use crate::plugin::{meta, PackageCache, PackageCacheAccess};
 use clap::{Parser, ValueEnum};
 use std::env;
@@ -32,9 +33,8 @@ pub struct Args {
     #[arg(long, value_enum)]
     pub target: Option<TargetKind>,
 
-    /// Marketplace name (default: github)
-    #[arg(long, short = 'm', default_value = "github")]
-    pub marketplace: String,
+    #[command(flatten)]
+    pub marketplace: MarketplaceArgs,
 }
 
 /// # Arguments
@@ -42,11 +42,12 @@ pub struct Args {
 /// * `args` - Parsed CLI arguments for `plm enable`.
 pub async fn run(args: Args) -> Result<(), String> {
     let cache = PackageCache::new().map_err(|e| format!("Failed to access cache: {}", e))?;
+    let marketplace = args.marketplace.marketplace_or_default();
 
-    if !cache.is_cached(Some(&args.marketplace), &args.name) {
+    if !cache.is_cached(Some(marketplace), &args.name) {
         return Err(format!(
             "Error: Plugin '{}' not found in cache (marketplace: {})",
-            args.name, args.marketplace
+            args.name, marketplace
         ));
     }
 
@@ -56,12 +57,12 @@ pub async fn run(args: Args) -> Result<(), String> {
     let result = enable_plugin(
         &cache,
         &args.name,
-        Some(&args.marketplace),
+        Some(marketplace),
         &project_root,
         target_filter,
     );
 
-    let plugin_path = cache.plugin_path(Some(&args.marketplace), &args.name);
+    let plugin_path = cache.plugin_path(Some(marketplace), &args.name);
     update_status_after_enable(&plugin_path, &result);
 
     if result.success {

--- a/src/commands/lifecycle/uninstall.rs
+++ b/src/commands/lifecycle/uninstall.rs
@@ -26,12 +26,9 @@ pub async fn run(args: Args) -> Result<(), String> {
     let cache = PackageCache::new().map_err(|e| format!("Failed to access cache: {}", e))?;
     let project_root =
         env::current_dir().map_err(|e| format!("Failed to get current dir: {}", e))?;
+    let marketplace = args.marketplace.marketplace.as_deref();
 
-    let info = application::get_uninstall_info(
-        &cache,
-        &args.name,
-        args.marketplace.marketplace.as_deref(),
-    )?;
+    let info = application::get_uninstall_info(&cache, &args.name, marketplace)?;
 
     display_uninstall_info(&info);
 
@@ -40,12 +37,7 @@ pub async fn run(args: Args) -> Result<(), String> {
         return Ok(());
     }
 
-    let result = application::uninstall_plugin(
-        &cache,
-        &args.name,
-        args.marketplace.marketplace.as_deref(),
-        &project_root,
-    );
+    let result = application::uninstall_plugin(&cache, &args.name, marketplace, &project_root);
 
     if result.success {
         println!(

--- a/src/commands/lifecycle/uninstall.rs
+++ b/src/commands/lifecycle/uninstall.rs
@@ -1,4 +1,5 @@
 use crate::application::{self, UninstallInfo};
+use crate::commands::args::MarketplaceArgs;
 use crate::plugin::PackageCache;
 use clap::Parser;
 use owo_colors::OwoColorize;
@@ -10,9 +11,8 @@ pub struct Args {
     /// プラグイン名（キャッシュディレクトリ名、例: "DIO0550--cc-plugin"）
     pub name: String,
 
-    /// マーケットプレイス（未指定なら "github"）
-    #[arg(long, short = 'm')]
-    pub marketplace: Option<String>,
+    #[command(flatten)]
+    pub marketplace: MarketplaceArgs,
 
     /// 確認プロンプトをスキップ
     #[arg(long, short = 'f')]
@@ -27,7 +27,11 @@ pub async fn run(args: Args) -> Result<(), String> {
     let project_root =
         env::current_dir().map_err(|e| format!("Failed to get current dir: {}", e))?;
 
-    let info = application::get_uninstall_info(&cache, &args.name, args.marketplace.as_deref())?;
+    let info = application::get_uninstall_info(
+        &cache,
+        &args.name,
+        args.marketplace.marketplace.as_deref(),
+    )?;
 
     display_uninstall_info(&info);
 
@@ -39,7 +43,7 @@ pub async fn run(args: Args) -> Result<(), String> {
     let result = application::uninstall_plugin(
         &cache,
         &args.name,
-        args.marketplace.as_deref(),
+        args.marketplace.marketplace.as_deref(),
         &project_root,
     );
 

--- a/src/commands/lifecycle/uninstall_test.rs
+++ b/src/commands/lifecycle/uninstall_test.rs
@@ -5,7 +5,7 @@ use clap::Parser;
 fn test_args_parsing_defaults() {
     let args = Args::parse_from(["uninstall", "my-plugin"]);
     assert_eq!(args.name, "my-plugin");
-    assert_eq!(args.marketplace, None);
+    assert_eq!(args.marketplace.marketplace, None);
     assert!(!args.force);
 }
 
@@ -13,7 +13,7 @@ fn test_args_parsing_defaults() {
 fn test_args_parsing_with_marketplace() {
     let args = Args::parse_from(["uninstall", "my-plugin", "--marketplace", "custom"]);
     assert_eq!(args.name, "my-plugin");
-    assert_eq!(args.marketplace, Some("custom".to_string()));
+    assert_eq!(args.marketplace.marketplace, Some("custom".to_string()));
     assert!(!args.force);
 }
 
@@ -28,7 +28,7 @@ fn test_args_parsing_with_force() {
 fn test_args_parsing_with_short_options() {
     let args = Args::parse_from(["uninstall", "my-plugin", "-m", "custom", "-f"]);
     assert_eq!(args.name, "my-plugin");
-    assert_eq!(args.marketplace, Some("custom".to_string()));
+    assert_eq!(args.marketplace.marketplace, Some("custom".to_string()));
     assert!(args.force);
 }
 
@@ -42,6 +42,6 @@ fn test_args_parsing_with_all_options() {
         "--force",
     ]);
     assert_eq!(args.name, "my-plugin");
-    assert_eq!(args.marketplace, Some("custom".to_string()));
+    assert_eq!(args.marketplace.marketplace, Some("custom".to_string()));
     assert!(args.force);
 }


### PR DESCRIPTION
## 概要

`#267` で導入した共通 Args 部品 `MarketplaceArgs` を、`enable` / `disable` / `uninstall` の 3 サブコマンドに `#[command(flatten)]` で適用する。これにより親 Issue `#257` の DoD「共通 Args 部品が定義され、3 つ以上のサブコマンドで再利用されている」を達成する。

## 変更の種類

- ♻️ Refactoring

## 詳細な変更内容

### `src/commands/args.rs`
- `MarketplaceArgs` 再エクスポートから `#[allow(unused_imports)]` を削除（実利用が始まったため）

### `src/commands/lifecycle/enable.rs`
- `pub marketplace: String` + `default_value = "github"` → `#[command(flatten)] pub marketplace: MarketplaceArgs`
- `run()` 内 4 箇所のアクセスを `let marketplace = args.marketplace.marketplace_or_default();` のローカル束縛経由に統一
- デフォルト適用ロジックは clap の属性ではなく `MarketplaceArgs::marketplace_or_default()` 側に集約

### `src/commands/lifecycle/disable.rs`
- enable と同型の置換（属性 → flatten、`default_value` → `marketplace_or_default()`）

### `src/commands/lifecycle/uninstall.rs`
- `pub marketplace: Option<String>` → `#[command(flatten)] pub marketplace: MarketplaceArgs`
- enable/disable と異なり、application 層への引き渡しは従来通り `Option<&str>`（`args.marketplace.marketplace.as_deref()`）を維持。フォールバック責務は application 層に残し、本案件のスコープは型統一のみとする

### `src/commands/lifecycle/uninstall_test.rs`
- `args.marketplace` の比較を `args.marketplace.marketplace` に更新（4 箇所）

## システム図

```mermaid
flowchart LR
    A["plm enable / disable / uninstall<br/>(CLI input)"] --> B["clap parse<br/>(derive Args)"]
    B --> C["Args { marketplace: MarketplaceArgs, ... }<br/>[NEW: flatten 化]"]
    C --> D{"サブコマンド種別"}
    D -- enable / disable --> E["marketplace_or_default()<br/>→ Some(&str)<br/>(default: github)"]
    D -- uninstall --> F["args.marketplace.marketplace.as_deref()<br/>→ Option<&str>"]
    E --> G["application::{enable,disable}_plugin"]
    F --> H["application::{get_uninstall_info,uninstall_plugin}<br/>(application 層が None を github に解決)"]

    style C fill:#e8f5e9,stroke:#388e3c
    style E fill:#fff3e0,stroke:#f57c00
    style F fill:#fff3e0,stroke:#f57c00
```

## 関連Issue

- Refs #268
- Refs #257（親 Issue: 共通 Args 部品の再利用 DoD）
- Refs #254（親 Epic）

## テスト

- [x] `cargo fmt`（Task 経由）: 通過
- [x] `cargo check`（`rust-workflow-plugin:type-check`）: エラーなし（既存 `assert_cmd` deprecation 警告 22 件は本変更と無関係）
- [x] `cargo test`（`rust-workflow-plugin:test`）: 1637 passed / 0 failed
- [x] Codex 一括レビュー: 「問題なし」
- [ ] 手動 CLI 検証（`enable/disable/uninstall --help` および `--marketplace custom` / `-m custom` / 省略時 default github）— マージ前に実施予定

## レビューポイント

1. **enable/disable と uninstall でデフォルト適用層が異なる点** — enable/disable は command 層で `marketplace_or_default()` を呼んで `Some("github")` を渡し、uninstall は `Option<&str>` を維持して application 層のフォールバックに委譲しています。本 PR では既存挙動互換を優先し、デフォルト集約の完全統一は将来の application 層リファクタに切り出す方針です（implementation-plan §5.2 / §10.4）。
2. **`#[allow(unused_imports)]` 削除タイミング** — `MarketplaceArgs` の初回利用と同じ PR で削除しています。
3. **`uninstall_test.rs` のアクセスパス書き換え 4 箇所** — `args.marketplace` → `args.marketplace.marketplace` の機械的置換が網羅されているか確認をお願いします。
4. **CLI ヘルプ表示** — `[default: github]` が消える代わりに `MarketplaceArgs` 側の doc コメントが表示される変更があります（観測可能な唯一の差分）。