### PR TITLE
🔖 [Release]: bump version to 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1648,7 +1648,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plm"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "assert_cmd",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plm"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 license = "MIT"
 


### PR DESCRIPTION
## 概要

`plm` のバージョンを `0.5.0` → `0.6.0` に更新する。

## 変更の種類

- 🔧 [Config]

## 変更した内容

- `Cargo.toml`: `version = "0.5.0"` → `"0.6.0"`
- `Cargo.lock`: 上記に追従

## 0.5.0 以降の主な変更

- ✨ [New Feature]: promote cursor item on Enter in TUI multi-select (#299)
- 🐛 [Bug Fix]: transition to PluginBrowse on marketplace add success (#298)
- 🐛 [Bug Fix]: surface Adding status and BrowsePlugins cache miss in managed TUI
- 🔒 [Security]: pin upstream repository in install.sh
- ✨ [New Feature]: auto-append PATH entry to shell profile in install.sh
- 📝 [Doc]: document Release download and install.sh in README
- ✨ [New Feature]: add scripts/install.sh for prebuilt binary install

新機能の追加を含むため SemVer の minor を上げる。

## 検証

- ✅ `cargo check`（`rust-workflow-plugin:type-check`）: `plm v0.6.0` で正常コンパイル

## レビューポイント

- バージョン番号のみの変更で破壊的変更なし