### PR TITLE
✨ [New Feature]: promote cursor item on Enter in TUI multi-select

### DIFF
--- a/src/tui/dialog.rs
+++ b/src/tui/dialog.rs
@@ -81,6 +81,48 @@ pub struct MultiSelectOutcome<T> {
     pub cancelled: bool,
 }
 
+/// Enter 確定時の結果を計算する純関数。
+///
+/// `selected` フラグが 1 件以上あれば従来通りそれらを返す。
+/// 全て未選択でも `items` が非空のとき、`cursor_idx`（範囲外は末尾に丸め）
+/// が指す `enabled` なアイテム 1 件をフォールバックとして採用する。
+pub(crate) fn compute_multi_select_outcome<T: Clone>(
+    items: &[SelectItem<T>],
+    cursor_idx: usize,
+) -> MultiSelectOutcome<T> {
+    let selected: Vec<T> = items
+        .iter()
+        .filter(|i| i.selected && i.enabled)
+        .map(|i| i.value.clone())
+        .collect();
+
+    if !selected.is_empty() {
+        return MultiSelectOutcome {
+            selected,
+            cancelled: false,
+        };
+    }
+
+    if items.is_empty() {
+        return MultiSelectOutcome {
+            selected,
+            cancelled: false,
+        };
+    }
+
+    let idx = cursor_idx.min(items.len() - 1);
+    let fallback: Vec<T> = items
+        .get(idx)
+        .filter(|i| i.enabled)
+        .map(|i| vec![i.value.clone()])
+        .unwrap_or_default();
+
+    MultiSelectOutcome {
+        selected: fallback,
+        cancelled: false,
+    }
+}
+
 /// 単一選択の結果
 #[derive(Debug)]
 pub struct SingleSelectOutcome<T> {
@@ -157,14 +199,8 @@ pub fn multi_select<T: Clone>(
                         };
                     }
                     KeyCode::Enter => {
-                        break MultiSelectOutcome {
-                            selected: items
-                                .iter()
-                                .filter(|i| i.selected && i.enabled)
-                                .map(|i| i.value.clone())
-                                .collect(),
-                            cancelled: false,
-                        };
+                        let cursor = state.selected().unwrap_or(0);
+                        break compute_multi_select_outcome(items, cursor);
                     }
                     KeyCode::Char(' ') => {
                         if let Some(i) = state.selected() {
@@ -291,3 +327,7 @@ pub fn single_select<T: Clone>(
 
     Ok(result)
 }
+
+#[cfg(test)]
+#[path = "dialog_test.rs"]
+mod tests;

--- a/src/tui/dialog_test.rs
+++ b/src/tui/dialog_test.rs
@@ -1,0 +1,68 @@
+use super::{compute_multi_select_outcome, SelectItem};
+
+fn item(label: &str, value: &str) -> SelectItem<String> {
+    SelectItem::new(label, value.to_string())
+}
+
+#[test]
+fn multi_select_promotes_cursor_when_none_selected() {
+    let items = vec![item("A", "a"), item("B", "b"), item("C", "c")];
+
+    let outcome = compute_multi_select_outcome(&items, 1);
+
+    assert_eq!(outcome.selected, vec!["b".to_string()]);
+    assert!(!outcome.cancelled);
+}
+
+#[test]
+fn multi_select_keeps_existing_selection() {
+    let items = vec![
+        item("A", "a"),
+        item("B", "b").with_selected(true),
+        item("C", "c"),
+    ];
+
+    let outcome = compute_multi_select_outcome(&items, 0);
+
+    assert_eq!(outcome.selected, vec!["b".to_string()]);
+}
+
+#[test]
+fn multi_select_returns_empty_when_no_items() {
+    let items: Vec<SelectItem<String>> = vec![];
+
+    let outcome = compute_multi_select_outcome(&items, 0);
+
+    assert!(outcome.selected.is_empty());
+    assert!(!outcome.cancelled);
+}
+
+#[test]
+fn multi_select_skips_disabled_cursor() {
+    let items = vec![item("A", "a").with_enabled(false)];
+
+    let outcome = compute_multi_select_outcome(&items, 0);
+
+    assert!(outcome.selected.is_empty());
+}
+
+#[test]
+fn multi_select_clamps_cursor_when_idx_out_of_range() {
+    let items = vec![item("A", "a"), item("B", "b")];
+
+    let outcome = compute_multi_select_outcome(&items, 99);
+
+    assert_eq!(outcome.selected, vec!["b".to_string()]);
+}
+
+#[test]
+fn multi_select_promotes_cursor_at_zero_when_first_disabled() {
+    let items = vec![item("A", "a").with_enabled(false), item("B", "b")];
+
+    let outcome = compute_multi_select_outcome(&items, 0);
+
+    assert!(
+        outcome.selected.is_empty(),
+        "Disabled cursor target should not be promoted"
+    );
+}

--- a/src/tui/manager/screens/marketplaces/update.rs
+++ b/src/tui/manager/screens/marketplaces/update.rs
@@ -753,11 +753,23 @@ fn back_to_market_list(
 /// StartInstall: PluginBrowse -> TargetSelect
 fn start_install(model: &mut MarketplacesScreenModel) -> UpdateEffect {
     if let MarketplacesScreenModel::PluginBrowse {
-        selected_plugins, ..
+        plugins,
+        selected_plugins,
+        highlighted_idx,
+        ..
     } = model
     {
-        if selected_plugins.is_empty() {
+        if plugins.is_empty() {
             return UpdateEffect::none();
+        }
+        if selected_plugins.is_empty() {
+            let idx = (*highlighted_idx).min(plugins.len() - 1);
+            match plugins.get(idx) {
+                Some(plugin) => {
+                    selected_plugins.insert(plugin.name.clone());
+                }
+                None => return UpdateEffect::none(),
+            }
         }
     } else {
         return UpdateEffect::none();
@@ -962,10 +974,21 @@ pub(super) fn execute_install_with(
 
 /// ConfirmTargets: TargetSelect -> ScopeSelect
 fn confirm_targets(model: &mut MarketplacesScreenModel) -> UpdateEffect {
-    // Guard: at least one target selected
-    if let MarketplacesScreenModel::TargetSelect { targets, .. } = model {
-        if !targets.iter().any(|(_, _, sel)| *sel) {
+    if let MarketplacesScreenModel::TargetSelect {
+        targets,
+        highlighted_idx,
+        ..
+    } = model
+    {
+        if targets.is_empty() {
             return UpdateEffect::none();
+        }
+        if !targets.iter().any(|(_, _, sel)| *sel) {
+            let idx = (*highlighted_idx).min(targets.len() - 1);
+            match targets.get_mut(idx) {
+                Some(target) => target.2 = true,
+                None => return UpdateEffect::none(),
+            }
         }
     } else {
         return UpdateEffect::none();

--- a/src/tui/manager/screens/marketplaces/update_test.rs
+++ b/src/tui/manager/screens/marketplaces/update_test.rs
@@ -591,18 +591,119 @@ fn confirm_targets_transitions_to_scope_select() {
 }
 
 #[test]
-fn confirm_targets_ignored_when_no_target_selected() {
+fn confirm_targets_promotes_cursor_when_no_target_selected() {
     let (_temp_dir, mut data) = make_data(&["mp-a"]);
     let mut model = make_target_select("mp-a");
-    // All targets unselected
+    // All targets unselected; highlighted_idx defaults to 0
+
+    update(&mut model, Msg::ConfirmTargets, &mut data);
+
+    assert_eq!(
+        model_variant(&model),
+        "ScopeSelect",
+        "Should transition to ScopeSelect using cursor as fallback"
+    );
+
+    if let MarketplacesScreenModel::ScopeSelect { target_names, .. } = &model {
+        assert_eq!(
+            target_names,
+            &vec!["codex".to_string()],
+            "Cursor target at idx 0 should be promoted"
+        );
+    } else {
+        panic!("Expected ScopeSelect");
+    }
+}
+
+#[test]
+fn confirm_targets_promotes_cursor_at_highlighted_idx() {
+    let (_temp_dir, mut data) = make_data(&["mp-a"]);
+    let mut model = make_target_select("mp-a");
+    if let MarketplacesScreenModel::TargetSelect {
+        highlighted_idx, ..
+    } = &mut model
+    {
+        *highlighted_idx = 2;
+    }
+
+    update(&mut model, Msg::ConfirmTargets, &mut data);
+
+    if let MarketplacesScreenModel::ScopeSelect { target_names, .. } = &model {
+        assert_eq!(target_names, &vec!["antigravity".to_string()]);
+    } else {
+        panic!("Expected ScopeSelect");
+    }
+}
+
+#[test]
+fn confirm_targets_keeps_existing_truthy_targets() {
+    let (_temp_dir, mut data) = make_data(&["mp-a"]);
+    let mut model = make_target_select("mp-a");
+    if let MarketplacesScreenModel::TargetSelect {
+        targets,
+        highlighted_idx,
+        ..
+    } = &mut model
+    {
+        targets[0].2 = true; // codex selected
+        *highlighted_idx = 2; // cursor on antigravity
+    }
+
+    update(&mut model, Msg::ConfirmTargets, &mut data);
+
+    if let MarketplacesScreenModel::ScopeSelect { target_names, .. } = &model {
+        assert_eq!(
+            target_names,
+            &vec!["codex".to_string()],
+            "Only existing true target should be carried over"
+        );
+    } else {
+        panic!("Expected ScopeSelect");
+    }
+}
+
+#[test]
+fn confirm_targets_noop_when_targets_empty() {
+    let (_temp_dir, mut data) = make_data(&["mp-a"]);
+    let mut model = make_target_select("mp-a");
+    if let MarketplacesScreenModel::TargetSelect { targets, .. } = &mut model {
+        targets.clear();
+    }
 
     update(&mut model, Msg::ConfirmTargets, &mut data);
 
     assert_eq!(
         model_variant(&model),
         "TargetSelect",
-        "Should stay TargetSelect when no target selected"
+        "Should stay TargetSelect when targets list is empty"
     );
+}
+
+#[test]
+fn confirm_targets_clamps_cursor_when_idx_out_of_range() {
+    let (_temp_dir, mut data) = make_data(&["mp-a"]);
+    let mut model = make_target_select("mp-a");
+    if let MarketplacesScreenModel::TargetSelect {
+        targets,
+        highlighted_idx,
+        ..
+    } = &mut model
+    {
+        targets.truncate(2); // codex, copilot
+        *highlighted_idx = 10;
+    }
+
+    update(&mut model, Msg::ConfirmTargets, &mut data);
+
+    if let MarketplacesScreenModel::ScopeSelect { target_names, .. } = &model {
+        assert_eq!(
+            target_names,
+            &vec!["copilot".to_string()],
+            "Out-of-range highlighted_idx should clamp to last target"
+        );
+    } else {
+        panic!("Expected ScopeSelect");
+    }
 }
 
 // ============================================================================
@@ -684,18 +785,138 @@ fn start_install_transitions_to_target_select() {
 }
 
 #[test]
-fn start_install_ignored_when_no_selection() {
+fn start_install_promotes_cursor_when_no_selection() {
     let (_temp_dir, mut data) = make_data(&["mp-a"]);
     let mut model = make_plugin_browse("mp-a", 3);
-    // selected_plugins is empty
+    // selected_plugins is empty; highlighted_idx defaults to 0
+
+    update(&mut model, Msg::StartInstall, &mut data);
+
+    assert_eq!(
+        model_variant(&model),
+        "TargetSelect",
+        "Should transition to TargetSelect using cursor as fallback"
+    );
+
+    if let MarketplacesScreenModel::TargetSelect {
+        selected_plugins, ..
+    } = &model
+    {
+        assert!(
+            selected_plugins.contains("plugin-0"),
+            "Cursor-promoted plugin should be in selected_plugins"
+        );
+        assert_eq!(
+            selected_plugins.len(),
+            1,
+            "Only the cursor plugin should be promoted"
+        );
+    } else {
+        panic!("Expected TargetSelect");
+    }
+}
+
+#[test]
+fn start_install_promotes_cursor_at_highlighted_idx() {
+    let (_temp_dir, mut data) = make_data(&["mp-a"]);
+    let mut model = make_plugin_browse("mp-a", 3);
+    if let MarketplacesScreenModel::PluginBrowse {
+        highlighted_idx, ..
+    } = &mut model
+    {
+        *highlighted_idx = 1;
+    }
+
+    update(&mut model, Msg::StartInstall, &mut data);
+
+    if let MarketplacesScreenModel::TargetSelect {
+        selected_plugins, ..
+    } = &model
+    {
+        assert!(
+            selected_plugins.contains("plugin-1"),
+            "Plugin at highlighted_idx=1 should be promoted"
+        );
+    } else {
+        panic!("Expected TargetSelect");
+    }
+}
+
+#[test]
+fn start_install_keeps_existing_selection() {
+    let (_temp_dir, mut data) = make_data(&["mp-a"]);
+    let mut model = make_plugin_browse("mp-a", 3);
+    if let MarketplacesScreenModel::PluginBrowse {
+        selected_plugins,
+        highlighted_idx,
+        ..
+    } = &mut model
+    {
+        selected_plugins.insert("plugin-2".to_string());
+        *highlighted_idx = 0;
+    }
+
+    update(&mut model, Msg::StartInstall, &mut data);
+
+    if let MarketplacesScreenModel::TargetSelect {
+        selected_plugins, ..
+    } = &model
+    {
+        assert!(selected_plugins.contains("plugin-2"));
+        assert!(
+            !selected_plugins.contains("plugin-0"),
+            "Cursor should not be promoted when selection already exists"
+        );
+        assert_eq!(selected_plugins.len(), 1);
+    } else {
+        panic!("Expected TargetSelect");
+    }
+}
+
+#[test]
+fn start_install_noop_when_plugin_list_empty() {
+    let (_temp_dir, mut data) = make_data(&["mp-a"]);
+    let mut model = make_plugin_browse("mp-a", 0);
 
     update(&mut model, Msg::StartInstall, &mut data);
 
     assert_eq!(
         model_variant(&model),
         "PluginBrowse",
-        "Should stay PluginBrowse when no selection"
+        "Should stay PluginBrowse when plugin list is empty"
     );
+    if let MarketplacesScreenModel::PluginBrowse {
+        selected_plugins, ..
+    } = &model
+    {
+        assert!(selected_plugins.is_empty());
+    }
+}
+
+#[test]
+fn start_install_clamps_cursor_when_idx_out_of_range() {
+    let (_temp_dir, mut data) = make_data(&["mp-a"]);
+    let mut model = make_plugin_browse("mp-a", 2);
+    if let MarketplacesScreenModel::PluginBrowse {
+        highlighted_idx, ..
+    } = &mut model
+    {
+        *highlighted_idx = 99;
+    }
+
+    update(&mut model, Msg::StartInstall, &mut data);
+
+    if let MarketplacesScreenModel::TargetSelect {
+        selected_plugins, ..
+    } = &model
+    {
+        assert!(
+            selected_plugins.contains("plugin-1"),
+            "Out-of-range highlighted_idx should clamp to last plugin"
+        );
+    } else {
+        panic!("Expected TargetSelect");
+    }
 }
 
 // ============================================================================


### PR DESCRIPTION
## 概要

TUI のマルチセレクト画面で「アイテムを 1 件もトグルしないまま Enter」を押したとき、カーソル位置のアイテムを暗黙的に選択して次フェーズへ進めるフォールバック挙動を導入する。明示的にトグルしたユーザーには一切影響しない（既選択ありの場合は従来挙動を維持）。

## 変更の種類

- ✨ [New Feature]
- 🎨 [UI/UX]

## 変更した内容

- `src/tui/manager/screens/marketplaces/update.rs::start_install`
  - `selected_plugins` が空でも `plugins` が非空なら、`highlighted_idx`（範囲外は末尾に丸め）の plugin 名を `selected_plugins` に挿入してから `TargetSelect` 遷移へ進む
- `src/tui/manager/screens/marketplaces/update.rs::confirm_targets`
  - `targets` 全 false でも `targets` が非空なら、カーソル位置の `targets[idx].2 = true` にしてから `ScopeSelect` 遷移へ進む
- `src/tui/dialog.rs::multi_select`
  - Enter ハンドラのロジックを純関数 `compute_multi_select_outcome(items, cursor_idx)` に抽出
  - 全 `selected=false` かつ `items` 非空のとき、カーソル位置の `enabled` アイテム 1 件だけを返すフォールバックを実装
  - disabled アイテム上のカーソル / 空リスト / カーソル範囲外丸めも明示的にハンドリング

## 追加した内容

- `src/tui/dialog_test.rs`（新規）
  - `compute_multi_select_outcome` の 6 テスト（fallback / 既選択 / 空リスト / disabled / 範囲外丸め）

## システム図

```mermaid
flowchart TD
    A[Enter 押下] --> B{候補リスト空?}
    B -- Yes --> N[no-op: UpdateEffect::none<br/>または空 Vec]
    B -- No  --> C{選択フラグ 1 件以上 true?}
    C -- Yes --> D[従来挙動: 次フェーズへ]
    C -- No  --> E[カーソル位置のアイテムに<br/>selected=true を暗黙適用<br/><b>NEW</b>]
    E --> D

    style E fill:#d4edda,stroke:#28a745
```

対象は以下 3 箇所のみ。シングルセレクト画面・Model 構造体・`view`・`key_to_msg`・`Msg` 列挙には一切手を入れない。

| 箇所 | 既存挙動 | 改修後 |
|------|----------|--------|
| `PluginBrowse::start_install` | 未選択で `UpdateEffect::none()` | カーソル位置 plugin を `selected_plugins` に取り込んで `TargetSelect` へ |
| `TargetSelect::confirm_targets` | 全 false で `UpdateEffect::none()` | カーソル位置 target を true 化して `ScopeSelect` へ |
| `dialog::multi_select` Enter | 空 `Vec` を返し呼び出し側で `PlmError::Deployment` | カーソル位置 enabled アイテム 1 件を返す |

## 関連 Spec / Issue

- Spec: `.plugin-workspace/.specs/034-tui-enter-default-select/`

## 検証

CLAUDE.md / MEMORY.md 規約に従いサブエージェント経由で実施：

- ✅ `cargo fmt -- --check`（Bash サブエージェント）: フォーマット差分なし
- ✅ `cargo check --tests`（`rust-workflow-plugin:type-check`）: エラー 0
- ✅ `cargo test`（`rust-workflow-plugin:test`）: **1668 passed / 0 failed**
  - 既存テスト 2 件を新フォールバック挙動に書き換え（`*_ignored_when_no_selection` → `*_promotes_cursor_when_no_selection` 等）
  - update_test に 10 件、dialog_test に 6 件、計 16 件の新規テストを追加
  - 全旧テスト含め回帰なし

## レビューポイント

- フォールバックは `selected が 1 件以上ある場合は発動しない` ことの確認（明示トグル運用への非干渉）
- `selected_plugins` に挿入するキー文字列が `ToggleSelect` の挿入ロジックと同じ `plugin.name` であること（後段の TargetSelect ターゲット解決でミスマッチを起こさないため）
- `highlighted_idx` の範囲外丸め (`.min(len - 1)`) で panic を回避していること
- `dialog::multi_select` で disabled 上カーソルは取り込まない（従来 `filter(selected && enabled)` のセマンティクスを踏襲）

## チェックリスト

- [x] `cargo fmt` をサブエージェント経由で実行した
- [x] `cargo check` を `rust-workflow-plugin:type-check` で実行しグリーン
- [x] `cargo test` を `rust-workflow-plugin:test` で実行しグリーン（1668 passed）
- [x] 公開 API への破壊的変更なし（`compute_multi_select_outcome` は `pub(crate)` のみ）
- [x] セルフレビュー実施
- [x] 関連 Spec を本文にリンクした