### PR TITLE
🔖 [Release]: bump version to 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1648,7 +1648,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plm"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "assert_cmd",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plm"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license = "MIT"
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -19,10 +19,53 @@ AIコーディングアシスタント（OpenAI Codex、VSCode Copilot、Google 
 
 ## インストール
 
+### インストールスクリプト（Linux / macOS）
+
+最も簡単な方法は、[GitHub Releases](https://github.com/DIO0550/plugin-manager/releases) からプラットフォームに合ったビルド済みバイナリをダウンロードして `~/.local/bin` に配置するインストールスクリプトです：
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/DIO0550/plugin-manager/main/scripts/install.sh | sh
+```
+
+環境変数でカスタマイズ可能：
+
+```bash
+# 特定のバージョンをインストール
+PLM_VERSION=v0.5.0 curl -fsSL https://raw.githubusercontent.com/DIO0550/plugin-manager/main/scripts/install.sh | sh
+
+# 配置先ディレクトリを変更
+PLM_INSTALL_DIR=/usr/local/bin curl -fsSL https://raw.githubusercontent.com/DIO0550/plugin-manager/main/scripts/install.sh | sudo -E sh
+```
+
+配置先ディレクトリが `PATH` に含まれていない場合、スクリプトがシェル設定への追記方法を表示します。
+
+### 手動ダウンロード
+
+[Releases ページ](https://github.com/DIO0550/plugin-manager/releases) からアーカイブをダウンロードして `plm` バイナリを展開してください：
+
+```bash
+# 例: Linux x86_64
+VERSION=v0.5.0
+curl -fsSL -o plm.tar.gz \
+  "https://github.com/DIO0550/plugin-manager/releases/download/${VERSION}/plm-${VERSION}-x86_64-unknown-linux-gnu.tar.gz"
+tar xzf plm.tar.gz
+install -m 0755 plm ~/.local/bin/plm
+```
+
+対応ターゲット：
+
+| OS | アーキテクチャ | アセット拡張子 |
+|----|----------------|----------------|
+| Linux  | x86_64  | `x86_64-unknown-linux-gnu.tar.gz` |
+| Linux  | aarch64 | `aarch64-unknown-linux-gnu.tar.gz` |
+| macOS  | x86_64  | `x86_64-apple-darwin.tar.gz` |
+| macOS  | aarch64 | `aarch64-apple-darwin.tar.gz` |
+| Windows | x86_64 | `x86_64-pc-windows-gnu.zip` |
+
 ### ソースからビルド
 
 ```bash
-git clone https://github.com/your-org/plugin-manager.git
+git clone https://github.com/DIO0550/plugin-manager.git
 cd plugin-manager
 cargo build --release
 ```
@@ -31,7 +74,7 @@ cargo build --release
 
 ### 必要要件
 
-- Rust 2021 エディション以降
+- Rust 2021 エディション以降（ソースからビルドする場合のみ）
 - Git（プラグインダウンロード用）
 
 ## クイックスタート

--- a/README.ja.md
+++ b/README.ja.md
@@ -37,7 +37,7 @@ PLM_VERSION=v0.5.0 curl -fsSL https://raw.githubusercontent.com/DIO0550/plugin-m
 PLM_INSTALL_DIR=/usr/local/bin curl -fsSL https://raw.githubusercontent.com/DIO0550/plugin-manager/main/scripts/install.sh | sudo -E sh
 ```
 
-配置先ディレクトリが `PATH` に含まれていない場合、スクリプトがシェル設定への追記方法を表示します。
+配置先ディレクトリが `PATH` に含まれていない場合、スクリプトが `$SHELL` を見て `.bashrc` / `.zshrc` / `~/.config/fish/config.fish` のいずれかに `export PATH=...` 行を自動追記します（冪等）。`PLM_NO_MODIFY_PATH=1` を設定すると追記をスキップし、追記行を表示するだけになります。
 
 ### 手動ダウンロード
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ PLM_VERSION=v0.5.0 curl -fsSL https://raw.githubusercontent.com/DIO0550/plugin-m
 PLM_INSTALL_DIR=/usr/local/bin curl -fsSL https://raw.githubusercontent.com/DIO0550/plugin-manager/main/scripts/install.sh | sudo -E sh
 ```
 
-If the install directory is not on your `PATH`, the script prints the line to add to your shell profile.
+If the install directory is not on your `PATH`, the script appends an `export PATH=...` line to your shell profile (`.bashrc`, `.zshrc`, or `~/.config/fish/config.fish` depending on `$SHELL`). The append is idempotent. Set `PLM_NO_MODIFY_PATH=1` to skip this and just print the line.
 
 ### Manual Download
 

--- a/README.md
+++ b/README.md
@@ -19,10 +19,53 @@ A unified CLI tool for managing plugins across AI coding assistants (OpenAI Code
 
 ## Installation
 
+### Install Script (Linux / macOS)
+
+The fastest way is the install script, which downloads the matching prebuilt binary from [GitHub Releases](https://github.com/DIO0550/plugin-manager/releases) and places it under `~/.local/bin`:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/DIO0550/plugin-manager/main/scripts/install.sh | sh
+```
+
+Options via environment variables:
+
+```bash
+# Install a specific version
+PLM_VERSION=v0.5.0 curl -fsSL https://raw.githubusercontent.com/DIO0550/plugin-manager/main/scripts/install.sh | sh
+
+# Install to a custom directory
+PLM_INSTALL_DIR=/usr/local/bin curl -fsSL https://raw.githubusercontent.com/DIO0550/plugin-manager/main/scripts/install.sh | sudo -E sh
+```
+
+If the install directory is not on your `PATH`, the script prints the line to add to your shell profile.
+
+### Manual Download
+
+Download the archive for your platform from the [Releases page](https://github.com/DIO0550/plugin-manager/releases) and extract the `plm` binary:
+
+```bash
+# Example: Linux x86_64
+VERSION=v0.5.0
+curl -fsSL -o plm.tar.gz \
+  "https://github.com/DIO0550/plugin-manager/releases/download/${VERSION}/plm-${VERSION}-x86_64-unknown-linux-gnu.tar.gz"
+tar xzf plm.tar.gz
+install -m 0755 plm ~/.local/bin/plm
+```
+
+Available targets:
+
+| OS | Architecture | Asset suffix |
+|----|--------------|--------------|
+| Linux  | x86_64  | `x86_64-unknown-linux-gnu.tar.gz` |
+| Linux  | aarch64 | `aarch64-unknown-linux-gnu.tar.gz` |
+| macOS  | x86_64  | `x86_64-apple-darwin.tar.gz` |
+| macOS  | aarch64 | `aarch64-apple-darwin.tar.gz` |
+| Windows | x86_64 | `x86_64-pc-windows-gnu.zip` |
+
 ### From Source
 
 ```bash
-git clone https://github.com/your-org/plugin-manager.git
+git clone https://github.com/DIO0550/plugin-manager.git
 cd plugin-manager
 cargo build --release
 ```
@@ -31,7 +74,7 @@ The binary will be available at `target/release/plm`.
 
 ### Requirements
 
-- Rust 2021 edition or later
+- Rust 2021 edition or later (only for building from source)
 - Git (for plugin downloads)
 
 ## Quick Start

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -7,12 +7,17 @@
 # Environment variables:
 #   PLM_VERSION      Release tag to install (e.g. "v0.5.0"). Defaults to the latest release.
 #   PLM_INSTALL_DIR  Directory to place the `plm` binary. Defaults to "$HOME/.local/bin".
-#   PLM_REPO         GitHub "owner/repo". Defaults to "DIO0550/plugin-manager".
 #   PLM_NO_MODIFY_PATH  If set to "1", skip appending PATH to your shell profile.
+#
+# The upstream repository is pinned: this script always downloads from
+# DIO0550/plugin-manager so that a fork cannot redirect installs to its own
+# Releases (e.g. by mirroring this file and setting PLM_REPO).
 
 set -eu
 
-REPO="${PLM_REPO:-DIO0550/plugin-manager}"
+# Pinned upstream repository. Do not override via environment.
+REPO="DIO0550/plugin-manager"
+
 INSTALL_DIR="${PLM_INSTALL_DIR:-$HOME/.local/bin}"
 VERSION="${PLM_VERSION:-}"
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -8,6 +8,7 @@
 #   PLM_VERSION      Release tag to install (e.g. "v0.5.0"). Defaults to the latest release.
 #   PLM_INSTALL_DIR  Directory to place the `plm` binary. Defaults to "$HOME/.local/bin".
 #   PLM_REPO         GitHub "owner/repo". Defaults to "DIO0550/plugin-manager".
+#   PLM_NO_MODIFY_PATH  If set to "1", skip appending PATH to your shell profile.
 
 set -eu
 
@@ -92,27 +93,78 @@ main() {
   case ":${PATH:-}:" in
     *":${INSTALL_DIR}:"*)
       info "PATH already contains ${INSTALL_DIR}. Run \`${BINARY_NAME} --version\` to verify."
-      ;;
-    *)
-      warn "${INSTALL_DIR} is not in your PATH."
-      shell_name=$(basename "${SHELL:-}")
-      case "$shell_name" in
-        bash) rc="$HOME/.bashrc" ;;
-        zsh)  rc="$HOME/.zshrc" ;;
-        fish) rc="$HOME/.config/fish/config.fish" ;;
-        *)    rc="" ;;
-      esac
-      printf '\n    Add the following line to your shell profile:\n\n'
-      if [ "$shell_name" = "fish" ]; then
-        printf '        fish_add_path %s\n\n' "$INSTALL_DIR"
-      else
-        printf '        export PATH="%s:$PATH"\n\n' "$INSTALL_DIR"
-      fi
-      if [ -n "$rc" ]; then
-        printf '    Example:\n        echo '\''export PATH="%s:$PATH"'\'' >> %s\n\n' "$INSTALL_DIR" "$rc"
-      fi
+      return 0
       ;;
   esac
+
+  if [ "${PLM_NO_MODIFY_PATH:-0}" = "1" ]; then
+    warn "${INSTALL_DIR} is not in your PATH (PLM_NO_MODIFY_PATH=1, skipping profile update)."
+    return 0
+  fi
+
+  add_to_path "$INSTALL_DIR"
+}
+
+# Append an "export PATH" / "fish_add_path" line to the user's shell profile(s).
+# Idempotent: skips files that already reference the directory.
+add_to_path() {
+  dir=$1
+  shell_name=$(basename "${SHELL:-}")
+  appended=0
+  already=0
+
+  case "$shell_name" in
+    fish)
+      line="fish_add_path $dir"
+      try_append "$HOME/.config/fish/config.fish" "$line" "$dir"
+      ;;
+    zsh)
+      line="export PATH=\"$dir:\$PATH\""
+      try_append "$HOME/.zshrc" "$line" "$dir"
+      ;;
+    bash)
+      line="export PATH=\"$dir:\$PATH\""
+      try_append "$HOME/.bashrc" "$line" "$dir"
+      ;;
+    *)
+      line="export PATH=\"$dir:\$PATH\""
+      try_append "$HOME/.profile" "$line" "$dir"
+      ;;
+  esac
+
+  if [ "$appended" -eq 1 ]; then
+    info "PATH entry written. Open a new shell or run \`exec \$SHELL\` to pick it up."
+  elif [ "$already" -eq 1 ]; then
+    info "PATH entry already present in your shell profile."
+  else
+    warn "${dir} not added to PATH (no writable profile found)."
+    printf '    Add this manually:\n        %s\n' "$line"
+  fi
+}
+
+# Append $2 to file $1 unless the file already contains $3.
+# Updates the outer `appended` / `already` counters instead of relying on return codes.
+try_append() {
+  rc=$1
+  line=$2
+  marker=$3
+
+  rc_dir=$(dirname "$rc")
+  [ -d "$rc_dir" ] || mkdir -p "$rc_dir" 2>/dev/null || return
+
+  if [ -f "$rc" ] && grep -Fq "$marker" "$rc" 2>/dev/null; then
+    info "Already referenced in $rc — leaving it untouched."
+    already=1
+    return
+  fi
+
+  if {
+    printf '\n# Added by plm install.sh\n'
+    printf '%s\n' "$line"
+  } >> "$rc" 2>/dev/null; then
+    info "Appended PATH entry to $rc"
+    appended=1
+  fi
 }
 
 main "$@"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env sh
+# Install plm (Plugin Manager CLI) from GitHub Releases.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/DIO0550/plugin-manager/main/scripts/install.sh | sh
+#
+# Environment variables:
+#   PLM_VERSION      Release tag to install (e.g. "v0.5.0"). Defaults to the latest release.
+#   PLM_INSTALL_DIR  Directory to place the `plm` binary. Defaults to "$HOME/.local/bin".
+#   PLM_REPO         GitHub "owner/repo". Defaults to "DIO0550/plugin-manager".
+
+set -eu
+
+REPO="${PLM_REPO:-DIO0550/plugin-manager}"
+INSTALL_DIR="${PLM_INSTALL_DIR:-$HOME/.local/bin}"
+VERSION="${PLM_VERSION:-}"
+
+BINARY_NAME="plm"
+
+info()  { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
+warn()  { printf '\033[1;33m!!\033[0m  %s\n' "$*" >&2; }
+error() { printf '\033[1;31mxx\033[0m  %s\n' "$*" >&2; exit 1; }
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || error "required command not found: $1"
+}
+
+detect_target() {
+  uname_s=$(uname -s)
+  uname_m=$(uname -m)
+
+  case "$uname_s" in
+    Linux)  os="unknown-linux-gnu" ;;
+    Darwin) os="apple-darwin" ;;
+    MINGW*|MSYS*|CYGWIN*)
+      error "Windows shell detected. Download the .zip from https://github.com/${REPO}/releases and extract plm.exe manually." ;;
+    *) error "unsupported OS: $uname_s" ;;
+  esac
+
+  case "$uname_m" in
+    x86_64|amd64)  arch="x86_64" ;;
+    arm64|aarch64) arch="aarch64" ;;
+    *) error "unsupported architecture: $uname_m" ;;
+  esac
+
+  printf '%s-%s' "$arch" "$os"
+}
+
+resolve_version() {
+  if [ -n "$VERSION" ]; then
+    printf '%s' "$VERSION"
+    return
+  fi
+  require_cmd curl
+  api_url="https://api.github.com/repos/${REPO}/releases/latest"
+  tag=$(curl -fsSL "$api_url" | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p' | head -n1)
+  [ -n "$tag" ] || error "failed to resolve latest release tag from $api_url"
+  printf '%s' "$tag"
+}
+
+main() {
+  require_cmd curl
+  require_cmd tar
+  require_cmd mkdir
+  require_cmd mktemp
+
+  target=$(detect_target)
+  version=$(resolve_version)
+  asset="${BINARY_NAME}-${version}-${target}.tar.gz"
+  url="https://github.com/${REPO}/releases/download/${version}/${asset}"
+
+  info "Installing ${BINARY_NAME} ${version} (${target})"
+  info "Download: ${url}"
+
+  tmpdir=$(mktemp -d)
+  trap 'rm -rf "$tmpdir"' EXIT
+
+  if ! curl -fsSL "$url" -o "${tmpdir}/${asset}"; then
+    error "failed to download ${url}"
+  fi
+
+  tar -xzf "${tmpdir}/${asset}" -C "$tmpdir"
+  [ -f "${tmpdir}/${BINARY_NAME}" ] || error "archive did not contain ${BINARY_NAME}"
+
+  mkdir -p "$INSTALL_DIR"
+  install_path="${INSTALL_DIR}/${BINARY_NAME}"
+  mv "${tmpdir}/${BINARY_NAME}" "$install_path"
+  chmod +x "$install_path"
+
+  info "Installed: $install_path"
+
+  case ":${PATH:-}:" in
+    *":${INSTALL_DIR}:"*)
+      info "PATH already contains ${INSTALL_DIR}. Run \`${BINARY_NAME} --version\` to verify."
+      ;;
+    *)
+      warn "${INSTALL_DIR} is not in your PATH."
+      shell_name=$(basename "${SHELL:-}")
+      case "$shell_name" in
+        bash) rc="$HOME/.bashrc" ;;
+        zsh)  rc="$HOME/.zshrc" ;;
+        fish) rc="$HOME/.config/fish/config.fish" ;;
+        *)    rc="" ;;
+      esac
+      printf '\n    Add the following line to your shell profile:\n\n'
+      if [ "$shell_name" = "fish" ]; then
+        printf '        fish_add_path %s\n\n' "$INSTALL_DIR"
+      else
+        printf '        export PATH="%s:$PATH"\n\n' "$INSTALL_DIR"
+      fi
+      if [ -n "$rc" ]; then
+        printf '    Example:\n        echo '\''export PATH="%s:$PATH"'\'' >> %s\n\n' "$INSTALL_DIR" "$rc"
+      fi
+      ;;
+  esac
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- Bump crate version `0.4.0` → `0.5.0` in `Cargo.toml` / `Cargo.lock`
- Add `scripts/install.sh` to install prebuilt binaries from GitHub Releases
- Document Release download / install script usage in `README.md` and `README.ja.md`

`v0.4.0` 以降に Breaking Change（`💥 launch managed TUI by default when no subcommand is given`）が入っているため semver マイナーバンプ。

## Release flow
`.github/workflows/release.yml` が `Cargo.toml` 変更の main マージをトリガに自動で：
1. `v0.5.0` タグを作成・push
2. クロスプラットフォームでバイナリをビルド（Linux x86_64/aarch64, macOS x86_64/aarch64, Windows x86_64）
3. GitHub Release を生成し、tarball / zip をアップロード

## Install commands (after release)

```bash
# 最新版
curl -fsSL https://raw.githubusercontent.com/DIO0550/plugin-manager/main/scripts/install.sh | sh

# バージョン指定
PLM_VERSION=v0.5.0 curl -fsSL https://raw.githubusercontent.com/DIO0550/plugin-manager/main/scripts/install.sh | sh

# 配置先指定
PLM_INSTALL_DIR=/usr/local/bin curl -fsSL https://raw.githubusercontent.com/DIO0550/plugin-manager/main/scripts/install.sh | sudo -E sh
```

`~/.local/bin` が PATH に無い場合はスクリプトが追記方法を案内します。

## Notable changes since v0.4.0
- 💥 Breaking: `plm` をサブコマンド無しで起動した際にデフォルトで managed TUI を起動
- ✨ Codex Hooks の変換と配置を有効化
- ♻️ `*Result` → `*Outcome` の大量リネーム（命名規約整備）
- ♻️ `MarketplaceArgs` の共通化 (`enable`/`disable`/`uninstall`)
- ♻️ TUI screen Model のリネーム（`*ScreenModel`）

## Test plan
- [ ] CI（fmt / clippy / test）が通ること
- [ ] マージ後、Release workflow が `v0.5.0` タグ作成 → アーカイブ公開まで成功すること
- [ ] `curl ... install.sh | sh` が `~/.local/bin/plm` を配置し `plm --version` が `0.5.0` を返すこと（Linux / macOS）

🤖 Generated with [Claude Code](https://claude.com/claude-code)