### PR TITLE
✨ [Feature]: normalize Codex hooks command_windows / commandWindows (#305)

### DIFF
--- a/docs/reference/hooks-schema-mapping.md
+++ b/docs/reference/hooks-schema-mapping.md
@@ -147,6 +147,17 @@ Codex hooks は Claude Code と同じ PascalCase 命名で 10 イベントをサ
 
 出典: <https://developers.openai.com/codex/hooks>
 
+### Codex CLI コマンドフックのフィールドマッピング
+
+Codex の command フックは POSIX シェル向けの `command` と Windows 向けの `command_windows` を持つ。PLM は Claude Code 由来の表記揺れ（camelCase `commandWindows`）を Codex 仕様の snake_case (`command_windows`) に正規化する。
+
+| 入力キー (Claude Code 形式) | 出力キー (Codex 形式) | 挙動 |
+|---|---|---|
+| `command_windows` | `command_windows` | command 型なら保持。command 型以外では削除して警告 |
+| `commandWindows` | `command_windows` | snake_case にリネーム。`command_windows` と併存時は snake_case を優先し camelCase 側を警告付きで破棄 |
+
+**表記揺れ正規化の理由**: Codex 公式の `config.toml` は snake_case を採用するため、PLM は入力に `commandWindows`（camelCase）が含まれていれば自動で `command_windows` にリネームする。両キーが同時に存在する場合は仕様準拠側（snake_case）を優先し、`ConversionWarning::RemovedField` で重複を通知する。command 以外の hook 型（`http` など）に付与された Windows コマンドフィールドは意味を持たないため削除し警告する。
+
 ---
 
 ## 3. stdin スキーマ

--- a/src/hooks/converter/codex.rs
+++ b/src/hooks/converter/codex.rs
@@ -47,6 +47,34 @@ impl KeyMap for CodexKeyMap {
                 "comment" => {
                     output.insert("statusMessage".to_string(), value.clone());
                 }
+                "command_windows" if hook_type == "command" => {
+                    output.insert("command_windows".to_string(), value.clone());
+                }
+                "command_windows" => warnings.push(ConversionWarning::RemovedField {
+                    field: "command_windows".to_string(),
+                    reason: "Codex command_windows is only meaningful on command hooks".to_string(),
+                }),
+                // Duplicate detection reads the input `hook_obj` instead of `output`
+                // because `serde_json::Map` defaults to `BTreeMap` (no `preserve_order`
+                // feature), which iterates keys in sorted order. ASCII `'W'`(0x57) <
+                // `'_'`(0x5F) means `"commandWindows"` is visited before
+                // `"command_windows"`, so an output-side check would miss the conflict.
+                "commandWindows" if hook_type != "command" => {
+                    warnings.push(ConversionWarning::RemovedField {
+                        field: "commandWindows".to_string(),
+                        reason: "Codex command_windows is only meaningful on command hooks"
+                            .to_string(),
+                    });
+                }
+                "commandWindows" if hook_obj.contains_key("command_windows") => {
+                    warnings.push(ConversionWarning::RemovedField {
+                        field: "commandWindows".to_string(),
+                        reason: "Codex hooks use command_windows, not commandWindows".to_string(),
+                    });
+                }
+                "commandWindows" => {
+                    output.insert("command_windows".to_string(), value.clone());
+                }
                 _ => {
                     output.insert(key.clone(), value.clone());
                 }

--- a/src/hooks/converter/codex_test.rs
+++ b/src/hooks/converter/codex_test.rs
@@ -80,6 +80,115 @@ fn test_codex_key_map_prefers_timeout_over_timeout_sec() {
 }
 
 #[test]
+fn test_codex_key_map_preserves_command_windows() {
+    let map = CodexKeyMap;
+    let hook = json!({
+        "type": "command",
+        "command": "echo hi",
+        "command_windows": "echo hi"
+    });
+
+    let (mapped, warnings) = map.map_keys(&hook, "command");
+
+    assert_eq!(mapped["command_windows"], "echo hi");
+    assert!(warnings.is_empty());
+}
+
+#[test]
+fn test_codex_key_map_renames_command_windows_camel_to_snake() {
+    let map = CodexKeyMap;
+    let hook = json!({
+        "type": "command",
+        "command": "echo hi",
+        "commandWindows": "echo hi"
+    });
+
+    let (mapped, warnings) = map.map_keys(&hook, "command");
+
+    assert_eq!(mapped["command_windows"], "echo hi");
+    assert!(mapped.get("commandWindows").is_none());
+    assert!(warnings.is_empty());
+}
+
+#[test]
+fn test_codex_key_map_prefers_command_windows_over_camel_case() {
+    let map = CodexKeyMap;
+    let hook = json!({
+        "type": "command",
+        "command": "echo hi",
+        "command_windows": "echo snake",
+        "commandWindows": "echo camel"
+    });
+
+    let (mapped, warnings) = map.map_keys(&hook, "command");
+
+    assert_eq!(mapped["command_windows"], "echo snake");
+    assert!(mapped.get("commandWindows").is_none());
+    assert_eq!(warnings.len(), 1);
+    assert!(matches!(
+        &warnings[0],
+        ConversionWarning::RemovedField { field, .. } if field == "commandWindows"
+    ));
+}
+
+#[test]
+fn test_codex_key_map_preserves_empty_command_windows_value() {
+    let map = CodexKeyMap;
+    let hook = json!({
+        "type": "command",
+        "command": "echo hi",
+        "command_windows": ""
+    });
+
+    let (mapped, warnings) = map.map_keys(&hook, "command");
+
+    assert_eq!(mapped["command_windows"], "");
+    assert!(warnings.is_empty());
+}
+
+#[test]
+fn test_codex_key_map_drops_command_windows_on_non_command_hook() {
+    let map = CodexKeyMap;
+    let hook = json!({
+        "type": "http",
+        "url": "https://example.com/hook",
+        "command_windows": "echo hi",
+        "commandWindows": "echo hi"
+    });
+
+    let (mapped, warnings) = map.map_keys(&hook, "http");
+
+    assert!(mapped.get("command_windows").is_none());
+    assert!(mapped.get("commandWindows").is_none());
+    assert_eq!(warnings.len(), 2);
+    assert!(warnings.iter().all(|w| matches!(
+        w,
+        ConversionWarning::RemovedField { field, .. }
+            if field == "command_windows" || field == "commandWindows"
+    )));
+}
+
+#[test]
+fn test_codex_key_map_command_windows_coexists_with_existing_fields() {
+    let map = CodexKeyMap;
+    let hook = json!({
+        "type": "command",
+        "command": "echo hi",
+        "command_windows": "echo hi",
+        "timeoutSec": 5,
+        "comment": "checking"
+    });
+
+    let (mapped, warnings) = map.map_keys(&hook, "command");
+
+    assert_eq!(mapped["command_windows"], "echo hi");
+    assert_eq!(mapped["timeout"], 5);
+    assert_eq!(mapped["statusMessage"], "checking");
+    assert_eq!(mapped["type"], "command");
+    assert!(warnings.is_empty());
+}
+
+#[test]
 fn test_codex_structure_converter_detects_claude_code() {
     let conv = CodexStructureConverter;
     let value = json!({"hooks": {"SessionStart": []}});


### PR DESCRIPTION
Closes #305

## 概要

PLM の Codex hooks 変換 (`CodexKeyMap`) に `command_windows` / `commandWindows` の明示的な保持・正規化を追加しました。Codex 公式の snake_case (`command_windows`) を正規形として採用し、Claude Code 由来の表記揺れ `commandWindows` (camelCase) を自動でリネームします。

## 変更内容

### `src/hooks/converter/codex.rs`
`CodexKeyMap::map_keys` に 3 つの分岐を追加:
- `command_windows` (command 型) → そのまま保持
- `command_windows` (command 型以外) → 削除して `ConversionWarning::RemovedField`
- `commandWindows` (command 型以外) → 削除して警告
- `commandWindows` (command 型 + 入力に `command_windows` が併存) → 削除して警告
- `commandWindows` (command 型 + 単独) → `command_windows` にリネーム

**設計上の重要な点**: 重複判定は出力ではなく入力 `hook_obj.contains_key(...)` で行います。`serde_json::Map` は `preserve_order` feature 無効時 `BTreeMap` を使うためキーソート順で反復し、ASCII `'W'`(0x57) < `'_'`(0x5F) のため `commandWindows` が `command_windows` より先に処理されます。出力側で判定すると camelCase 処理時に重複検出できず警告が発火しません。コード内コメントとドキュメントで方針を明示しています。

### `src/hooks/converter/codex_test.rs`
TDD で 6 ケース追加:

| カテゴリ | テストケース | UC |
|---|---|---|
| 正常系 | `test_codex_key_map_preserves_command_windows` | UC-1: snake_case 保持 |
| 正常系 | `test_codex_key_map_renames_command_windows_camel_to_snake` | UC-2: camelCase リネーム |
| 正常系 | `test_codex_key_map_command_windows_coexists_with_existing_fields` | 既存 `timeoutSec`/`comment` との回帰 |
| 境界値 | `test_codex_key_map_preserves_empty_command_windows_value` | 空文字列保持 |
| 異常系 | `test_codex_key_map_drops_command_windows_on_non_command_hook` | UC-4: http hook で削除 |
| エッジケース | `test_codex_key_map_prefers_command_windows_over_camel_case` | UC-3: 重複時優先順位 + 警告 |

### `docs/reference/hooks-schema-mapping.md`
Codex CLI セクションに「コマンドフックのフィールドマッピング」サブセクションを追加。`command_windows` のマッピング表と表記揺れ正規化の挙動を記述。

## テスト結果

- 新規 6 テスト: 全件 PASS
- 既存テスト: 回帰なし（1676 → 1682 pass、29 件の既存失敗は本 PR とは無関係）

## 仕様駆動開発の成果物

本変更は `.plugin-workspace/.specs/001-codex-hooks-command-windows/` 配下に仕様駆動開発スキル (`spec-driven-dev`) で作成した以下のドキュメントに基づいています:
- `hearing-notes.md`
- `exploration-report.md`
- `requirements.md` (UC-1〜UC-4, F-1〜F-6, NF-1〜NF-5, C-1〜C-8)
- `implementation-plan.md` (状態遷移図 + データフロー図 + before/after)
- `tasks.md` (TDD Red→Green→Refactor)

3 つのセルフチェック (plan-format / design-validity / test-pattern) を実施。`design-validity-checker` が BTreeMap 反復順依存の不具合を検出し、`hook_obj.contains_key` ベースに修正した上で全件 PASS で実装に進みました。

## Out of Scope

- 他ターゲット (Copilot/Antigravity/Gemini) の逆方向変換 → 別 Issue
- 既存 `timeoutSec` の "重複時に黙って捨てる" 挙動との一貫性 → 別 Issue
- `_ =>` フォールスルーのホワイトリスト化 → 将来 Issue


---
_Generated by [Claude Code](https://claude.ai/code/session_018ZS4c6JuaPTvuXMTEDsVXz)_