### PR TITLE
💥 [Breaking]: make batch update_all_plugins all-or-nothing

### DIFF
--- a/src/commands/lifecycle/update.rs
+++ b/src/commands/lifecycle/update.rs
@@ -52,13 +52,16 @@ pub async fn run(args: Args) -> Result<(), String> {
         let results = update_all_plugins(&cache, &project_root, target_filter).await;
         display_batch_results(&results);
 
-        // Exit with an error only when every plugin failed.
-        if !results.is_empty()
-            && results
-                .iter()
-                .all(|r| matches!(r.status, UpdateStatus::Failed))
-        {
-            return Err("All updates failed".to_string());
+        // Atomic batch: nothing was committed when any plugin Failed and no
+        // plugin was Updated (the whole batch was rolled back). Treat as error exit.
+        let any_updated = results
+            .iter()
+            .any(|r| matches!(r.status, UpdateStatus::Updated { .. }));
+        let any_failed = results
+            .iter()
+            .any(|r| matches!(r.status, UpdateStatus::Failed));
+        if any_failed && !any_updated {
+            return Err("Batch update rolled back: no plugins were updated".to_string());
         }
     } else if let Some(name) = &args.name {
         let (plugin_input, marketplace_hint) = match name.split_once('@') {
@@ -114,6 +117,15 @@ fn display_single_result(result: &UpdateOutcome) {
             }
             eprintln!("  Previous version retained.");
         }
+        UpdateStatus::RolledBack => {
+            eprintln!(
+                "Rolled back: '{}' (batch update aborted, previous version retained)",
+                result.plugin_name
+            );
+            if let Some(note) = &result.error {
+                eprintln!("  {}", note);
+            }
+        }
     }
 }
 
@@ -137,6 +149,10 @@ fn display_batch_results(results: &[UpdateOutcome]) {
         .iter()
         .filter(|r| matches!(r.status, UpdateStatus::Failed))
         .count();
+    let rolled_back = results
+        .iter()
+        .filter(|r| matches!(r.status, UpdateStatus::RolledBack))
+        .count();
 
     println!("\nSummary:");
     println!("  Updated: {}", updated);
@@ -146,5 +162,8 @@ fn display_batch_results(results: &[UpdateOutcome]) {
     }
     if failed > 0 {
         println!("  Failed: {}", failed);
+    }
+    if rolled_back > 0 {
+        println!("  Rolled back: {}", rolled_back);
     }
 }

--- a/src/plugin/cache/cache.rs
+++ b/src/plugin/cache/cache.rs
@@ -571,6 +571,11 @@ impl PackageCacheAccess for PackageCache {
         source_path: Option<&str>,
     ) -> Result<PathBuf> {
         let fs = RealFs;
+
+        // source_path の防御的検証（store_from_archive と同等。doc の「正規化済み」契約を
+        // 強制し、`..`/絶対パス等の非正規化 source_path が展開処理に到達するのを防ぐ）
+        validate_source_path(source_path)?;
+
         let temp_dir = self.temp_path(marketplace, name);
 
         // temp ディレクトリをクリーンアップ

--- a/src/plugin/cache/cache.rs
+++ b/src/plugin/cache/cache.rs
@@ -210,6 +210,42 @@ pub trait PackageCacheAccess: Send + Sync {
         source_path: Option<&str>,
     ) -> Result<PathBuf>;
 
+    /// staging: temp へ展開 + plugin.json 検証まで行い、本番 swap はしない
+    ///
+    /// `atomic_update_with_source_path` の「展開 + 検証」部分のみを実施する prepare 用 API。
+    /// 既存本番ディレクトリ（plugin_path）は一切触らない。失敗時は temp を破棄する。
+    /// commit は別途 `commit_staged` で行う。
+    ///
+    /// # Arguments
+    /// * `marketplace` - マーケットプレイス名（None の場合は "github"）
+    /// * `name` - プラグイン名
+    /// * `archive` - zip アーカイブのバイト列
+    /// * `source_path` - 抽出するソースパス（正規化済み）
+    fn stage_from_archive(
+        &self,
+        marketplace: Option<&str>,
+        name: &str,
+        archive: &[u8],
+        source_path: Option<&str>,
+    ) -> Result<PathBuf>;
+
+    /// commit: `stage_from_archive` で作成した temp を本番 plugin_path へ swap する
+    ///
+    /// temp が存在しない場合はエラー。既存本番ディレクトリは削除してから rename する。
+    /// 呼び出し側は事前に backup 済みであることを前提とする（rollback 可能化のため）。
+    ///
+    /// # Arguments
+    /// * `marketplace` - マーケットプレイス名（None の場合は "github"）
+    /// * `name` - プラグイン名
+    fn commit_staged(&self, marketplace: Option<&str>, name: &str) -> Result<PathBuf>;
+
+    /// staging temp を破棄する（abort 用、存在しなければ no-op）
+    ///
+    /// # Arguments
+    /// * `marketplace` - マーケットプレイス名（None の場合は "github"）
+    /// * `name` - プラグイン名
+    fn discard_staged(&self, marketplace: Option<&str>, name: &str) -> Result<()>;
+
     /// marketplace 配下に指定 entry が存在するか確認
     ///
     /// # Arguments
@@ -525,6 +561,64 @@ impl PackageCacheAccess for PackageCache {
         fs.rename(&temp_dir, &target)?;
 
         Ok(target)
+    }
+
+    fn stage_from_archive(
+        &self,
+        marketplace: Option<&str>,
+        name: &str,
+        archive: &[u8],
+        source_path: Option<&str>,
+    ) -> Result<PathBuf> {
+        let fs = RealFs;
+        let temp_dir = self.temp_path(marketplace, name);
+
+        // temp ディレクトリをクリーンアップ
+        if fs.exists(&temp_dir) {
+            fs.remove_dir_all(&temp_dir)?;
+        }
+        if let Some(parent) = temp_dir.parent() {
+            fs.create_dir_all(parent)?;
+        }
+
+        // temp に展開（失敗時は temp 破棄）
+        if let Err(e) = extract_archive_with_source_path(&temp_dir, archive, source_path) {
+            let _ = fs.remove_dir_all(&temp_dir);
+            return Err(e);
+        }
+        // plugin.json 検証
+        if !has_manifest(&temp_dir) {
+            let _ = fs.remove_dir_all(&temp_dir);
+            return Err(PlmError::InvalidManifest("plugin.json not found".into()));
+        }
+        Ok(temp_dir)
+    }
+
+    fn commit_staged(&self, marketplace: Option<&str>, name: &str) -> Result<PathBuf> {
+        let fs = RealFs;
+        let temp_dir = self.temp_path(marketplace, name);
+        let target = self.plugin_path(marketplace, name);
+
+        if !fs.exists(&temp_dir) {
+            return Err(PlmError::Cache(format!(
+                "Staged update not found: {}",
+                temp_dir.display()
+            )));
+        }
+        if fs.exists(&target) {
+            fs.remove_dir_all(&target)?;
+        }
+        fs.rename(&temp_dir, &target)?;
+        Ok(target)
+    }
+
+    fn discard_staged(&self, marketplace: Option<&str>, name: &str) -> Result<()> {
+        let fs = RealFs;
+        let temp_dir = self.temp_path(marketplace, name);
+        if fs.exists(&temp_dir) {
+            fs.remove_dir_all(&temp_dir)?;
+        }
+        Ok(())
     }
 
     fn has_marketplace_entry(&self, marketplace: &str, entry: &str) -> Result<bool> {

--- a/src/plugin/cache/cache_test.rs
+++ b/src/plugin/cache/cache_test.rs
@@ -600,6 +600,223 @@ fn test_atomic_update_cleans_up_temp_on_failure() {
 }
 
 // =============================================================================
+// staging API tests: stage_from_archive / commit_staged / discard_staged
+// =============================================================================
+
+#[test]
+fn test_stage_from_archive_does_not_touch_production() {
+    // 正常系: stage は本番を触らない
+    let temp_dir = TempDir::new().unwrap();
+    let cache = PackageCache::with_cache_dir(temp_dir.path().to_path_buf()).unwrap();
+
+    // 既存本番プラグイン (v1)
+    let archive_v1 = create_test_archive(&[
+        (
+            "repo-main/plugin.json",
+            r#"{"name":"test","version":"1.0.0"}"#,
+        ),
+        ("repo-main/data.txt", "version 1"),
+    ]);
+    cache
+        .store_from_archive(Some("github"), "test-plugin", &archive_v1, None)
+        .unwrap();
+
+    // 有効 archive (v2) を stage
+    let archive_v2 = create_test_archive(&[
+        (
+            "repo-main/plugin.json",
+            r#"{"name":"test","version":"2.0.0"}"#,
+        ),
+        ("repo-main/data.txt", "version 2"),
+    ]);
+    let staged = cache
+        .stage_from_archive(Some("github"), "test-plugin", &archive_v2, None)
+        .unwrap();
+
+    // temp に展開され plugin.json 存在
+    assert!(staged.join("plugin.json").exists());
+    assert_eq!(
+        fs::read_to_string(staged.join("data.txt")).unwrap(),
+        "version 2"
+    );
+
+    // 本番は旧内容のまま不変
+    let plugin_path = cache.plugin_path(Some("github"), "test-plugin");
+    assert_eq!(
+        fs::read_to_string(plugin_path.join("data.txt")).unwrap(),
+        "version 1"
+    );
+}
+
+#[test]
+fn test_commit_staged_swaps_into_production() {
+    // 正常系: commit_staged で swap
+    let temp_dir = TempDir::new().unwrap();
+    let cache = PackageCache::with_cache_dir(temp_dir.path().to_path_buf()).unwrap();
+
+    let archive_v1 = create_test_archive(&[
+        (
+            "repo-main/plugin.json",
+            r#"{"name":"test","version":"1.0.0"}"#,
+        ),
+        ("repo-main/data.txt", "version 1"),
+    ]);
+    cache
+        .store_from_archive(Some("github"), "test-plugin", &archive_v1, None)
+        .unwrap();
+
+    let archive_v2 = create_test_archive(&[
+        (
+            "repo-main/plugin.json",
+            r#"{"name":"test","version":"2.0.0"}"#,
+        ),
+        ("repo-main/data.txt", "version 2"),
+    ]);
+    cache
+        .stage_from_archive(Some("github"), "test-plugin", &archive_v2, None)
+        .unwrap();
+
+    let committed = cache.commit_staged(Some("github"), "test-plugin").unwrap();
+
+    // 本番が新内容に置換
+    assert_eq!(
+        fs::read_to_string(committed.join("data.txt")).unwrap(),
+        "version 2"
+    );
+    // temp 消滅
+    let temp_path = temp_dir
+        .path()
+        .join(".temp")
+        .join("github")
+        .join("test-plugin");
+    assert!(!temp_path.exists());
+}
+
+#[test]
+fn test_stage_then_commit_round_trip_consistency() {
+    // 正常系: stage→commit の往復一貫性
+    let temp_dir = TempDir::new().unwrap();
+    let cache = PackageCache::with_cache_dir(temp_dir.path().to_path_buf()).unwrap();
+
+    let archive_v1 = create_test_archive(&[(
+        "repo-main/plugin.json",
+        r#"{"name":"test","version":"1.0.0"}"#,
+    )]);
+    cache
+        .store_from_archive(Some("github"), "test-plugin", &archive_v1, None)
+        .unwrap();
+
+    let archive_v2 = create_test_archive(&[
+        (
+            "repo-main/plugin.json",
+            r#"{"name":"test","version":"2.0.0"}"#,
+        ),
+        ("repo-main/new-file.txt", "fresh content"),
+    ]);
+    cache
+        .stage_from_archive(Some("github"), "test-plugin", &archive_v2, None)
+        .unwrap();
+    let committed = cache.commit_staged(Some("github"), "test-plugin").unwrap();
+
+    assert!(committed.join("new-file.txt").exists());
+    assert_eq!(
+        fs::read_to_string(committed.join("new-file.txt")).unwrap(),
+        "fresh content"
+    );
+    let manifest = fs::read_to_string(committed.join("plugin.json")).unwrap();
+    assert!(manifest.contains("2.0.0"));
+}
+
+#[test]
+fn test_stage_from_archive_invalid_manifest_keeps_production() {
+    // 異常系: plugin.json を含まない archive → Err、temp 破棄、本番不変
+    let temp_dir = TempDir::new().unwrap();
+    let cache = PackageCache::with_cache_dir(temp_dir.path().to_path_buf()).unwrap();
+
+    let archive_v1 = create_test_archive(&[(
+        "repo-main/plugin.json",
+        r#"{"name":"test","version":"1.0.0"}"#,
+    )]);
+    cache
+        .store_from_archive(Some("github"), "test-plugin", &archive_v1, None)
+        .unwrap();
+
+    let bad_archive = create_test_archive(&[("repo-main/readme.md", "# no plugin.json")]);
+    let result = cache.stage_from_archive(Some("github"), "test-plugin", &bad_archive, None);
+
+    assert!(matches!(result, Err(PlmError::InvalidManifest(_))));
+
+    // temp 破棄
+    let temp_path = temp_dir
+        .path()
+        .join(".temp")
+        .join("github")
+        .join("test-plugin");
+    assert!(!temp_path.exists());
+
+    // 本番不変
+    let plugin_path = cache.plugin_path(Some("github"), "test-plugin");
+    assert!(plugin_path.join("plugin.json").exists());
+}
+
+#[test]
+fn test_commit_staged_without_stage_returns_error() {
+    // 異常系: stage せず commit_staged → Err、本番不変
+    let temp_dir = TempDir::new().unwrap();
+    let cache = PackageCache::with_cache_dir(temp_dir.path().to_path_buf()).unwrap();
+
+    let archive_v1 = create_test_archive(&[(
+        "repo-main/plugin.json",
+        r#"{"name":"test","version":"1.0.0"}"#,
+    )]);
+    cache
+        .store_from_archive(Some("github"), "test-plugin", &archive_v1, None)
+        .unwrap();
+
+    let result = cache.commit_staged(Some("github"), "test-plugin");
+    assert!(result.is_err());
+
+    // 本番不変
+    let plugin_path = cache.plugin_path(Some("github"), "test-plugin");
+    assert!(plugin_path.join("plugin.json").exists());
+}
+
+#[test]
+fn test_discard_staged_is_idempotent() {
+    // エッジケース: temp 無し状態で discard_staged → Ok（no-op）
+    let temp_dir = TempDir::new().unwrap();
+    let cache = PackageCache::with_cache_dir(temp_dir.path().to_path_buf()).unwrap();
+
+    let result = cache.discard_staged(Some("github"), "nonexistent-plugin");
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_discard_staged_removes_temp() {
+    // discard_staged が staging temp を破棄する
+    let temp_dir = TempDir::new().unwrap();
+    let cache = PackageCache::with_cache_dir(temp_dir.path().to_path_buf()).unwrap();
+
+    let archive = create_test_archive(&[(
+        "repo-main/plugin.json",
+        r#"{"name":"test","version":"1.0.0"}"#,
+    )]);
+    cache
+        .stage_from_archive(Some("github"), "test-plugin", &archive, None)
+        .unwrap();
+
+    let temp_path = temp_dir
+        .path()
+        .join(".temp")
+        .join("github")
+        .join("test-plugin");
+    assert!(temp_path.exists());
+
+    cache.discard_staged(Some("github"), "test-plugin").unwrap();
+    assert!(!temp_path.exists());
+}
+
+// =============================================================================
 // load_package() tests
 // =============================================================================
 

--- a/src/plugin/cache/cache_test.rs
+++ b/src/plugin/cache/cache_test.rs
@@ -760,6 +760,30 @@ fn test_stage_from_archive_invalid_manifest_keeps_production() {
 }
 
 #[test]
+fn test_stage_from_archive_rejects_non_normalized_source_path() {
+    // セキュリティ: 非正規化 source_path（".." 含む）は展開前に拒否する
+    let temp_dir = TempDir::new().unwrap();
+    let cache = PackageCache::with_cache_dir(temp_dir.path().to_path_buf()).unwrap();
+
+    let archive = create_test_archive(&[(
+        "repo-main/plugin.json",
+        r#"{"name":"test","version":"1.0.0"}"#,
+    )]);
+    let result =
+        cache.stage_from_archive(Some("github"), "test-plugin", &archive, Some("../escape"));
+
+    assert!(matches!(result, Err(PlmError::InvalidSource(_))));
+
+    // temp は作られない
+    let temp_path = temp_dir
+        .path()
+        .join(".temp")
+        .join("github")
+        .join("test-plugin");
+    assert!(!temp_path.exists());
+}
+
+#[test]
 fn test_commit_staged_without_stage_returns_error() {
     // 異常系: stage せず commit_staged → Err、本番不変
     let temp_dir = TempDir::new().unwrap();

--- a/src/plugin/lifecycle/update.rs
+++ b/src/plugin/lifecycle/update.rs
@@ -1007,29 +1007,39 @@ fn abort(
     PrepareOutcome::Aborted(results)
 }
 
-/// COMMIT: 全件 swap → redeploy → meta。swap 中失敗で ROLLBACK。
+/// COMMIT: 全件 swap（Phase 1）→ 全件 redeploy + meta（Phase 2）。
+///
+/// swap（`commit_staged`）が唯一のロールバック可能フェーズであり、ここで失敗したら
+/// 即 ROLLBACK する。**redeploy / meta 書き込みは全件の swap が成功してから**まとめて行う。
+/// こうすることで、後続プラグインの swap 失敗による ROLLBACK が「いずれかのプラグインの
+/// redeploy 副作用がデプロイ先に残ったまま」発生することを防ぐ（rollback はキャッシュ復元のみで
+/// 整合する）。redeploy / write_meta 失敗は従来どおり非アトミック（disabled / 警告）扱い。
 fn commit_all(
     cache: &dyn PackageCacheAccess,
     staged: Vec<StagedUpdate>,
     project_root: &Path,
     target_filter: Option<&str>,
 ) -> Vec<UpdateOutcome> {
-    let mut results: Vec<UpdateOutcome> = Vec::new();
-
+    // Phase 1: 全件 swap（本番差し替え）。1 件でも失敗したら、まだ redeploy は一切
+    // 行っていないので ROLLBACK はキャッシュ復元だけで完結する。
     for (idx, s) in staged.iter().enumerate() {
         let mp = s.target.marketplace.as_deref();
-        // 4. swap（本番差し替え）
-        let plugin_path = match cache.commit_staged(mp, &s.target.cache_id) {
-            Ok(p) => p,
-            Err(e) => {
-                // swap 失敗 → ROLLBACK（既 swap 分 + 当該 + 未 swap 残り全件）
-                // 当該は staged 内インデックスで識別する（cache_id 文字列は
-                // 別 marketplace 間で衝突し得るため使わない）。
-                return rollback_all(cache, &staged, idx, e);
-            }
-        };
+        if let Err(e) = cache.commit_staged(mp, &s.target.cache_id) {
+            // swap 失敗 → ROLLBACK（既 swap 分 + 当該 + 未 swap 残り全件）。
+            // 当該は staged 内インデックスで識別する（cache_id 文字列は
+            // 別 marketplace 間で衝突し得るため使わない）。
+            return rollback_all(cache, &staged, idx, e);
+        }
+    }
 
-        // 5. redeploy（非アトミック: 失敗 target は disabled）
+    // Phase 2: 全件 swap 成功。redeploy + meta を行う（非アトミック: ここから先は
+    // 失敗しても ROLLBACK しない）。
+    let mut results: Vec<UpdateOutcome> = Vec::new();
+    for s in &staged {
+        let mp = s.target.marketplace.as_deref();
+        let plugin_path = cache.plugin_path(mp, &s.target.cache_id);
+
+        // redeploy（非アトミック: 失敗 target は disabled）
         let enabled = s.target.old_meta.enabled_targets();
         let targets: Vec<&str> = match target_filter {
             Some(f) => enabled.into_iter().filter(|t| *t == f).collect(),
@@ -1038,7 +1048,7 @@ fn commit_all(
         let (deployed, failed) =
             redeploy_to_targets(cache, &s.target.cache_id, mp, &targets, project_root);
 
-        // 6. meta 更新（best-effort。アトミック境界は swap までのため失敗しても巻き戻さない）
+        // meta 更新（best-effort。アトミック境界は swap までのため失敗しても巻き戻さない）
         let mut new_meta = s.target.old_meta.clone();
         new_meta.set_git_info(&s.target.git_ref, &s.archive_sha);
         for t in &failed {
@@ -1064,7 +1074,7 @@ fn commit_all(
         ));
     }
 
-    // 全件 swap 成功 → backup 確定削除
+    // 全件成功 → backup 確定削除
     for s in &staged {
         let mp = s.target.marketplace.as_deref();
         cleanup_backup(cache, mp, &s.target.cache_id);

--- a/src/plugin/lifecycle/update.rs
+++ b/src/plugin/lifecycle/update.rs
@@ -28,6 +28,9 @@ pub enum UpdateStatus {
     Failed,
     /// スキップ
     Skipped { reason: String },
+    /// 一括更新で他プラグインの失敗により更新前へロールバックされた
+    /// (本来は更新成功していたが、batch all-or-nothing により巻き戻された)
+    RolledBack,
 }
 
 /// 更新結果
@@ -118,6 +121,23 @@ impl UpdateOutcome {
             marketplace: "github".to_string(),
             status: UpdateStatus::Skipped { reason },
             error: None,
+            deployed_targets: vec![],
+            failed_targets: vec![],
+        }
+    }
+
+    /// ロールバック済み（バッチ失敗により更新前へ巻き戻された）
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - Plugin name.
+    /// * `note` - 任意の補足（restore 失敗時の警告など）。None なら error なし。
+    pub fn rolled_back(name: &str, note: Option<String>) -> Self {
+        Self {
+            plugin_name: name.to_string(),
+            marketplace: "github".to_string(),
+            status: UpdateStatus::RolledBack,
+            error: note,
             deployed_targets: vec![],
             failed_targets: vec![],
         }
@@ -580,10 +600,73 @@ fn redeploy_to_targets(
     (deployed, failed)
 }
 
-/// 全プラグインの一括更新
+/// marketplace 解決の抽象（テストで差し替え可能にする）
+pub(crate) trait MarketplaceResolver {
+    /// 指定 marketplace の MarketplaceCache を返す（無ければ None）
+    fn resolve(&self, marketplace: &str) -> Result<Option<MarketplaceCache>>;
+}
+
+/// 本番実装: registry を 1 度だけロードして保持し、以降の resolve はキャッシュ参照のみ。
+///
+/// `MarketplaceRegistry::new()` 失敗時は registry を None とし、resolve は常に None を返す
+/// （= 現行 `update_all_plugins` の「registry ロード失敗は警告して続行」挙動と同一）。
+pub(crate) struct RegistryResolver {
+    registry: Option<MarketplaceRegistry>,
+}
+
+impl RegistryResolver {
+    pub(crate) fn new() -> Self {
+        match MarketplaceRegistry::new() {
+            Ok(r) => Self { registry: Some(r) },
+            Err(e) => {
+                eprintln!("Warning: Failed to load marketplace registry: {}", e);
+                Self { registry: None }
+            }
+        }
+    }
+}
+
+impl MarketplaceResolver for RegistryResolver {
+    fn resolve(&self, marketplace: &str) -> Result<Option<MarketplaceCache>> {
+        match &self.registry {
+            Some(r) => r.get(marketplace),
+            None => Ok(None),
+        }
+    }
+}
+
+/// CHECK フェーズで確定した「更新すべき対象」1 件分
+struct UpdateTarget {
+    marketplace: Option<String>,
+    cache_id: String,
+    display_name: String,
+    repo: Repo,
+    source_path: Option<String>,
+    old_meta: PluginMeta,
+    git_ref: String,
+}
+
+/// PREPARE 成功後の staging 済み 1 件分
+struct StagedUpdate {
+    target: UpdateTarget,
+    archive_sha: String,
+}
+
+/// prepare の集約結果
+enum PrepareOutcome {
+    /// 全件 staging + backup 成功
+    AllStaged(Vec<StagedUpdate>),
+    /// 1 件失敗。本番は非改変、staging/backup は破棄済み。
+    /// 失敗・スキップした全 plugin の UpdateOutcome を含む。
+    Aborted(Vec<UpdateOutcome>),
+}
+
+/// 全プラグインの一括更新（all-or-nothing バッチアトミック）
 ///
 /// キャッシュ内の全プラグイン（直接 GitHub / marketplace 経由）を走査し、
-/// 各プラグインの commit SHA を比較して差分があるものを更新する。
+/// 各プラグインの commit SHA を比較して差分があるものを 2 フェーズ（prepare → commit）で更新する。
+/// prepare 中に 1 件でも失敗したら本番を一切改変せず、commit(swap) 中に失敗したら
+/// swap 済みを含め全件を更新前へロールバックする。
 ///
 /// # Arguments
 ///
@@ -592,6 +675,27 @@ fn redeploy_to_targets(
 /// * `target_filter` - When `Some`, only redeploy to this single target.
 pub async fn update_all_plugins(
     cache: &dyn PackageCacheAccess,
+    project_root: &Path,
+    target_filter: Option<&str>,
+) -> Vec<UpdateOutcome> {
+    let factory = HostClientFactory::with_defaults();
+    let client = factory.create(HostKind::GitHub);
+    let resolver = RegistryResolver::new();
+    update_all_plugins_with_deps(
+        cache,
+        client.as_ref(),
+        &resolver,
+        project_root,
+        target_filter,
+    )
+    .await
+}
+
+/// 依存注入版本体（テストから直接呼ぶ）
+pub(crate) async fn update_all_plugins_with_deps(
+    cache: &dyn PackageCacheAccess,
+    client: &dyn HostClient,
+    resolver: &dyn MarketplaceResolver,
     project_root: &Path,
     target_filter: Option<&str>,
 ) -> Vec<UpdateOutcome> {
@@ -609,169 +713,30 @@ pub async fn update_all_plugins(
     }
 
     println!("Checking for updates...");
-    let factory = HostClientFactory::with_defaults();
-    let client = factory.create(HostKind::GitHub);
 
-    // marketplace 別に MarketplaceCache を 1 度だけロード
-    let registry = match MarketplaceRegistry::new() {
-        Ok(r) => Some(r),
-        Err(e) => {
-            eprintln!("Warning: Failed to load marketplace registry: {}", e);
-            None
-        }
-    };
-
+    // marketplace 別に MarketplaceCache を 1 度だけ解決
     let mut mp_caches: std::collections::HashMap<String, MarketplaceCache> =
         std::collections::HashMap::new();
-    if let Some(reg) = &registry {
-        let unique_markets: std::collections::HashSet<String> = plugins
-            .iter()
-            .filter_map(|(m, _)| m.clone())
-            .filter(|m| m != "github")
-            .collect();
-        for m in unique_markets {
-            if let Ok(Some(c)) = reg.get(&m) {
-                mp_caches.insert(m, c);
-            }
+    let unique_markets: std::collections::HashSet<String> = plugins
+        .iter()
+        .filter_map(|(m, _)| m.clone())
+        .filter(|m| m != "github")
+        .collect();
+    for m in unique_markets {
+        if let Ok(Some(c)) = resolver.resolve(&m) {
+            mp_caches.insert(m, c);
         }
     }
 
-    let mut results = Vec::new();
-    let mut up_to_date_count = 0usize;
-    let mut error_count = 0usize;
-    let mut updates_to_do: Vec<(Option<String>, String, String, ResolvedPlugin)> = Vec::new();
+    // CHECK フェーズ: 更新が必要な対象（targets）と、確定済み結果（up_to_date/skipped）を構築
+    let CheckOutcome {
+        targets,
+        mut results,
+        up_to_date_count,
+        error_count,
+    } = check_all(cache, client, &plugins, &mp_caches).await;
 
-    for (marketplace, cache_id) in &plugins {
-        let plugin_path = cache.plugin_path(marketplace.as_deref(), cache_id);
-        let pkg = match cache.load_package(marketplace.as_deref(), cache_id) {
-            Ok(p) => p,
-            Err(e) => {
-                error_count += 1;
-                eprintln!("  {}: Failed to load ({})", cache_id, e);
-                continue;
-            }
-        };
-        let display_name = pkg.name.clone();
-        let plugin_meta = meta::load_meta(&plugin_path).unwrap_or_default();
-
-        // marketplace 経由 plugin
-        if let Some(market) = marketplace.as_deref() {
-            if market == "github" {
-                // 直接 GitHub install
-                let result =
-                    check_github_remote(&*client, &plugin_meta, cache_id, &display_name).await;
-                match result {
-                    RemoteCheck::UpToDate => {
-                        up_to_date_count += 1;
-                        results.push(UpdateOutcome::up_to_date(&display_name));
-                    }
-                    RemoteCheck::NeedsUpdate(latest) => {
-                        let resolved = ResolvedPlugin {
-                            marketplace: marketplace.clone(),
-                            cache_id: cache_id.clone(),
-                            display_name: display_name.clone(),
-                            package: pkg,
-                            package_meta: plugin_meta,
-                        };
-                        updates_to_do.push((
-                            marketplace.clone(),
-                            cache_id.clone(),
-                            latest,
-                            resolved,
-                        ));
-                    }
-                    RemoteCheck::Failed(msg) => {
-                        error_count += 1;
-                        eprintln!("  {}: Failed to check ({})", display_name, msg);
-                    }
-                    RemoteCheck::Skipped(_reason) => {
-                        // GitHub 以外はあり得ないが念のため
-                    }
-                }
-                continue;
-            }
-
-            let mp_cache = match mp_caches.get(market) {
-                Some(c) => c,
-                None => {
-                    error_count += 1;
-                    eprintln!("  {}: Marketplace not found: {}", display_name, market);
-                    continue;
-                }
-            };
-            let entry = match mp_cache.plugins.iter().find(|p| p.name == *cache_id) {
-                Some(e) => e,
-                None => {
-                    // marketplace から消えたものは up_to_date 扱い
-                    up_to_date_count += 1;
-                    results.push(UpdateOutcome::up_to_date(&display_name));
-                    continue;
-                }
-            };
-            let git_ref = plugin_meta.git_ref.as_deref().unwrap_or("HEAD");
-            let repo =
-                match parse_repo_from_mp_source(&mp_cache.source, &entry.source, Some(git_ref)) {
-                    Ok(r) => r,
-                    Err(e) => {
-                        error_count += 1;
-                        eprintln!("  {}: {}", display_name, e);
-                        continue;
-                    }
-                };
-            let latest_sha = match with_retry(|| client.get_commit_sha(&repo, git_ref), 3).await {
-                Ok(s) => s,
-                Err(e) => {
-                    error_count += 1;
-                    eprintln!("  {}: Failed to check ({})", display_name, e);
-                    continue;
-                }
-            };
-
-            if !needs_update(plugin_meta.commit_sha.as_deref(), &latest_sha) {
-                up_to_date_count += 1;
-                results.push(UpdateOutcome::up_to_date(&display_name));
-                continue;
-            }
-
-            let resolved = ResolvedPlugin {
-                marketplace: marketplace.clone(),
-                cache_id: cache_id.clone(),
-                display_name: display_name.clone(),
-                package: pkg,
-                package_meta: plugin_meta,
-            };
-            updates_to_do.push((marketplace.clone(), cache_id.clone(), latest_sha, resolved));
-            continue;
-        }
-
-        // marketplace == None 経路
-        let result = check_github_remote(&*client, &plugin_meta, cache_id, &display_name).await;
-        match result {
-            RemoteCheck::UpToDate => {
-                up_to_date_count += 1;
-                results.push(UpdateOutcome::up_to_date(&display_name));
-            }
-            RemoteCheck::NeedsUpdate(latest) => {
-                let resolved = ResolvedPlugin {
-                    marketplace: None,
-                    cache_id: cache_id.clone(),
-                    display_name: display_name.clone(),
-                    package: pkg,
-                    package_meta: plugin_meta,
-                };
-                updates_to_do.push((None, cache_id.clone(), latest, resolved));
-            }
-            RemoteCheck::Skipped(reason) => {
-                results.push(UpdateOutcome::skipped(&display_name, reason));
-            }
-            RemoteCheck::Failed(msg) => {
-                error_count += 1;
-                eprintln!("  {}: Failed to check ({})", display_name, msg);
-            }
-        }
-    }
-
-    let update_count = updates_to_do.len();
+    let update_count = targets.len();
 
     if update_count == 0 {
         println!(
@@ -797,69 +762,330 @@ pub async fn update_all_plugins(
         }
     );
 
-    for (idx, (marketplace, _cache_id, _latest, resolved)) in updates_to_do.into_iter().enumerate()
-    {
-        println!(
-            "\n[{}/{}] Updating {}...",
-            idx + 1,
-            update_count,
-            resolved.display_name
-        );
-
-        let result = if let Some(market) = marketplace.as_deref() {
-            update_marketplace_plugin(cache, market, &resolved, project_root, target_filter).await
-        } else {
-            update_github_plugin(cache, &resolved, project_root, target_filter).await
-        };
-
-        match &result.status {
-            UpdateStatus::Updated { from_sha, to_sha } => {
-                let from = from_sha.as_deref().unwrap_or("unknown");
-                println!("  Updated: {} -> {}", from, to_sha);
-            }
-            UpdateStatus::Failed => {
-                if let Some(e) = &result.error {
-                    eprintln!("  Error: {}", e);
-                }
-            }
-            _ => {}
+    // PREPARE フェーズ（本番非破壊）
+    match prepare_all(cache, client, targets).await {
+        PrepareOutcome::AllStaged(staged) => {
+            // COMMIT フェーズ（swap → redeploy → meta、swap 失敗で ROLLBACK）
+            results.extend(commit_all(cache, staged, project_root, target_filter));
         }
-        results.push(result);
+        PrepareOutcome::Aborted(failures) => {
+            // prepare 失敗: 本番非改変。staged/未到達は RolledBack、当該は Failed。
+            results.extend(failures);
+        }
     }
 
     results
 }
 
-enum RemoteCheck {
-    UpToDate,
-    NeedsUpdate(String),
-    Skipped(String),
-    Failed(String),
+/// CHECK フェーズの集約結果
+struct CheckOutcome {
+    /// 更新が必要な対象
+    targets: Vec<UpdateTarget>,
+    /// 確定済み結果（up_to_date / skipped）。CHECK で弾かれた対象を含む。
+    results: Vec<UpdateOutcome>,
+    /// 最新だった件数（メッセージ表示用）
+    up_to_date_count: usize,
+    /// CHECK 中に load/解決/SHA 取得が失敗しスキップした件数（結果には含めない＝従来挙動）
+    error_count: usize,
 }
 
-async fn check_github_remote(
+/// CHECK: 全 plugin を走査し、SHA 比較で更新が必要な対象を `UpdateTarget` に確定する。
+///
+/// marketplace 経由（`market != "github"`）と直接 GitHub（`None` または `"github"`）の 2 経路で
+/// `repo` / `source_path` の解決方法のみが異なり、SHA 比較・`UpdateTarget` 構築の末尾処理は共通化する。
+/// CHECK で `get_commit_sha` 等が失敗した plugin は従来どおり `error_count` でスキップし、
+/// 他対象のアトミック処理の引き金にはしない。
+async fn check_all(
+    cache: &dyn PackageCacheAccess,
     client: &dyn HostClient,
-    plugin_meta: &PluginMeta,
-    cache_id: &str,
-    display_name: &str,
-) -> RemoteCheck {
-    if !plugin_meta.is_github() {
-        return RemoteCheck::Skipped("Not a GitHub plugin".to_string());
+    plugins: &[(Option<String>, String)],
+    mp_caches: &std::collections::HashMap<String, MarketplaceCache>,
+) -> CheckOutcome {
+    let mut results = Vec::new();
+    let mut up_to_date_count = 0usize;
+    let mut error_count = 0usize;
+    let mut targets: Vec<UpdateTarget> = Vec::new();
+
+    for (marketplace, cache_id) in plugins {
+        let plugin_path = cache.plugin_path(marketplace.as_deref(), cache_id);
+        let pkg = match cache.load_package(marketplace.as_deref(), cache_id) {
+            Ok(p) => p,
+            Err(e) => {
+                error_count += 1;
+                eprintln!("  {}: Failed to load ({})", cache_id, e);
+                continue;
+            }
+        };
+        let display_name = pkg.name.clone();
+        let plugin_meta = meta::load_meta(&plugin_path).unwrap_or_default();
+        let git_ref = plugin_meta.git_ref.as_deref().unwrap_or("HEAD");
+
+        // 経路ごとに repo / source_path を解決（早期 continue で skip / up_to_date / error を確定）
+        let (repo, source_path) = if let Some(market) =
+            marketplace.as_deref().filter(|m| *m != "github")
+        {
+            // marketplace 経由
+            let mp_cache = match mp_caches.get(market) {
+                Some(c) => c,
+                None => {
+                    error_count += 1;
+                    eprintln!("  {}: Marketplace not found: {}", display_name, market);
+                    continue;
+                }
+            };
+            let entry = match mp_cache.plugins.iter().find(|p| p.name == *cache_id) {
+                Some(e) => e,
+                None => {
+                    // marketplace から消えたものは up_to_date 扱い
+                    up_to_date_count += 1;
+                    results.push(UpdateOutcome::up_to_date(&display_name));
+                    continue;
+                }
+            };
+            let repo =
+                match parse_repo_from_mp_source(&mp_cache.source, &entry.source, Some(git_ref)) {
+                    Ok(r) => r,
+                    Err(e) => {
+                        error_count += 1;
+                        eprintln!("  {}: {}", display_name, e);
+                        continue;
+                    }
+                };
+            let source_path = match &entry.source {
+                MpPluginSource::Local(p) => Some(p.clone()),
+                MpPluginSource::External { .. } => None,
+            };
+            (repo, source_path)
+        } else {
+            // 直接 GitHub 経路（marketplace == None もしくは "github"）
+            if !plugin_meta.is_github() {
+                results.push(UpdateOutcome::skipped(
+                    &display_name,
+                    "Not a GitHub plugin".to_string(),
+                ));
+                continue;
+            }
+            let repo = match restore_repo(&plugin_meta, cache_id, git_ref) {
+                Ok(r) => r,
+                Err(e) => {
+                    error_count += 1;
+                    eprintln!("  {}: Failed to check ({})", display_name, e);
+                    continue;
+                }
+            };
+            (repo, None)
+        };
+
+        // 共通末尾: SHA 取得 → needs_update 判定 → UpdateTarget 構築
+        let latest_sha = match with_retry(|| client.get_commit_sha(&repo, git_ref), 3).await {
+            Ok(s) => s,
+            Err(e) => {
+                error_count += 1;
+                eprintln!("  {}: Failed to check ({})", display_name, e);
+                continue;
+            }
+        };
+        if !needs_update(plugin_meta.commit_sha.as_deref(), &latest_sha) {
+            up_to_date_count += 1;
+            results.push(UpdateOutcome::up_to_date(&display_name));
+            continue;
+        }
+        let git_ref_owned = git_ref.to_string();
+        targets.push(UpdateTarget {
+            marketplace: marketplace.clone(),
+            cache_id: cache_id.clone(),
+            display_name,
+            repo,
+            source_path,
+            old_meta: plugin_meta,
+            git_ref: git_ref_owned,
+        });
     }
-    let git_ref = plugin_meta.git_ref.as_deref().unwrap_or("HEAD");
-    let repo = match restore_repo(plugin_meta, cache_id, git_ref) {
-        Ok(r) => r,
-        Err(e) => return RemoteCheck::Failed(e),
-    };
-    let latest_sha = match with_retry(|| client.get_commit_sha(&repo, git_ref), 3).await {
-        Ok(s) => s,
-        Err(e) => return RemoteCheck::Failed(e.to_string()),
-    };
-    if !needs_update(plugin_meta.commit_sha.as_deref(), &latest_sha) {
-        let _ = display_name;
-        return RemoteCheck::UpToDate;
+
+    CheckOutcome {
+        targets,
+        results,
+        up_to_date_count,
+        error_count,
     }
-    RemoteCheck::NeedsUpdate(latest_sha)
+}
+
+/// PREPARE: 全件 backup + download + stage + 検証（本番非破壊）
+///
+/// 1 件でも失敗したら、それまでの staging/backup を全破棄して Aborted を返す。
+async fn prepare_all(
+    cache: &dyn PackageCacheAccess,
+    client: &dyn HostClient,
+    targets: Vec<UpdateTarget>,
+) -> PrepareOutcome {
+    let mut staged: Vec<StagedUpdate> = Vec::new();
+    // 失敗時に「未到達の残り対象」を拾えるよう iterator を保持する。
+    let mut iter = targets.into_iter();
+    while let Some(target) = iter.next() {
+        let mp = target.marketplace.as_deref();
+        // 1. backup
+        if let Err(e) = cache.backup(mp, &target.cache_id) {
+            let failure = failed_for(&target, format!("Backup failed: {}", e));
+            return abort(cache, staged, failure, iter);
+        }
+        // 2. download（本番非破壊）
+        let (archive, _ref, archive_sha) =
+            match with_retry(|| client.download_archive_with_sha(&target.repo), 3).await {
+                Ok(t) => t,
+                Err(e) => {
+                    let _ = cache.remove_backup(mp, &target.cache_id);
+                    let failure = failed_for(&target, format!("Download failed: {}", e));
+                    return abort(cache, staged, failure, iter);
+                }
+            };
+        // 3. stage（temp 展開 + plugin.json 検証, swap しない）
+        if let Err(e) = cache.stage_from_archive(
+            mp,
+            &target.cache_id,
+            &archive,
+            target.source_path.as_deref(),
+        ) {
+            let _ = cache.remove_backup(mp, &target.cache_id);
+            let failure = failed_for(&target, format!("Staging failed: {}", e));
+            return abort(cache, staged, failure, iter);
+        }
+        staged.push(StagedUpdate {
+            target,
+            archive_sha,
+        });
+    }
+    PrepareOutcome::AllStaged(staged)
+}
+
+/// 単一 UpdateTarget から失敗の UpdateOutcome を作る
+fn failed_for(target: &UpdateTarget, msg: String) -> UpdateOutcome {
+    UpdateOutcome::failed(&target.display_name, msg)
+}
+
+/// abort: それまでの staged 全件の staging/backup を破棄し、本番は触らずに失敗結果を返す。
+///
+/// `remaining`（失敗点より後ろの未到達対象）も「本番未改変のまま据え置き」＝ RolledBack として
+/// 結果に必ず含める。これにより「1 プラグイン = 1 UpdateOutcome」「全件が結果に出る」不変条件を保つ。
+fn abort(
+    cache: &dyn PackageCacheAccess,
+    staged: Vec<StagedUpdate>,
+    failure: UpdateOutcome,
+    remaining: impl Iterator<Item = UpdateTarget>,
+) -> PrepareOutcome {
+    let mut results = Vec::new();
+    // すでに staging 済み（本来成功予定）→ RolledBack
+    for s in &staged {
+        let mp = s.target.marketplace.as_deref();
+        let _ = cache.discard_staged(mp, &s.target.cache_id);
+        let _ = cache.remove_backup(mp, &s.target.cache_id);
+        results.push(UpdateOutcome::rolled_back(&s.target.display_name, None));
+    }
+    // 失敗した当該プラグイン → Failed
+    results.push(failure);
+    // 未到達の残り対象（本番未改変・更新前のまま）→ RolledBack
+    for t in remaining {
+        results.push(UpdateOutcome::rolled_back(&t.display_name, None));
+    }
+    PrepareOutcome::Aborted(results)
+}
+
+/// COMMIT: 全件 swap → redeploy → meta。swap 中失敗で ROLLBACK。
+fn commit_all(
+    cache: &dyn PackageCacheAccess,
+    staged: Vec<StagedUpdate>,
+    project_root: &Path,
+    target_filter: Option<&str>,
+) -> Vec<UpdateOutcome> {
+    let mut results: Vec<UpdateOutcome> = Vec::new();
+
+    for (idx, s) in staged.iter().enumerate() {
+        let mp = s.target.marketplace.as_deref();
+        // 4. swap（本番差し替え）
+        let plugin_path = match cache.commit_staged(mp, &s.target.cache_id) {
+            Ok(p) => p,
+            Err(e) => {
+                // swap 失敗 → ROLLBACK（既 swap 分 + 当該 + 未 swap 残り全件）
+                // 当該は staged 内インデックスで識別する（cache_id 文字列は
+                // 別 marketplace 間で衝突し得るため使わない）。
+                return rollback_all(cache, &staged, idx, e);
+            }
+        };
+
+        // 5. redeploy（非アトミック: 失敗 target は disabled）
+        let enabled = s.target.old_meta.enabled_targets();
+        let targets: Vec<&str> = match target_filter {
+            Some(f) => enabled.into_iter().filter(|t| *t == f).collect(),
+            None => enabled,
+        };
+        let (deployed, failed) =
+            redeploy_to_targets(cache, &s.target.cache_id, mp, &targets, project_root);
+
+        // 6. meta 更新（best-effort。アトミック境界は swap までのため失敗しても巻き戻さない）
+        let mut new_meta = s.target.old_meta.clone();
+        new_meta.set_git_info(&s.target.git_ref, &s.archive_sha);
+        for t in &failed {
+            new_meta.set_status(t, "disabled");
+        }
+        let _ = meta::write_meta(&plugin_path, &new_meta);
+
+        results.push(UpdateOutcome::updated(
+            &s.target.display_name,
+            s.target.old_meta.commit_sha.clone(),
+            s.archive_sha.clone(),
+            deployed,
+            failed,
+        ));
+    }
+
+    // 全件 swap 成功 → backup 確定削除
+    for s in &staged {
+        let mp = s.target.marketplace.as_deref();
+        let _ = cache.remove_backup(mp, &s.target.cache_id);
+    }
+    results
+}
+
+/// ROLLBACK: swap 済み全件 + 未 swap 残り全件を backup から restore する。
+///
+/// restore 失敗は警告として該当 outcome の error に載せる（部分復元失敗）。
+/// `failed_idx` は swap に失敗した当該プラグインの `staged` 内インデックス。当該は restore
+/// （部分 swap の巻き戻しのため restore 自体は必要）しつつ、結果は `Failed` のみを 1 件 push する。
+/// `staged` 全件を単一パスで走査し、インデックス一致で当該を識別することで、
+/// 別 marketplace 間の同名 cache_id 衝突による二重計上を防ぐ。
+fn rollback_all(
+    cache: &dyn PackageCacheAccess,
+    staged: &[StagedUpdate],
+    failed_idx: usize,
+    cause: PlmError,
+) -> Vec<UpdateOutcome> {
+    let mut results = Vec::new();
+    for (idx, s) in staged.iter().enumerate() {
+        let mp = s.target.marketplace.as_deref();
+        let restored = cache.restore(mp, &s.target.cache_id);
+        // 未 swap 分に残る staging temp も掃除（既 swap 分は commit_staged で temp 消費済み）
+        let _ = cache.discard_staged(mp, &s.target.cache_id);
+
+        if idx == failed_idx {
+            // 当該（swap 失敗）は Failed のみ。restore 結果は警告として error に併記。
+            let msg = match restored {
+                Ok(()) => format!("Commit (swap) failed: {}", cause),
+                Err(e) => format!(
+                    "Commit (swap) failed: {} (WARNING: restore also failed: {})",
+                    cause, e
+                ),
+            };
+            results.push(UpdateOutcome::failed(&s.target.display_name, msg));
+        } else {
+            results.push(match restored {
+                Ok(()) => UpdateOutcome::rolled_back(&s.target.display_name, None),
+                Err(e) => UpdateOutcome::rolled_back(
+                    &s.target.display_name,
+                    Some(format!("WARNING: restore failed: {}", e)),
+                ),
+            });
+        }
+    }
+    results
 }
 
 #[cfg(test)]

--- a/src/plugin/lifecycle/update.rs
+++ b/src/plugin/lifecycle/update.rs
@@ -1044,7 +1044,16 @@ fn commit_all(
         for t in &failed {
             new_meta.set_status(t, "disabled");
         }
-        let _ = meta::write_meta(&plugin_path, &new_meta);
+        // best-effort: 失敗してもロールバックしない（アトミック境界は swap まで）が、
+        // commit SHA がメタに反映されない不整合を無言にしないよう警告する。
+        // 次回 update の check_all で archive_sha 比較により収束する。
+        if let Err(e) = meta::write_meta(&plugin_path, &new_meta) {
+            eprintln!(
+                "Warning: Failed to write metadata for '{}': {} \
+                 (cache already updated; will reconcile on next update)",
+                s.target.display_name, e
+            );
+        }
 
         results.push(UpdateOutcome::updated(
             &s.target.display_name,

--- a/src/plugin/lifecycle/update.rs
+++ b/src/plugin/lifecycle/update.rs
@@ -1056,11 +1056,14 @@ fn commit_all(
         }
         // best-effort: 失敗してもロールバックしない（アトミック境界は swap まで）が、
         // commit SHA がメタに反映されない不整合を無言にしないよう警告する。
-        // 次回 update の check_all で archive_sha 比較により収束する。
+        // check_all は meta の commit_sha とリモート SHA を比較して更新要否を判定するため、
+        // ここで write_meta が失敗すると commit_sha が旧値のまま残り、次回 update で
+        // 当該プラグインは再び更新対象として処理される（=自動収束ではなく再ダウンロード・再 swap）。
         if let Err(e) = meta::write_meta(&plugin_path, &new_meta) {
             eprintln!(
                 "Warning: Failed to write metadata for '{}': {} \
-                 (cache already updated; will reconcile on next update)",
+                 (cache already updated, but commit_sha was not persisted; \
+                 the plugin will be re-updated on the next run)",
                 s.target.display_name, e
             );
         }

--- a/src/plugin/lifecycle/update.rs
+++ b/src/plugin/lifecycle/update.rs
@@ -910,6 +910,24 @@ async fn check_all(
     }
 }
 
+/// best-effort で backup を削除する。失敗してもバッチは継続するが、
+/// `.backup` 残骸を放置して無言にしないよう警告を出す（運用者が部分クリーンアップを検知できる）。
+fn cleanup_backup(cache: &dyn PackageCacheAccess, marketplace: Option<&str>, name: &str) {
+    if let Err(e) = cache.remove_backup(marketplace, name) {
+        eprintln!("Warning: Failed to remove backup for '{}': {}", name, e);
+    }
+}
+
+/// best-effort で staging temp を破棄する。失敗時は `.temp` 残骸を無言にしないよう警告を出す。
+fn cleanup_staged(cache: &dyn PackageCacheAccess, marketplace: Option<&str>, name: &str) {
+    if let Err(e) = cache.discard_staged(marketplace, name) {
+        eprintln!(
+            "Warning: Failed to discard staged update for '{}': {}",
+            name, e
+        );
+    }
+}
+
 /// PREPARE: 全件 backup + download + stage + 検証（本番非破壊）
 ///
 /// 1 件でも失敗したら、それまでの staging/backup を全破棄して Aborted を返す。
@@ -933,7 +951,7 @@ async fn prepare_all(
             match with_retry(|| client.download_archive_with_sha(&target.repo), 3).await {
                 Ok(t) => t,
                 Err(e) => {
-                    let _ = cache.remove_backup(mp, &target.cache_id);
+                    cleanup_backup(cache, mp, &target.cache_id);
                     let failure = failed_for(&target, format!("Download failed: {}", e));
                     return abort(cache, staged, failure, iter);
                 }
@@ -945,7 +963,7 @@ async fn prepare_all(
             &archive,
             target.source_path.as_deref(),
         ) {
-            let _ = cache.remove_backup(mp, &target.cache_id);
+            cleanup_backup(cache, mp, &target.cache_id);
             let failure = failed_for(&target, format!("Staging failed: {}", e));
             return abort(cache, staged, failure, iter);
         }
@@ -976,8 +994,8 @@ fn abort(
     // すでに staging 済み（本来成功予定）→ RolledBack
     for s in &staged {
         let mp = s.target.marketplace.as_deref();
-        let _ = cache.discard_staged(mp, &s.target.cache_id);
-        let _ = cache.remove_backup(mp, &s.target.cache_id);
+        cleanup_staged(cache, mp, &s.target.cache_id);
+        cleanup_backup(cache, mp, &s.target.cache_id);
         results.push(UpdateOutcome::rolled_back(&s.target.display_name, None));
     }
     // 失敗した当該プラグイン → Failed
@@ -1040,7 +1058,7 @@ fn commit_all(
     // 全件 swap 成功 → backup 確定削除
     for s in &staged {
         let mp = s.target.marketplace.as_deref();
-        let _ = cache.remove_backup(mp, &s.target.cache_id);
+        cleanup_backup(cache, mp, &s.target.cache_id);
     }
     results
 }
@@ -1063,7 +1081,7 @@ fn rollback_all(
         let mp = s.target.marketplace.as_deref();
         let restored = cache.restore(mp, &s.target.cache_id);
         // 未 swap 分に残る staging temp も掃除（既 swap 分は commit_staged で temp 消費済み）
-        let _ = cache.discard_staged(mp, &s.target.cache_id);
+        cleanup_staged(cache, mp, &s.target.cache_id);
 
         if idx == failed_idx {
             // 当該（swap 失敗）は Failed のみ。restore 結果は警告として error に併記。

--- a/src/plugin/lifecycle/update.rs
+++ b/src/plugin/lifecycle/update.rs
@@ -1085,13 +1085,20 @@ fn commit_all(
     results
 }
 
-/// ROLLBACK: swap 済み全件 + 未 swap 残り全件を backup から restore する。
+/// ROLLBACK: `commit_all` の Phase 1（swap）で失敗したときに、本番キャッシュを更新前へ戻す。
+///
+/// `commit_all` は最初の `commit_staged` 失敗で即 return するため、`staged` を `failed_idx` 基準に
+/// 3 区分で扱う:
+/// - `idx < failed_idx`: swap 済み → backup から restore（巻き戻し）。RolledBack。
+/// - `idx == failed_idx`: swap に失敗した当該。swap が途中まで進んで本番を壊している可能性が
+///   あるため restore する。結果は `Failed` のみ 1 件（二重計上しない）。
+/// - `idx > failed_idx`: swap 未実施で本番は無改変。`restore()` は本番を一度削除してから backup を
+///   複製するため、無改変のプラグインに対して呼ぶと複製失敗時にかえって壊しうる。よって restore せず
+///   staging temp と backup の後始末のみ行う。RolledBack。
 ///
 /// restore 失敗は警告として該当 outcome の error に載せる（部分復元失敗）。
-/// `failed_idx` は swap に失敗した当該プラグインの `staged` 内インデックス。当該は restore
-/// （部分 swap の巻き戻しのため restore 自体は必要）しつつ、結果は `Failed` のみを 1 件 push する。
-/// `staged` 全件を単一パスで走査し、インデックス一致で当該を識別することで、
-/// 別 marketplace 間の同名 cache_id 衝突による二重計上を防ぐ。
+/// インデックス一致で当該を識別することで、別 marketplace 間の同名 cache_id 衝突による
+/// 二重計上を防ぐ。
 fn rollback_all(
     cache: &dyn PackageCacheAccess,
     staged: &[StagedUpdate],
@@ -1101,8 +1108,19 @@ fn rollback_all(
     let mut results = Vec::new();
     for (idx, s) in staged.iter().enumerate() {
         let mp = s.target.marketplace.as_deref();
+
+        if idx > failed_idx {
+            // swap 未実施・本番無改変 → restore せず後始末のみ（無改変ディレクトリを
+            // restore の delete→copy で壊さない）。
+            cleanup_staged(cache, mp, &s.target.cache_id);
+            cleanup_backup(cache, mp, &s.target.cache_id);
+            results.push(UpdateOutcome::rolled_back(&s.target.display_name, None));
+            continue;
+        }
+
+        // idx <= failed_idx: swap 済み、または swap 途中で失敗した当該 → backup から restore。
         let restored = cache.restore(mp, &s.target.cache_id);
-        // 未 swap 分に残る staging temp も掃除（既 swap 分は commit_staged で temp 消費済み）
+        // swap 途中失敗の当該に temp が残っている場合に備えて掃除（既 swap 分は consume 済み）。
         cleanup_staged(cache, mp, &s.target.cache_id);
 
         if idx == failed_idx {

--- a/src/plugin/lifecycle/update_test.rs
+++ b/src/plugin/lifecycle/update_test.rs
@@ -79,6 +79,7 @@ mod batch {
     use std::future::Future;
     use std::path::{Path, PathBuf};
     use std::pin::Pin;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use tempfile::TempDir;
 
     const OLD_SHA: &str = "oldsha";
@@ -401,6 +402,11 @@ mod batch {
         fail_restore: HashSet<String>,
         fail_commit_keyed: HashSet<String>,
         fail_restore_keyed: HashSet<String>,
+        /// N 番目（1 始まり）の commit_staged 呼び出しを失敗させる（0 = 無効）。
+        /// cache.list() の順序が非決定的なテストで「先に swap 成功した 1 件＋次で失敗」を
+        /// プラグイン名に依存せず再現するために使う。
+        fail_commit_nth: usize,
+        commit_calls: AtomicUsize,
     }
 
     impl FaultyCache {
@@ -411,6 +417,8 @@ mod batch {
                 fail_restore: HashSet::new(),
                 fail_commit_keyed: HashSet::new(),
                 fail_restore_keyed: HashSet::new(),
+                fail_commit_nth: 0,
+                commit_calls: AtomicUsize::new(0),
             }
         }
 
@@ -494,10 +502,12 @@ mod batch {
                 .stage_from_archive(marketplace, name, archive, source_path)
         }
         fn commit_staged(&self, marketplace: Option<&str>, name: &str) -> Result<PathBuf> {
+            let call = self.commit_calls.fetch_add(1, Ordering::SeqCst) + 1;
             if self.fail_commit.contains(name)
                 || self
                     .fail_commit_keyed
                     .contains(&Self::key(marketplace, name))
+                || (self.fail_commit_nth != 0 && self.fail_commit_nth == call)
             {
                 return Err(PlmError::Cache("injected commit failure".to_string()));
             }
@@ -752,27 +762,98 @@ mod batch {
 
     #[tokio::test]
     async fn test_rollback_restore_failure_warns() {
+        // swap 済み（RolledBack 予定）のプラグインの restore が失敗したら警告が outcome に載る。
+        // cache.list() の順序は非決定的なため、「2 番目の swap を失敗」させることで
+        // 「1 件目=swap 成功（後で restore 失敗）/ 2 件目=swap 失敗」をプラグイン名に依存せず再現する。
         let tmp = TempDir::new().unwrap();
         let cache_dir = tmp.path().to_path_buf();
         for id in ["repoA", "repoB"] {
             setup_plugin(&cache_dir, id, OLD_SHA, &[]);
         }
         let mut cache = FaultyCache::new(cache_dir.clone());
-        cache.fail_commit.insert("repoB".to_string());
-        // RolledBack 予定の repoA の restore を失敗させる
+        cache.fail_commit_nth = 2; // 2 番目の swap を失敗 → 1 番目は swap 済み
         cache.fail_restore.insert("repoA".to_string());
+        cache.fail_restore.insert("repoB".to_string()); // どちらが swap 済みでも restore 失敗
         let client = MockBatchClient::new();
         let resolver = NoMarketplaces;
 
         let results =
             update_all_plugins_with_deps(&cache, &client, &resolver, tmp.path(), None).await;
 
-        let a = find(&results, "repoA");
-        assert!(matches!(a.status, UpdateStatus::RolledBack));
+        assert_eq!(results.len(), 2);
+        // 1 件目（swap 済み）→ RolledBack + restore 失敗の警告
+        let rolled: Vec<&UpdateOutcome> = results
+            .iter()
+            .filter(|r| matches!(r.status, UpdateStatus::RolledBack))
+            .collect();
+        assert_eq!(rolled.len(), 1);
         assert!(
-            a.error.as_deref().unwrap_or("").contains("restore failed"),
-            "expected restore warning, got {:?}",
-            a.error
+            rolled[0]
+                .error
+                .as_deref()
+                .unwrap_or("")
+                .contains("restore failed"),
+            "expected restore warning on rolled-back plugin, got {:?}",
+            rolled[0].error
+        );
+        // 2 件目（swap 失敗）→ Failed（restore も失敗するため併記される）
+        let failed: Vec<&UpdateOutcome> = results
+            .iter()
+            .filter(|r| matches!(r.status, UpdateStatus::Failed))
+            .collect();
+        assert_eq!(failed.len(), 1);
+        assert!(
+            failed[0]
+                .error
+                .as_deref()
+                .unwrap_or("")
+                .contains("restore also failed"),
+            "expected combined warning on failed plugin, got {:?}",
+            failed[0].error
+        );
+    }
+
+    #[tokio::test]
+    async fn test_rollback_skips_restore_for_unswapped_plugins() {
+        // review 指摘: swap 未実施（idx > failed_idx）のプラグインには restore を呼ばない。
+        // 2 番目の swap を失敗させ、3 番目（未 swap）の restore を失敗注入しても、
+        // restore は呼ばれないため警告は出ず、本番は無改変（v1）のまま RolledBack になる。
+        let tmp = TempDir::new().unwrap();
+        let cache_dir = tmp.path().to_path_buf();
+        for id in ["repoA", "repoB", "repoC"] {
+            setup_plugin(&cache_dir, id, OLD_SHA, &[]);
+        }
+        let mut cache = FaultyCache::new(cache_dir.clone());
+        cache.fail_commit_nth = 2; // 1 件目 swap 成功 / 2 件目 swap 失敗 / 3 件目 未 swap
+                                   // 全件の restore を失敗注入する。未 swap の 3 件目で restore が呼ばれていれば
+                                   // 警告が載るが、呼ばれない設計なので 1 件は警告なし RolledBack になるはず。
+        for id in ["repoA", "repoB", "repoC"] {
+            cache.fail_restore.insert(id.to_string());
+        }
+        let client = MockBatchClient::new();
+        let resolver = NoMarketplaces;
+
+        let results =
+            update_all_plugins_with_deps(&cache, &client, &resolver, tmp.path(), None).await;
+
+        assert_eq!(results.len(), 3);
+        // Failed は 1 件（2 件目）
+        assert_eq!(
+            count_status(&results, |s| matches!(s, UpdateStatus::Failed)),
+            1
+        );
+        // RolledBack は 2 件。うち未 swap の 1 件は restore 未実行なので警告なし。
+        let rolled: Vec<&UpdateOutcome> = results
+            .iter()
+            .filter(|r| matches!(r.status, UpdateStatus::RolledBack))
+            .collect();
+        assert_eq!(rolled.len(), 2);
+        let no_warning = rolled.iter().filter(|r| r.error.is_none()).count();
+        assert_eq!(
+            no_warning,
+            1,
+            "unswapped plugin must be RolledBack without a restore attempt/warning, got {:?}",
+            rolled.iter().map(|r| &r.error).collect::<Vec<_>>()
         );
     }
 

--- a/src/plugin/lifecycle/update_test.rs
+++ b/src/plugin/lifecycle/update_test.rs
@@ -49,3 +49,886 @@ fn test_update_outcome_factories() {
     let skipped = UpdateOutcome::skipped("test", "reason".to_string());
     assert!(matches!(skipped.status, UpdateStatus::Skipped { .. }));
 }
+
+#[test]
+fn test_rolled_back_factory_without_note() {
+    let outcome = UpdateOutcome::rolled_back("test", None);
+    assert!(matches!(outcome.status, UpdateStatus::RolledBack));
+    assert_eq!(outcome.plugin_name, "test");
+    assert_eq!(outcome.error, None);
+    assert!(outcome.deployed_targets.is_empty());
+    assert!(outcome.failed_targets.is_empty());
+}
+
+#[test]
+fn test_rolled_back_factory_with_note() {
+    let outcome = UpdateOutcome::rolled_back("test", Some("WARNING: restore failed".to_string()));
+    assert!(matches!(outcome.status, UpdateStatus::RolledBack));
+    assert_eq!(outcome.error.as_deref(), Some("WARNING: restore failed"));
+}
+
+// =============================================================================
+// バッチアトミック (update_all_plugins_with_deps) テスト
+// =============================================================================
+
+mod batch {
+    use super::super::*;
+    use crate::plugin::PackageCache;
+    use std::collections::{HashMap, HashSet};
+    use std::fs;
+    use std::future::Future;
+    use std::path::{Path, PathBuf};
+    use std::pin::Pin;
+    use tempfile::TempDir;
+
+    const OLD_SHA: &str = "oldsha";
+
+    /// zip アーカイブを生成（GitHub 形式の prefix 付き）
+    fn make_zip(entries: &[(&str, &str)]) -> Vec<u8> {
+        use std::io::Write;
+        let mut buf = Vec::new();
+        {
+            let mut zip = zip::ZipWriter::new(std::io::Cursor::new(&mut buf));
+            let options = zip::write::SimpleFileOptions::default();
+            for (path, content) in entries {
+                zip.start_file(*path, options).unwrap();
+                zip.write_all(content.as_bytes()).unwrap();
+            }
+            zip.finish().unwrap();
+        }
+        buf
+    }
+
+    /// 有効な更新後アーカイブ（plugin.json + data.txt="v2"）
+    fn valid_archive(name: &str) -> Vec<u8> {
+        let manifest = format!(r#"{{"name":"{}","version":"2.0.0"}}"#, name);
+        make_zip(&[
+            ("pkg-main/plugin.json", manifest.as_str()),
+            ("pkg-main/data.txt", "v2"),
+        ])
+    }
+
+    /// plugin.json を含まない無効アーカイブ
+    fn invalid_archive() -> Vec<u8> {
+        make_zip(&[("pkg-main/readme.md", "no manifest here")])
+    }
+
+    /// テスト用プラグインをキャッシュにセットアップする。
+    ///
+    /// `cache_id` = `name` とし、`sourceRepo = "owner/{name}"`（直接 GitHub 扱い）。
+    /// data.txt は "v1"、commitSha は `installed_sha`。
+    fn setup_plugin(cache_dir: &Path, cache_id: &str, installed_sha: &str, enabled: &[&str]) {
+        let dir = cache_dir.join("github").join(cache_id);
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(
+            dir.join("plugin.json"),
+            format!(r#"{{"name":"{}","version":"1.0.0"}}"#, cache_id),
+        )
+        .unwrap();
+        fs::write(dir.join("data.txt"), "v1").unwrap();
+
+        let mut status = HashMap::new();
+        for t in enabled {
+            status.insert(t.to_string(), "enabled");
+        }
+        let status_json = if status.is_empty() {
+            String::new()
+        } else {
+            let entries: Vec<String> = status
+                .iter()
+                .map(|(k, v)| format!(r#""{}":"{}""#, k, v))
+                .collect();
+            format!(r#","statusByTarget":{{{}}}"#, entries.join(","))
+        };
+        let meta = format!(
+            r#"{{"gitRef":"main","commitSha":"{}","sourceRepo":"owner/{}"{}}}"#,
+            installed_sha, cache_id, status_json
+        );
+        fs::write(dir.join(".plm-meta.json"), meta).unwrap();
+    }
+
+    fn read_data_in(cache_dir: &Path, mp_dir: &str, cache_id: &str) -> String {
+        fs::read_to_string(cache_dir.join(mp_dir).join(cache_id).join("data.txt"))
+            .unwrap_or_default()
+    }
+
+    fn read_data(cache_dir: &Path, cache_id: &str) -> String {
+        read_data_in(cache_dir, "github", cache_id)
+    }
+
+    fn read_commit_sha(cache_dir: &Path, cache_id: &str) -> Option<String> {
+        let path = cache_dir
+            .join("github")
+            .join(cache_id)
+            .join(".plm-meta.json");
+        let content = fs::read_to_string(path).ok()?;
+        let v: serde_json::Value = serde_json::from_str(&content).ok()?;
+        v.get("commitSha")
+            .and_then(|s| s.as_str())
+            .map(String::from)
+    }
+
+    fn backup_exists(cache_dir: &Path, cache_id: &str) -> bool {
+        cache_dir
+            .join(".backup")
+            .join("github")
+            .join(cache_id)
+            .exists()
+    }
+
+    fn temp_exists(cache_dir: &Path, cache_id: &str) -> bool {
+        temp_exists_in(cache_dir, "github", cache_id)
+    }
+
+    fn temp_exists_in(cache_dir: &Path, mp_dir: &str, cache_id: &str) -> bool {
+        cache_dir.join(".temp").join(mp_dir).join(cache_id).exists()
+    }
+
+    /// 直接 GitHub プラグインを、manifest 名・sourceRepo を明示指定してセットアップする。
+    ///
+    /// `source_repo`（"owner/name" 形式）から `restore_repo` が `repo.name()` を導出するため、
+    /// MockBatchClient のキー（repo.name()）を制御したい場合に使う。
+    fn setup_plugin_named(
+        cache_dir: &Path,
+        cache_id: &str,
+        display_name: &str,
+        source_repo: &str,
+        installed_sha: &str,
+    ) {
+        let dir = cache_dir.join("github").join(cache_id);
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(
+            dir.join("plugin.json"),
+            format!(r#"{{"name":"{}","version":"1.0.0"}}"#, display_name),
+        )
+        .unwrap();
+        fs::write(dir.join("data.txt"), "v1").unwrap();
+        fs::write(
+            dir.join(".plm-meta.json"),
+            format!(
+                r#"{{"gitRef":"main","commitSha":"{}","sourceRepo":"{}"}}"#,
+                installed_sha, source_repo
+            ),
+        )
+        .unwrap();
+    }
+
+    fn find<'a>(results: &'a [UpdateOutcome], name: &str) -> &'a UpdateOutcome {
+        results
+            .iter()
+            .find(|r| r.plugin_name == name)
+            .unwrap_or_else(|| panic!("outcome for '{}' not found", name))
+    }
+
+    /// marketplace 配下に外部 GitHub プラグインをセットアップする。
+    ///
+    /// `mp_dir/cache_id` に plugin.json（manifest 名 = `display_name`）+ data.txt="v1" + meta。
+    /// meta は `commitSha`/`gitRef` のみ（marketplace 経路は `sourceRepo` を使わない）。
+    fn setup_mp_plugin(
+        cache_dir: &Path,
+        mp_dir: &str,
+        cache_id: &str,
+        display_name: &str,
+        installed_sha: &str,
+    ) {
+        let dir = cache_dir.join(mp_dir).join(cache_id);
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(
+            dir.join("plugin.json"),
+            format!(r#"{{"name":"{}","version":"1.0.0"}}"#, display_name),
+        )
+        .unwrap();
+        fs::write(dir.join("data.txt"), "v1").unwrap();
+        fs::write(
+            dir.join(".plm-meta.json"),
+            format!(
+                r#"{{"gitRef":"main","commitSha":"{}","marketplace":"{}"}}"#,
+                installed_sha, mp_dir
+            ),
+        )
+        .unwrap();
+    }
+
+    /// 更新対象がない marketplace stub（直接 GitHub 経路のみ使うテスト用）
+    struct NoMarketplaces;
+    impl MarketplaceResolver for NoMarketplaces {
+        fn resolve(&self, _marketplace: &str) -> Result<Option<MarketplaceCache>> {
+            Ok(None)
+        }
+    }
+
+    /// 固定の MarketplaceCache を返す resolver stub。
+    ///
+    /// 各 entry は External GitHub（`repo` = `owner/{repo_name}`）として登録する。
+    /// `repo_name` は MockBatchClient のキー（repo.name()）と一致させる。
+    struct WithMarketplace {
+        market: String,
+        entries: Vec<(String, String)>, // (cache_id, repo_name)
+    }
+    impl MarketplaceResolver for WithMarketplace {
+        fn resolve(&self, marketplace: &str) -> Result<Option<MarketplaceCache>> {
+            if marketplace != self.market {
+                return Ok(None);
+            }
+            let plugins = self
+                .entries
+                .iter()
+                .map(
+                    |(cache_id, repo_name)| crate::marketplace::MarketplacePlugin {
+                        name: cache_id.clone(),
+                        source: crate::marketplace::PluginSource::External {
+                            source: "github".to_string(),
+                            repo: format!("owner/{}", repo_name),
+                        },
+                        description: None,
+                        version: None,
+                    },
+                )
+                .collect();
+            Ok(Some(MarketplaceCache {
+                name: self.market.clone(),
+                fetched_at: chrono::Utc::now(),
+                source: format!("github:owner/{}", self.market),
+                owner: None,
+                plugins,
+            }))
+        }
+    }
+
+    #[derive(Clone)]
+    enum Download {
+        Valid,
+        Invalid,
+        Fail,
+    }
+
+    /// repo.name() をキーに挙動を切り替えるモッククライアント
+    struct MockBatchClient {
+        /// name -> get_commit_sha が返す SHA（未指定は "REMOTE_SHA"）
+        latest: HashMap<String, String>,
+        /// get_commit_sha が Err を返す name 集合
+        sha_fail: HashSet<String>,
+        /// name -> download 挙動（未指定は Valid）
+        download: HashMap<String, Download>,
+    }
+
+    impl MockBatchClient {
+        fn new() -> Self {
+            Self {
+                latest: HashMap::new(),
+                sha_fail: HashSet::new(),
+                download: HashMap::new(),
+            }
+        }
+    }
+
+    impl HostClient for MockBatchClient {
+        fn get_default_branch<'a>(
+            &'a self,
+            _repo: &'a Repo,
+        ) -> Pin<Box<dyn Future<Output = Result<String>> + Send + 'a>> {
+            Box::pin(async { Ok("main".to_string()) })
+        }
+
+        fn get_commit_sha<'a>(
+            &'a self,
+            repo: &'a Repo,
+            _git_ref: &'a str,
+        ) -> Pin<Box<dyn Future<Output = Result<String>> + Send + 'a>> {
+            let name = repo.name().to_string();
+            let result = if self.sha_fail.contains(&name) {
+                Err(PlmError::RepoApi {
+                    url: "https://api.github.com/test".to_string(),
+                    status: 500,
+                    message: "injected sha failure".to_string(),
+                })
+            } else {
+                Ok(self
+                    .latest
+                    .get(&name)
+                    .cloned()
+                    .unwrap_or_else(|| "REMOTE_SHA".to_string()))
+            };
+            Box::pin(async move { result })
+        }
+
+        fn download_archive<'a>(
+            &'a self,
+            _repo: &'a Repo,
+        ) -> Pin<Box<dyn Future<Output = Result<Vec<u8>>> + Send + 'a>> {
+            Box::pin(async { Ok(vec![]) })
+        }
+
+        fn download_archive_with_sha<'a>(
+            &'a self,
+            repo: &'a Repo,
+        ) -> Pin<Box<dyn Future<Output = Result<(Vec<u8>, String, String)>> + Send + 'a>> {
+            let name = repo.name().to_string();
+            let behavior = self.download.get(&name).cloned().unwrap_or(Download::Valid);
+            let result = match behavior {
+                Download::Valid => Ok((
+                    valid_archive(&name),
+                    "main".to_string(),
+                    format!("commit-{}", name),
+                )),
+                Download::Invalid => Ok((invalid_archive(), "main".to_string(), "x".to_string())),
+                Download::Fail => Err(PlmError::RepoApi {
+                    url: "https://api.github.com/test".to_string(),
+                    status: 500,
+                    message: "injected download failure".to_string(),
+                }),
+            };
+            Box::pin(async move { result })
+        }
+
+        fn fetch_file<'a>(
+            &'a self,
+            _repo: &'a Repo,
+            _path: &'a str,
+        ) -> Pin<Box<dyn Future<Output = Result<String>> + Send + 'a>> {
+            Box::pin(async { Ok(String::new()) })
+        }
+    }
+
+    /// commit_staged / restore に障害を注入できるキャッシュデコレータ
+    ///
+    /// `fail_commit` / `fail_restore` は cache_id（name）一致で発火（github 単一 marketplace 用）。
+    /// `fail_commit_keyed` / `fail_restore_keyed` は `"{mp}/{cache_id}"` キー一致で発火し、
+    /// 別 marketplace 間で同名 cache_id を区別する必要があるテスト（W-002）で使う。
+    struct FaultyCache {
+        inner: PackageCache,
+        fail_commit: HashSet<String>,
+        fail_restore: HashSet<String>,
+        fail_commit_keyed: HashSet<String>,
+        fail_restore_keyed: HashSet<String>,
+    }
+
+    impl FaultyCache {
+        fn new(cache_dir: PathBuf) -> Self {
+            Self {
+                inner: PackageCache::with_cache_dir(cache_dir).unwrap(),
+                fail_commit: HashSet::new(),
+                fail_restore: HashSet::new(),
+                fail_commit_keyed: HashSet::new(),
+                fail_restore_keyed: HashSet::new(),
+            }
+        }
+
+        fn key(marketplace: Option<&str>, name: &str) -> String {
+            format!("{}/{}", marketplace.unwrap_or("github"), name)
+        }
+    }
+
+    impl PackageCacheAccess for FaultyCache {
+        fn plugin_path(&self, marketplace: Option<&str>, name: &str) -> PathBuf {
+            self.inner.plugin_path(marketplace, name)
+        }
+        fn is_cached(&self, marketplace: Option<&str>, name: &str) -> bool {
+            self.inner.is_cached(marketplace, name)
+        }
+        fn store_from_archive(
+            &self,
+            marketplace: Option<&str>,
+            name: &str,
+            archive: &[u8],
+            source_path: Option<&str>,
+        ) -> Result<PathBuf> {
+            self.inner
+                .store_from_archive(marketplace, name, archive, source_path)
+        }
+        fn load_manifest(
+            &self,
+            marketplace: Option<&str>,
+            name: &str,
+        ) -> Result<crate::plugin::PluginManifest> {
+            self.inner.load_manifest(marketplace, name)
+        }
+        fn remove(&self, marketplace: Option<&str>, name: &str) -> Result<()> {
+            self.inner.remove(marketplace, name)
+        }
+        fn list(&self) -> Result<Vec<(Option<String>, String)>> {
+            self.inner.list()
+        }
+        fn backup(&self, marketplace: Option<&str>, name: &str) -> Result<PathBuf> {
+            self.inner.backup(marketplace, name)
+        }
+        fn restore(&self, marketplace: Option<&str>, name: &str) -> Result<()> {
+            if self.fail_restore.contains(name)
+                || self
+                    .fail_restore_keyed
+                    .contains(&Self::key(marketplace, name))
+            {
+                return Err(PlmError::Cache("injected restore failure".to_string()));
+            }
+            self.inner.restore(marketplace, name)
+        }
+        fn remove_backup(&self, marketplace: Option<&str>, name: &str) -> Result<()> {
+            self.inner.remove_backup(marketplace, name)
+        }
+        fn atomic_update(
+            &self,
+            marketplace: Option<&str>,
+            name: &str,
+            archive: &[u8],
+        ) -> Result<PathBuf> {
+            self.inner.atomic_update(marketplace, name, archive)
+        }
+        fn atomic_update_with_source_path(
+            &self,
+            marketplace: Option<&str>,
+            name: &str,
+            archive: &[u8],
+            source_path: Option<&str>,
+        ) -> Result<PathBuf> {
+            self.inner
+                .atomic_update_with_source_path(marketplace, name, archive, source_path)
+        }
+        fn stage_from_archive(
+            &self,
+            marketplace: Option<&str>,
+            name: &str,
+            archive: &[u8],
+            source_path: Option<&str>,
+        ) -> Result<PathBuf> {
+            self.inner
+                .stage_from_archive(marketplace, name, archive, source_path)
+        }
+        fn commit_staged(&self, marketplace: Option<&str>, name: &str) -> Result<PathBuf> {
+            if self.fail_commit.contains(name)
+                || self
+                    .fail_commit_keyed
+                    .contains(&Self::key(marketplace, name))
+            {
+                return Err(PlmError::Cache("injected commit failure".to_string()));
+            }
+            self.inner.commit_staged(marketplace, name)
+        }
+        fn discard_staged(&self, marketplace: Option<&str>, name: &str) -> Result<()> {
+            self.inner.discard_staged(marketplace, name)
+        }
+        fn has_marketplace_entry(&self, marketplace: &str, entry: &str) -> Result<bool> {
+            self.inner.has_marketplace_entry(marketplace, entry)
+        }
+        fn remove_marketplace_entry(&self, marketplace: &str, entry: &str) -> Result<()> {
+            self.inner.remove_marketplace_entry(marketplace, entry)
+        }
+        fn list_marketplace_entries(&self, marketplace: &str) -> Result<Vec<String>> {
+            self.inner.list_marketplace_entries(marketplace)
+        }
+    }
+
+    fn count_status(results: &[UpdateOutcome], pred: impl Fn(&UpdateStatus) -> bool) -> usize {
+        results.iter().filter(|r| pred(&r.status)).count()
+    }
+
+    // ---- 正常系 ----
+
+    #[tokio::test]
+    async fn test_single_update_commits() {
+        let tmp = TempDir::new().unwrap();
+        let cache_dir = tmp.path().to_path_buf();
+        setup_plugin(&cache_dir, "repoA", OLD_SHA, &[]);
+        let cache = PackageCache::with_cache_dir(cache_dir.clone()).unwrap();
+        let client = MockBatchClient::new();
+        let resolver = NoMarketplaces;
+
+        let results =
+            update_all_plugins_with_deps(&cache, &client, &resolver, tmp.path(), None).await;
+
+        assert_eq!(results.len(), 1);
+        let a = find(&results, "repoA");
+        assert!(matches!(a.status, UpdateStatus::Updated { .. }));
+        assert_eq!(read_data(&cache_dir, "repoA"), "v2");
+        assert_eq!(
+            read_commit_sha(&cache_dir, "repoA").as_deref(),
+            Some("commit-repoA")
+        );
+        assert!(!backup_exists(&cache_dir, "repoA"));
+        // staging temp が commit_staged で消費されている（rename→copy 退行検出）
+        assert!(!temp_exists(&cache_dir, "repoA"));
+    }
+
+    #[tokio::test]
+    async fn test_multiple_updates_all_commit() {
+        let tmp = TempDir::new().unwrap();
+        let cache_dir = tmp.path().to_path_buf();
+        for id in ["repoA", "repoB", "repoC"] {
+            setup_plugin(&cache_dir, id, OLD_SHA, &[]);
+        }
+        let cache = PackageCache::with_cache_dir(cache_dir.clone()).unwrap();
+        let client = MockBatchClient::new();
+        let resolver = NoMarketplaces;
+
+        let results =
+            update_all_plugins_with_deps(&cache, &client, &resolver, tmp.path(), None).await;
+
+        assert_eq!(results.len(), 3);
+        assert_eq!(
+            count_status(&results, |s| matches!(s, UpdateStatus::Updated { .. })),
+            3
+        );
+        for id in ["repoA", "repoB", "repoC"] {
+            assert_eq!(read_data(&cache_dir, id), "v2");
+            assert!(
+                !backup_exists(&cache_dir, id),
+                "backup for {} should be gone",
+                id
+            );
+            // staging temp が全件 commit_staged で消費されている
+            assert!(!temp_exists(&cache_dir, id), "temp for {} remained", id);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_zero_updates_keeps_production() {
+        let tmp = TempDir::new().unwrap();
+        let cache_dir = tmp.path().to_path_buf();
+        // installed sha == remote sha → up to date
+        setup_plugin(&cache_dir, "repoA", "REMOTE_SHA", &[]);
+        setup_plugin(&cache_dir, "repoB", "REMOTE_SHA", &[]);
+        let cache = PackageCache::with_cache_dir(cache_dir.clone()).unwrap();
+        let client = MockBatchClient::new();
+        let resolver = NoMarketplaces;
+
+        let results =
+            update_all_plugins_with_deps(&cache, &client, &resolver, tmp.path(), None).await;
+
+        assert_eq!(results.len(), 2);
+        assert_eq!(
+            count_status(&results, |s| matches!(s, UpdateStatus::AlreadyUpToDate)),
+            2
+        );
+        // 本番不変・backup なし
+        for id in ["repoA", "repoB"] {
+            assert_eq!(read_data(&cache_dir, id), "v1");
+            assert!(!backup_exists(&cache_dir, id));
+        }
+    }
+
+    // ---- prepare 失敗の全件ロールバック ----
+
+    #[tokio::test]
+    async fn test_download_failure_rolls_back_all() {
+        let tmp = TempDir::new().unwrap();
+        let cache_dir = tmp.path().to_path_buf();
+        for id in ["repoA", "repoB", "repoC"] {
+            setup_plugin(&cache_dir, id, OLD_SHA, &[]);
+        }
+        let cache = PackageCache::with_cache_dir(cache_dir.clone()).unwrap();
+        let mut client = MockBatchClient::new();
+        client.download.insert("repoB".to_string(), Download::Fail);
+        let resolver = NoMarketplaces;
+
+        let results =
+            update_all_plugins_with_deps(&cache, &client, &resolver, tmp.path(), None).await;
+
+        // 全件が結果に出る（review B: 未到達も RolledBack）
+        assert_eq!(results.len(), 3);
+        assert!(matches!(
+            find(&results, "repoB").status,
+            UpdateStatus::Failed
+        ));
+        assert!(matches!(
+            find(&results, "repoA").status,
+            UpdateStatus::RolledBack
+        ));
+        assert!(matches!(
+            find(&results, "repoC").status,
+            UpdateStatus::RolledBack
+        ));
+        // 本番は全件更新前のまま、staging/backup 全削除
+        for id in ["repoA", "repoB", "repoC"] {
+            assert_eq!(read_data(&cache_dir, id), "v1");
+            assert_eq!(read_commit_sha(&cache_dir, id).as_deref(), Some(OLD_SHA));
+            assert!(!backup_exists(&cache_dir, id), "backup {} remained", id);
+            assert!(!temp_exists(&cache_dir, id), "temp {} remained", id);
+        }
+        // 整合性: 件数保存（check失敗なし → up_to_date(0)+skipped(0)+update_count(3)）
+        assert_eq!(results.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn test_staging_validation_failure_rolls_back_all() {
+        let tmp = TempDir::new().unwrap();
+        let cache_dir = tmp.path().to_path_buf();
+        for id in ["repoA", "repoB", "repoC"] {
+            setup_plugin(&cache_dir, id, OLD_SHA, &[]);
+        }
+        let cache = PackageCache::with_cache_dir(cache_dir.clone()).unwrap();
+        let mut client = MockBatchClient::new();
+        client
+            .download
+            .insert("repoB".to_string(), Download::Invalid);
+        let resolver = NoMarketplaces;
+
+        let results =
+            update_all_plugins_with_deps(&cache, &client, &resolver, tmp.path(), None).await;
+
+        assert_eq!(results.len(), 3);
+        assert!(matches!(
+            find(&results, "repoB").status,
+            UpdateStatus::Failed
+        ));
+        for id in ["repoA", "repoC"] {
+            assert!(matches!(
+                find(&results, id).status,
+                UpdateStatus::RolledBack
+            ));
+        }
+        for id in ["repoA", "repoB", "repoC"] {
+            assert_eq!(read_data(&cache_dir, id), "v1");
+            assert!(!backup_exists(&cache_dir, id));
+            assert!(!temp_exists(&cache_dir, id));
+        }
+    }
+
+    // ---- commit(swap) 失敗の全件 restore ----
+
+    #[tokio::test]
+    async fn test_commit_failure_restores_all() {
+        let tmp = TempDir::new().unwrap();
+        let cache_dir = tmp.path().to_path_buf();
+        for id in ["repoA", "repoB", "repoC"] {
+            setup_plugin(&cache_dir, id, OLD_SHA, &[]);
+        }
+        let mut cache = FaultyCache::new(cache_dir.clone());
+        cache.fail_commit.insert("repoB".to_string());
+        let client = MockBatchClient::new();
+        let resolver = NoMarketplaces;
+
+        let results =
+            update_all_plugins_with_deps(&cache, &client, &resolver, tmp.path(), None).await;
+
+        assert_eq!(results.len(), 3);
+        // 当該 repoB は Failed ちょうど 1 件、RolledBack で二重計上されない（review A）
+        let repo_b_outcomes: Vec<&UpdateOutcome> = results
+            .iter()
+            .filter(|r| r.plugin_name == "repoB")
+            .collect();
+        assert_eq!(repo_b_outcomes.len(), 1);
+        assert!(matches!(repo_b_outcomes[0].status, UpdateStatus::Failed));
+        // 他は RolledBack
+        assert!(matches!(
+            find(&results, "repoA").status,
+            UpdateStatus::RolledBack
+        ));
+        assert!(matches!(
+            find(&results, "repoC").status,
+            UpdateStatus::RolledBack
+        ));
+        // 全件が更新前状態に復元
+        for id in ["repoA", "repoB", "repoC"] {
+            assert_eq!(read_data(&cache_dir, id), "v1", "{} not restored", id);
+            assert_eq!(read_commit_sha(&cache_dir, id).as_deref(), Some(OLD_SHA));
+        }
+    }
+
+    #[tokio::test]
+    async fn test_single_commit_failure_restores() {
+        let tmp = TempDir::new().unwrap();
+        let cache_dir = tmp.path().to_path_buf();
+        setup_plugin(&cache_dir, "repoA", OLD_SHA, &[]);
+        let mut cache = FaultyCache::new(cache_dir.clone());
+        cache.fail_commit.insert("repoA".to_string());
+        let client = MockBatchClient::new();
+        let resolver = NoMarketplaces;
+
+        let results =
+            update_all_plugins_with_deps(&cache, &client, &resolver, tmp.path(), None).await;
+
+        assert_eq!(results.len(), 1);
+        assert!(matches!(
+            find(&results, "repoA").status,
+            UpdateStatus::Failed
+        ));
+        assert_eq!(read_data(&cache_dir, "repoA"), "v1");
+        assert_eq!(
+            read_commit_sha(&cache_dir, "repoA").as_deref(),
+            Some(OLD_SHA)
+        );
+    }
+
+    // ---- エッジケース: restore 自体の失敗 ----
+
+    #[tokio::test]
+    async fn test_rollback_restore_failure_warns() {
+        let tmp = TempDir::new().unwrap();
+        let cache_dir = tmp.path().to_path_buf();
+        for id in ["repoA", "repoB"] {
+            setup_plugin(&cache_dir, id, OLD_SHA, &[]);
+        }
+        let mut cache = FaultyCache::new(cache_dir.clone());
+        cache.fail_commit.insert("repoB".to_string());
+        // RolledBack 予定の repoA の restore を失敗させる
+        cache.fail_restore.insert("repoA".to_string());
+        let client = MockBatchClient::new();
+        let resolver = NoMarketplaces;
+
+        let results =
+            update_all_plugins_with_deps(&cache, &client, &resolver, tmp.path(), None).await;
+
+        let a = find(&results, "repoA");
+        assert!(matches!(a.status, UpdateStatus::RolledBack));
+        assert!(
+            a.error.as_deref().unwrap_or("").contains("restore failed"),
+            "expected restore warning, got {:?}",
+            a.error
+        );
+    }
+
+    #[tokio::test]
+    async fn test_rollback_restore_failure_on_failed_target() {
+        let tmp = TempDir::new().unwrap();
+        let cache_dir = tmp.path().to_path_buf();
+        setup_plugin(&cache_dir, "repoA", OLD_SHA, &[]);
+        let mut cache = FaultyCache::new(cache_dir.clone());
+        cache.fail_commit.insert("repoA".to_string());
+        cache.fail_restore.insert("repoA".to_string());
+        let client = MockBatchClient::new();
+        let resolver = NoMarketplaces;
+
+        let results =
+            update_all_plugins_with_deps(&cache, &client, &resolver, tmp.path(), None).await;
+
+        let a = find(&results, "repoA");
+        assert!(matches!(a.status, UpdateStatus::Failed));
+        assert!(
+            a.error
+                .as_deref()
+                .unwrap_or("")
+                .contains("restore also failed"),
+            "expected combined warning, got {:?}",
+            a.error
+        );
+    }
+
+    // ---- 回帰 ----
+
+    #[tokio::test]
+    async fn test_redeploy_failure_does_not_trigger_rollback() {
+        // redeploy（enable_plugin）失敗は非アトミック: commit 済みは Updated を維持
+        let tmp = TempDir::new().unwrap();
+        let cache_dir = tmp.path().to_path_buf();
+        setup_plugin(&cache_dir, "repoA", OLD_SHA, &["codex"]);
+        let cache = PackageCache::with_cache_dir(cache_dir.clone()).unwrap();
+        let client = MockBatchClient::new();
+        let resolver = NoMarketplaces;
+
+        let results =
+            update_all_plugins_with_deps(&cache, &client, &resolver, tmp.path(), None).await;
+
+        assert_eq!(results.len(), 1);
+        // redeploy の成否に関わらず swap は確定し Updated（ロールバックしない）
+        assert!(matches!(
+            find(&results, "repoA").status,
+            UpdateStatus::Updated { .. }
+        ));
+        assert_eq!(read_data(&cache_dir, "repoA"), "v2");
+    }
+
+    #[tokio::test]
+    async fn test_sha_check_failure_is_skipped_others_proceed() {
+        let tmp = TempDir::new().unwrap();
+        let cache_dir = tmp.path().to_path_buf();
+        setup_plugin(&cache_dir, "repoA", OLD_SHA, &[]);
+        setup_plugin(&cache_dir, "repoB", OLD_SHA, &[]);
+        let cache = PackageCache::with_cache_dir(cache_dir.clone()).unwrap();
+        let mut client = MockBatchClient::new();
+        client.sha_fail.insert("repoB".to_string()); // CHECK で get_commit_sha 失敗
+        let resolver = NoMarketplaces;
+
+        let results =
+            update_all_plugins_with_deps(&cache, &client, &resolver, tmp.path(), None).await;
+
+        // repoB は error_count でスキップ → results に出ない。repoA のみ Updated。
+        assert_eq!(results.len(), 1);
+        assert!(matches!(
+            find(&results, "repoA").status,
+            UpdateStatus::Updated { .. }
+        ));
+        assert_eq!(read_data(&cache_dir, "repoA"), "v2");
+        // repoB は本番未改変
+        assert_eq!(read_data(&cache_dir, "repoB"), "v1");
+        assert_eq!(
+            read_commit_sha(&cache_dir, "repoB").as_deref(),
+            Some(OLD_SHA)
+        );
+    }
+
+    // ---- marketplace 経由経路 ----
+
+    #[tokio::test]
+    async fn test_marketplace_plugin_commits() {
+        // marketplace 経由（market != "github"）の更新がコミットされる
+        let tmp = TempDir::new().unwrap();
+        let cache_dir = tmp.path().to_path_buf();
+        // cache_id "plugM" を marketplace "mymarket" 配下に配置
+        setup_mp_plugin(&cache_dir, "mymarket", "plugM", "plugM-disp", OLD_SHA);
+        let cache = PackageCache::with_cache_dir(cache_dir.clone()).unwrap();
+        let client = MockBatchClient::new();
+        // entry: cache_id "plugM" → repo "owner/repoM"（repo.name() = "repoM" が mock キー）
+        let resolver = WithMarketplace {
+            market: "mymarket".to_string(),
+            entries: vec![("plugM".to_string(), "repoM".to_string())],
+        };
+
+        let results =
+            update_all_plugins_with_deps(&cache, &client, &resolver, tmp.path(), None).await;
+
+        assert_eq!(results.len(), 1);
+        assert!(matches!(
+            find(&results, "plugM-disp").status,
+            UpdateStatus::Updated { .. }
+        ));
+        // 本番（mymarket 配下）が v2 に更新
+        assert_eq!(read_data_in(&cache_dir, "mymarket", "plugM"), "v2");
+        assert!(!temp_exists_in(&cache_dir, "mymarket", "plugM"));
+    }
+
+    // ---- 複数 marketplace 間の同名 cache_id 衝突（review A リグレッションガード）----
+
+    #[tokio::test]
+    async fn test_same_cache_id_across_marketplaces_commit_failure() {
+        // github/foo と mymarket/foo（同名 cache_id）が併存し、mymarket/foo のみ commit 失敗。
+        // 当該はちょうど 1 件 Failed、github/foo は RolledBack（cache_id 文字列衝突で
+        // 二重計上されないこと＝index 識別の検証）。
+        let tmp = TempDir::new().unwrap();
+        let cache_dir = tmp.path().to_path_buf();
+        // 直接 GitHub: github/foo（display "foo-gh", sourceRepo owner/foo-gh → repo.name "foo-gh"）
+        setup_plugin_named(&cache_dir, "foo", "foo-gh", "owner/foo-gh", OLD_SHA);
+        // marketplace: mymarket/foo（display "foo-mp", entry repo "owner/foo-mp"）
+        setup_mp_plugin(&cache_dir, "mymarket", "foo", "foo-mp", OLD_SHA);
+
+        let mut cache = FaultyCache::new(cache_dir.clone());
+        // mymarket/foo の commit のみ失敗させる（github/foo は成功させる）
+        cache.fail_commit_keyed.insert("mymarket/foo".to_string());
+
+        let client = MockBatchClient::new();
+        let resolver = WithMarketplace {
+            market: "mymarket".to_string(),
+            entries: vec![("foo".to_string(), "foo-mp".to_string())],
+        };
+
+        let results =
+            update_all_plugins_with_deps(&cache, &client, &resolver, tmp.path(), None).await;
+
+        assert_eq!(results.len(), 2);
+        // Failed はちょうど 1 件（mymarket/foo = "foo-mp"）。二重計上されない。
+        let failed: Vec<&UpdateOutcome> = results
+            .iter()
+            .filter(|r| matches!(r.status, UpdateStatus::Failed))
+            .collect();
+        assert_eq!(failed.len(), 1, "exactly one Failed expected");
+        assert_eq!(failed[0].plugin_name, "foo-mp");
+        // github/foo は RolledBack（更新前へ復元）
+        let rolled: Vec<&UpdateOutcome> = results
+            .iter()
+            .filter(|r| matches!(r.status, UpdateStatus::RolledBack))
+            .collect();
+        assert_eq!(rolled.len(), 1);
+        assert_eq!(rolled[0].plugin_name, "foo-gh");
+        // 本番は両方更新前（v1）に復元
+        assert_eq!(read_data_in(&cache_dir, "github", "foo"), "v1");
+        assert_eq!(read_data_in(&cache_dir, "mymarket", "foo"), "v1");
+    }
+}

--- a/src/tui/manager/screens/installed/actions.rs
+++ b/src/tui/manager/screens/installed/actions.rs
@@ -140,5 +140,9 @@ fn run_update_plugin(key: &PluginKey, project_root: &Path) -> UpdateStatusDispla
         UpdateStatus::Failed => {
             UpdateStatusDisplay::Failed(result.error.unwrap_or_else(|| "Unknown error".to_string()))
         }
+        // 単一経路では発生しないが、match 網羅のため対応
+        UpdateStatus::RolledBack => {
+            UpdateStatusDisplay::Failed(result.error.unwrap_or_else(|| "Rolled back".to_string()))
+        }
     }
 }


### PR DESCRIPTION
## 概要

`plm update`（引数なしの一括更新 = `update_all_plugins`）を **all-or-nothing（バッチ全体アトミック）** に変更する。従来は各プラグインを逐次その場コミットしていたため、途中で 1 件失敗すると成功分が上書きされたまま残った。これを 2 フェーズ（prepare → commit）化し、1 件でも失敗したら成功分を含め全件を更新前の状態へ戻す。

> **破壊的挙動変更**: 一括更新で 1 件でも失敗すると、これまで成功扱いだったプラグインも更新前へロールバックされる。区別のため `UpdateStatus::RolledBack` を追加（実失敗 = `Failed` / 巻き戻し = `RolledBack`）。スコープは一括更新のみで、単一 `update_plugin` / `do_safe_update` / install / sync は無改修。

## 変更の種類

- 💥 Breaking（一括更新の失敗時セマンティクス変更・`UpdateStatus` への新バリアント追加）
- ✨ New Feature（staging 専用 cache API）
- 🧪 Tests

## 追加した内容

- `PackageCacheAccess` に staging 専用 API: `stage_from_archive` / `commit_staged` / `discard_staged`（prepare＝temp 展開+検証 と commit＝本番 swap を分離）
- `UpdateStatus::RolledBack` バリアントと `UpdateOutcome::rolled_back` ファクトリ
- `MarketplaceResolver` trait + `RegistryResolver`（registry を単回ロードして保持）による依存注入
- `update_all_plugins_with_deps`（HostClient / MarketplaceResolver 注入版本体）と `check_all` / `prepare_all` / `commit_all` / `rollback_all`

## 変更した内容

- `update_all_plugins` を薄いラッパ化し、本体を 2 フェーズ（prepare → commit）フローへ刷新
- CHECK フェーズを `check_all` に切り出し、marketplace 経由／直接 GitHub の 2 経路の共通末尾（SHA 比較・`UpdateTarget` 構築）を集約
- swap 失敗時の当該識別を **`staged` 内インデックス**で行い、別 marketplace 間の同名 `cache_id` 衝突による二重計上を防止
- CLI（`commands/lifecycle/update.rs`）: 終了コードを「Updated 無し かつ Failed あり → エラー終了」に変更し、`RolledBack` の表示・集計を追加
- TUI（`screens/installed/actions.rs`）: `UpdateStatus` match を網羅対応

## 削除した内容

- バッチ専用だった `check_github_remote` / `RemoteCheck`（`check_all` に統合）

## システム図

\`\`\`mermaid
flowchart TD
    Check[CHECK: 全 plugin 走査 + SHA 比較<br/>check_all で UpdateTarget を確定]
    Check -->|更新 0 件| Done[DONE 全件最新]
    Check -->|更新 1 件以上| Prepare[PREPARE 本番非破壊<br/>各件 backup + download + stage + 検証]
    Prepare -->|全件成功| Commit[COMMIT<br/>各件 swap + redeploy + meta]
    Prepare -->|1 件でも失敗| Abort[ABORT_PREPARE<br/>本番非改変・staging/backup 破棄]
    Commit -->|全件 swap 成功| CommitOk[全件 remove_backup 確定<br/>全件 = Updated]
    Commit -->|swap 中失敗| Rollback[ROLLBACK<br/>swap 済み含め全件 restore]
    Abort --> Res[RETURN results]
    Rollback --> Res
    CommitOk --> Res

    style Prepare fill:#e6f3ff
    style Abort fill:#ffe6e6
    style Rollback fill:#ffe6e6
\`\`\`

- 当該失敗 = `Failed` / 巻き戻し = `RolledBack`（PREPARE 未到達分も含め全件が結果に出る）
- **アトミック境界はキャッシュ swap まで**: redeploy（`enable_plugin`）失敗・`write_meta` 失敗はロールバックの引き金にせず、従来どおり `disabled` 扱いで Updated を維持

## 関連 Spec / Issue

- Spec: `.plugin-workspace/.specs/035-atomic-update`（一括アップデートのアトミック化）
- 関連 Issue: なし

## 検証

CLAUDE.md 規約に従いサブエージェント経由で実行:

- `cargo fmt`: 差分なし
- `cargo check`（rust-workflow-plugin:type-check）: グリーン（コンパイルエラー 0）
- `cargo test`（rust-workflow-plugin:test）: **全 1703 件パス / 失敗 0**
  - バッチ update 経路 19 件（正常系・prepare 失敗ロールバック・commit 失敗 restore・restore 途中失敗警告・redeploy 非アトミック・SHA チェック失敗スキップ・marketplace 経由・同名 cache_id 衝突）
  - cache staging API 35 件
- `cargo clippy --all-targets`: 変更ファイル（update.rs / cache.rs / update_test.rs）に指摘なし
- 無回帰確認: install 187 件 / sync 63 件 / lifecycle 26 件すべて green

## レビューポイント

- **公開 API 破壊的変更**: `UpdateStatus` に `RolledBack` を追加（網羅 match 影響）。一括更新の失敗時挙動が「部分成功保持」→「全件ロールバック」に変わる点
- **アトミック境界**: swap 成功後の redeploy / `write_meta` 失敗は best-effort（ロールバックしない）。単一 `do_safe_update` が write_meta 失敗時に restore するのと非対称（仕様として許容・既知の制約）
- **ロールバック当該識別**: `rollback_all` を cache_id 文字列でなく `staged` インデックスで識別（同名 cache_id 衝突対策）