### PR TITLE
✨ [Feature]: Codex hooks 変換に不足 4 イベント (PreCompact/PostCompact/SubagentStart/SubagentStop) を追加

### DIFF
--- a/docs/concepts/targets.md
+++ b/docs/concepts/targets.md
@@ -19,7 +19,7 @@ PLMがサポートするAI開発環境（ターゲット）について説明し
 | Agents | ✅ | ✅ | ❌ | ❌ |
 | Commands | ❌ | ✅ | ❌ | ❌ |
 | Instructions | ✅ | ✅ | ❌* | ✅** |
-| Hooks | ❌ | ✅ | ❌ | ❌ |
+| Hooks | ✅ | ✅ | ❌ | ❌ |
 
 > *AntigravityはSkills専用の設計で、Instructionsは別途設定で管理します。
 > **Gemini CLIは`GEMINI.md`による階層的な指示システムを持ちます。
@@ -54,6 +54,27 @@ PLMがサポートするAI開発環境（ターゲット）について説明し
 | Skills | `SKILL.md` | `~/.codex/skills/<marketplace>/<plugin>/<skill>/` | `.codex/skills/<marketplace>/<plugin>/<skill>/` |
 | Agents | `*.agent.md` | `~/.codex/agents/<marketplace>/<plugin>/` | `.codex/agents/<marketplace>/<plugin>/` |
 | Instructions | `AGENTS.md` | `~/.codex/AGENTS.md` | `AGENTS.md` |
+
+### Hooks（10 イベント対応）
+
+公式ドキュメント: [Codex Hooks](https://developers.openai.com/codex/hooks)
+
+Codex CLI は PascalCase 命名の hooks イベントを 10 種サポートし、PLM の `CodexEventMap` はそれらをすべて変換対象として保持する（イベント名は変換時にそのまま維持）。
+
+| イベント | scope |
+|----------|-------|
+| `SessionStart` | thread |
+| `PreToolUse` | turn |
+| `PermissionRequest` | turn |
+| `PostToolUse` | turn |
+| `UserPromptSubmit` | turn |
+| `Stop` | turn |
+| `PreCompact` | turn |
+| `PostCompact` | turn |
+| `SubagentStop` | turn |
+| `SubagentStart` | subagent-start |
+
+詳細なスキーマ対応は `docs/reference/hooks-schema-mapping.md` を参照。
 
 ## VSCode GitHub Copilot
 

--- a/docs/reference/hooks-schema-mapping.md
+++ b/docs/reference/hooks-schema-mapping.md
@@ -12,6 +12,7 @@ PLM でフック変換ツールを実装する際のリファレンス。
 | Copilot CLI Hooks 設定 | https://docs.github.com/en/copilot/reference/hooks-configuration |
 | Copilot CLI Hooks ガイド | https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/use-hooks |
 | Copilot CLI Hooks チュートリアル | https://docs.github.com/en/copilot/tutorials/copilot-cli-hooks |
+| Codex CLI Hooks | https://developers.openai.com/codex/hooks |
 
 ---
 
@@ -126,6 +127,25 @@ PLM でフック変換ツールを実装する際のリファレンス。
 | Copilot CLI | 近似手段 |
 |-------------|---------|
 | `errorOccurred` | `PostToolUseFailure` で部分的に代替 |
+
+### Codex CLI（Claude Code と 1:1 対応）
+
+Codex hooks は Claude Code と同じ PascalCase 命名で 10 イベントをサポートし、PLM の `CodexEventMap` は変換時にイベント名をそのまま保持する。
+
+| Claude Code / Codex | scope | PLM 対応 |
+|---------------------|-------|----------|
+| `SessionStart` | thread | ✅ |
+| `PreToolUse` | turn | ✅ |
+| `PermissionRequest` | turn | ✅ |
+| `PostToolUse` | turn | ✅ |
+| `UserPromptSubmit` | turn | ✅ |
+| `Stop` | turn | ✅ |
+| `PreCompact` | turn | ✅ |
+| `PostCompact` | turn | ✅ |
+| `SubagentStop` | turn | ✅ |
+| `SubagentStart` | subagent-start | ✅ |
+
+出典: <https://developers.openai.com/codex/hooks>
 
 ---
 

--- a/src/hooks/converter/codex_test.rs
+++ b/src/hooks/converter/codex_test.rs
@@ -22,7 +22,10 @@ fn test_codex_event_map_keeps_supported_events() {
         map.map_event("PermissionRequest"),
         Some("PermissionRequest")
     );
-    assert_eq!(map.map_event("SubagentStop"), None);
+    assert_eq!(map.map_event("PreCompact"), Some("PreCompact"));
+    assert_eq!(map.map_event("PostCompact"), Some("PostCompact"));
+    assert_eq!(map.map_event("SubagentStart"), Some("SubagentStart"));
+    assert_eq!(map.map_event("SubagentStop"), Some("SubagentStop"));
 }
 
 #[test]

--- a/src/hooks/event/codex.rs
+++ b/src/hooks/event/codex.rs
@@ -13,6 +13,10 @@ impl EventMap for CodexEventMap {
             "UserPromptSubmit" => Some("UserPromptSubmit"),
             "Stop" => Some("Stop"),
             "PermissionRequest" => Some("PermissionRequest"),
+            "PreCompact" => Some("PreCompact"),
+            "PostCompact" => Some("PostCompact"),
+            "SubagentStart" => Some("SubagentStart"),
+            "SubagentStop" => Some("SubagentStop"),
             _ => None,
         }
     }

--- a/src/hooks/event/codex_test.rs
+++ b/src/hooks/event/codex_test.rs
@@ -15,12 +15,16 @@ fn test_codex_event_map_keeps_supported_events() {
         map.map_event("PermissionRequest"),
         Some("PermissionRequest")
     );
+    assert_eq!(map.map_event("PreCompact"), Some("PreCompact"));
+    assert_eq!(map.map_event("PostCompact"), Some("PostCompact"));
+    assert_eq!(map.map_event("SubagentStart"), Some("SubagentStart"));
+    assert_eq!(map.map_event("SubagentStop"), Some("SubagentStop"));
 }
 
 #[test]
-fn test_codex_event_map_rejects_unsupported_events() {
+fn test_codex_event_map_rejects_unknown_events() {
     let map = CodexEventMap;
-    assert_eq!(map.map_event("SubagentStop"), None);
     assert_eq!(map.map_event("unknown"), None);
     assert_eq!(map.map_event(""), None);
+    assert_eq!(map.map_event("NotAnEvent"), None);
 }


### PR DESCRIPTION
## 概要

Codex CLI が公式にサポートする 10 イベントのうち、PLM の `CodexEventMap` が変換できていなかった以下 4 イベントを追加し、Codex 公式仕様への完全準拠を達成する。

- `PreCompact`
- `PostCompact`
- `SubagentStart`
- `SubagentStop`

これらのイベントを含む Claude Code 形式の `hooks.json` を Codex 向けに変換した際、`UnsupportedEvent` 警告で黙って除外されるのを防ぐ。命名は Codex 公式仕様および既存 6 イベントと統一する形で **PascalCase をそのまま保持**。

Closes #303

## 変更内容

### コード

- `src/hooks/event/codex.rs`
  - `CodexEventMap::map_event` の `match` 式に 4 分岐を追加
- `src/hooks/event/codex_test.rs`
  - `test_codex_event_map_keeps_supported_events` を 10 イベント網羅に拡張
  - 旧 `test_codex_event_map_rejects_unsupported_events` を `test_codex_event_map_rejects_unknown_events` にリネームし、`SubagentStop=None` 期待を削除
- `src/hooks/converter/codex_test.rs`
  - 同名の重複テストの前提を上記と一致させる（`SubagentStop=None` 期待削除 + 4 イベント追加アサーション）

### ドキュメント

- `docs/concepts/targets.md`
  - 対応マトリクスで Hooks の Codex 列を ❌ → ✅
  - Codex セクションに Hooks（10 イベント対応）の節を新設
- `docs/reference/hooks-schema-mapping.md`
  - 公式ドキュメント表に Codex Hooks URL を追加
  - 「2. イベント名マッピング」内に Codex 用の 10 イベント対応表（PLM 対応状況付き）を追加

## 検証

開発手順: t-wada TDD（Red → Green → Refactor）

- [x] **Red**: 4 イベント分のアサーションを追加した時点で `cargo test codex_event_map` が失敗することを確認
- [x] **Green**: `match` 分岐を 4 件追加し、`cargo test codex_event_map` が成功（3 / 3 passed）
- [x] `cargo fmt` 差分なし
- [x] `cargo clippy` 新規警告ゼロ（既存の `tui/manager/screens/marketplaces/update_test.rs` の警告は本 PR スコープ外）
- [x] `cargo test hooks::` 163 / 163 passed（hooks 配下の既存テストに回帰なし）

> 注: `cli::tests::test_*_help` 等の `cargo_bin("plm")` 系テストはサンドボックス環境固有の理由で失敗するが、これは main ブランチ HEAD でも同様に失敗するため本変更とは無関係。

## 出典

- Codex Hooks 公式: <https://developers.openai.com/codex/hooks>

---
_Generated by [Claude Code](https://claude.ai/code/session_011JoCxNbnE7zDqZUQkZLzow)_