### PR TITLE
refactor: introduce value objects for GitHub repository references (#334)

### DIFF
--- a/src/application/info.rs
+++ b/src/application/info.rs
@@ -4,7 +4,8 @@
 
 use crate::error::{PlmError, Result};
 use crate::plugin::{
-    list_installed, meta, InstalledPlugin, MarketplaceContent, PackageCacheAccess, Plugin,
+    list_installed, meta, GithubCacheId, InstalledPlugin, MarketplaceContent, PackageCacheAccess,
+    Plugin,
 };
 use crate::target::{list_all_placed, PluginOrigin};
 use std::path::{Path, PathBuf};
@@ -183,11 +184,9 @@ fn determine_source(marketplace: &str, dir_name: &str) -> Source {
 ///
 /// * `dir_name` - Cache directory name in the `owner--repo` form.
 fn restore_github_repo(dir_name: &str) -> String {
-    if let Some(pos) = dir_name.find("--") {
-        let (owner, repo) = dir_name.split_at(pos);
-        format!("{}/{}", owner, &repo[2..])
-    } else {
-        dir_name.to_string()
+    match GithubCacheId::from_cache_name(dir_name).parts() {
+        Some((owner, repo)) => format!("{}/{}", owner, repo),
+        None => dir_name.to_string(),
     }
 }
 

--- a/src/commands/manage/marketplace.rs
+++ b/src/commands/manage/marketplace.rs
@@ -1,7 +1,7 @@
 use crate::host::HostClientFactory;
 use crate::marketplace::{
-    normalize_name, normalize_source_path, to_display_source, MarketplaceConfig,
-    MarketplaceRegistration, MarketplaceRegistry,
+    normalize_name, normalize_source_path, MarketplaceConfig, MarketplaceRegistration,
+    MarketplaceRegistry, MarketplaceSourceRef,
 };
 use crate::repo;
 use clap::{Parser, Subcommand};
@@ -95,7 +95,7 @@ async fn run_list() -> Result<(), String> {
     table.set_header(vec!["NAME", "SOURCE", "PLUGINS", "LAST UPDATED"]);
 
     for entry in entries {
-        let source_display = to_display_source(&entry.source);
+        let source_display = entry.source.full_name();
         let (plugins_count, last_updated) = match registry.get(&entry.name) {
             Ok(Some(cache)) => {
                 let count = cache.plugins.len().to_string();
@@ -163,7 +163,7 @@ async fn run_add(source: String, name: Option<String>, path: Option<String>) -> 
 
     let entry = MarketplaceRegistration {
         name: normalized_name.clone(),
-        source: parsed_repo.full_name(),
+        source: MarketplaceSourceRef::from_repo(&parsed_repo),
         source_path,
     };
     config.add(entry)?;
@@ -227,14 +227,7 @@ async fn run_update(name: Option<String>) -> Result<(), String> {
 
     for entry in entries {
         print!("Updating '{}'... ", entry.name);
-        let repo = match repo::from_url(&entry.source) {
-            Ok(r) => r,
-            Err(e) => {
-                println!("FAILED");
-                failures.push((entry.name.clone(), e.to_string()));
-                continue;
-            }
-        };
+        let repo = entry.source.to_repo();
 
         let client = factory.create(repo.host());
         match registry
@@ -286,7 +279,7 @@ async fn run_show(name: String) -> Result<(), String> {
         .ok_or_else(|| format!("Marketplace '{}' not found.", name))?;
 
     println!("Marketplace: {}", entry.name);
-    println!("Source: {}", to_display_source(&entry.source));
+    println!("Source: {}", entry.source.full_name());
     println!("Path: {}", entry.source_path.as_deref().unwrap_or("(root)"));
 
     match registry.get(&name) {

--- a/src/marketplace.rs
+++ b/src/marketplace.rs
@@ -2,10 +2,10 @@ mod config;
 mod download;
 mod path;
 mod registry;
+mod source_ref;
 
 pub use config::{
-    normalize_name, normalize_source_path, to_display_source, to_internal_source,
-    MarketplaceConfig, MarketplaceRegistration,
+    normalize_name, normalize_source_path, MarketplaceConfig, MarketplaceRegistration,
 };
 // Re-exported for tests
 #[cfg(test)]
@@ -15,6 +15,7 @@ pub use path::PluginSourcePath;
 pub use registry::{
     validate_plugin_names, MarketplaceCache, MarketplaceManifest, MarketplaceRegistry, PluginSource,
 };
+pub use source_ref::MarketplaceSourceRef;
 // Re-exported for tests
 #[cfg(test)]
 pub use registry::MarketplacePlugin;

--- a/src/marketplace/config.rs
+++ b/src/marketplace/config.rs
@@ -1,3 +1,4 @@
+use crate::marketplace::MarketplaceSourceRef;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
@@ -8,7 +9,7 @@ const MAX_NAME_LENGTH: usize = 64;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MarketplaceRegistration {
     pub name: String,
-    pub source: String,
+    pub source: MarketplaceSourceRef,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source_path: Option<String>,
 }
@@ -206,33 +207,6 @@ pub fn normalize_source_path(path: &str) -> Result<Option<String>, String> {
     }
 
     Ok(Some(normalized.to_string()))
-}
-
-/// 内部表現からユーザー表示用に変換
-/// github:owner/repo → owner/repo
-///
-/// # Arguments
-///
-/// * `internal` - Internal source string (e.g. `github:owner/repo`).
-pub fn to_display_source(internal: &str) -> String {
-    internal
-        .strip_prefix("github:")
-        .unwrap_or(internal)
-        .to_string()
-}
-
-/// ユーザー入力から内部表現に変換
-/// owner/repo → github:owner/repo
-///
-/// # Arguments
-///
-/// * `display` - User-facing source string (e.g. `owner/repo`).
-pub fn to_internal_source(display: &str) -> String {
-    if display.starts_with("github:") {
-        display.to_string()
-    } else {
-        format!("github:{}", display)
-    }
 }
 
 #[cfg(test)]

--- a/src/marketplace/config_test.rs
+++ b/src/marketplace/config_test.rs
@@ -1,8 +1,8 @@
 #[cfg(test)]
 mod tests {
     use crate::marketplace::{
-        normalize_name, normalize_source_path, to_display_source, to_internal_source,
-        validate_name, MarketplaceConfig, MarketplaceRegistration,
+        normalize_name, normalize_source_path, validate_name, MarketplaceConfig,
+        MarketplaceRegistration,
     };
     use tempfile::TempDir;
 
@@ -143,32 +143,6 @@ mod tests {
         assert!(normalize_source_path("plugins\\marketplace").is_err());
     }
 
-    // ==================== to_display_source / to_internal_source tests ====================
-
-    #[test]
-    fn to_display_source_removes_github_prefix() {
-        let result = to_display_source("github:owner/repo");
-        assert_eq!(result, "owner/repo");
-    }
-
-    #[test]
-    fn to_display_source_returns_unchanged_if_no_prefix() {
-        let result = to_display_source("owner/repo");
-        assert_eq!(result, "owner/repo");
-    }
-
-    #[test]
-    fn to_internal_source_adds_github_prefix() {
-        let result = to_internal_source("owner/repo");
-        assert_eq!(result, "github:owner/repo");
-    }
-
-    #[test]
-    fn to_internal_source_returns_unchanged_if_already_prefixed() {
-        let result = to_internal_source("github:owner/repo");
-        assert_eq!(result, "github:owner/repo");
-    }
-
     // ==================== MarketplaceConfig tests ====================
 
     #[test]
@@ -202,7 +176,7 @@ mod tests {
 
         let entry = MarketplaceRegistration {
             name: "my-mp".to_string(),
-            source: "owner/repo".to_string(),
+            source: "owner/repo".parse().unwrap(),
             source_path: None,
         };
         config.add(entry).unwrap();
@@ -221,7 +195,7 @@ mod tests {
 
         let entry = MarketplaceRegistration {
             name: "test-mp".to_string(),
-            source: "owner/repo".to_string(),
+            source: "owner/repo".parse().unwrap(),
             source_path: None,
         };
         config.add(entry).unwrap();
@@ -238,14 +212,14 @@ mod tests {
 
         let entry1 = MarketplaceRegistration {
             name: "test-mp".to_string(),
-            source: "owner/repo1".to_string(),
+            source: "owner/repo1".parse().unwrap(),
             source_path: None,
         };
         config.add(entry1).unwrap();
 
         let entry2 = MarketplaceRegistration {
             name: "test-mp".to_string(),
-            source: "owner/repo2".to_string(),
+            source: "owner/repo2".parse().unwrap(),
             source_path: None,
         };
         assert!(config.add(entry2).is_err());
@@ -259,7 +233,7 @@ mod tests {
 
         let entry = MarketplaceRegistration {
             name: "test-mp".to_string(),
-            source: "owner/repo".to_string(),
+            source: "owner/repo".parse().unwrap(),
             source_path: None,
         };
         config.add(entry).unwrap();
@@ -286,14 +260,14 @@ mod tests {
 
         let entry = MarketplaceRegistration {
             name: "test-mp".to_string(),
-            source: "owner/repo".to_string(),
+            source: "owner/repo".parse().unwrap(),
             source_path: Some("plugins".to_string()),
         };
         config.add(entry).unwrap();
 
         let result = config.get("test-mp");
         assert!(result.is_some());
-        assert_eq!(result.unwrap().source, "owner/repo");
+        assert_eq!(result.unwrap().source.full_name(), "owner/repo");
         assert_eq!(result.unwrap().source_path, Some("plugins".to_string()));
     }
 
@@ -315,14 +289,14 @@ mod tests {
         config
             .add(MarketplaceRegistration {
                 name: "mp1".to_string(),
-                source: "owner/repo1".to_string(),
+                source: "owner/repo1".parse().unwrap(),
                 source_path: None,
             })
             .unwrap();
         config
             .add(MarketplaceRegistration {
                 name: "mp2".to_string(),
-                source: "owner/repo2".to_string(),
+                source: "owner/repo2".parse().unwrap(),
                 source_path: None,
             })
             .unwrap();

--- a/src/marketplace/download.rs
+++ b/src/marketplace/download.rs
@@ -54,35 +54,28 @@ async fn download_marketplace_plugin_with_registry(
 
     let cached = match &plugin_entry.source {
         MpPluginSource::Local(path) => {
-            let parts: Vec<&str> = mp_cache
-                .source
-                .strip_prefix("github:")
-                .unwrap_or(&mp_cache.source)
-                .split('/')
-                .collect();
-
-            if parts.len() < 2 {
-                return Err(PlmError::InvalidRepoFormat(mp_cache.source.clone()));
-            }
-
-            let owner = parts[0];
-            let repo_name = parts[1];
-            let repo = crate::repo::from_url(&format!("{}/{}", owner, repo_name))?;
+            let repo = mp_cache.source.to_repo();
             let source_path: PluginSourcePath = path.parse()?;
 
-            GitHubSource::with_marketplace_and_source_path(
+            GitHubSource::with_marketplace_plugin(
                 repo,
                 marketplace_name.to_string(),
-                source_path.into(),
+                Some(source_path.into()),
+                plugin_entry.name.clone(),
             )
             .download(cache, force)
             .await?
         }
         MpPluginSource::External { repo: repo_url, .. } => {
             let repo = crate::repo::from_url(repo_url)?;
-            GitHubSource::with_marketplace(repo, marketplace_name.to_string())
-                .download(cache, force)
-                .await?
+            GitHubSource::with_marketplace_plugin(
+                repo,
+                marketplace_name.to_string(),
+                None,
+                plugin_entry.name.clone(),
+            )
+            .download(cache, force)
+            .await?
         }
     };
 

--- a/src/marketplace/download_test.rs
+++ b/src/marketplace/download_test.rs
@@ -37,7 +37,7 @@ async fn test_download_with_registry_plugin_not_found() {
         .store(&MarketplaceCache {
             name: "test-marketplace".to_string(),
             fetched_at: Utc::now(),
-            source: "github:test/repo".to_string(),
+            source: "github:test/repo".parse().unwrap(),
             owner: None,
             plugins: vec![],
         })

--- a/src/marketplace/registry.rs
+++ b/src/marketplace/registry.rs
@@ -1,6 +1,7 @@
 use crate::error::{PlmError, Result};
 use crate::host::HostClient;
 use crate::marketplace::config::normalize_name;
+use crate::marketplace::MarketplaceSourceRef;
 use crate::repo::Repo;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -60,7 +61,7 @@ pub struct MarketplaceManifest {
 pub struct MarketplaceCache {
     pub name: String,
     pub fetched_at: DateTime<Utc>,
-    pub source: String,
+    pub source: MarketplaceSourceRef,
     #[serde(default)]
     pub owner: Option<MarketplaceOwner>,
     pub plugins: Vec<MarketplacePlugin>,
@@ -105,7 +106,7 @@ pub fn validate_plugin_names(plugins: &[MarketplacePlugin]) -> Result<()> {
 impl MarketplaceCache {
     /// MarketplaceManifest とメタ情報から MarketplaceCache を構築する。
     ///
-    /// - `source` は `"github:{repo_owner}/{repo_name}"` 形式で構築（`repo` 引数の owner / name を使用）
+    /// - `source` は `repo` 引数の owner / name から構築（保存形式は `"github:{owner}/{name}"`）
     /// - `fetched_at` は現在時刻（`Utc::now()`）
     ///
     /// # Arguments
@@ -117,7 +118,7 @@ impl MarketplaceCache {
         Self {
             name: name.to_string(),
             fetched_at: Utc::now(),
-            source: format!("github:{}/{}", repo.owner(), repo.name()),
+            source: MarketplaceSourceRef::from_repo(repo),
             owner: manifest.owner,
             plugins: manifest.plugins,
         }

--- a/src/marketplace/registry_test.rs
+++ b/src/marketplace/registry_test.rs
@@ -131,7 +131,7 @@ fn sample_manifest_json() -> String {
 #[test]
 fn from_manifest_sets_source_as_github_owner_name() {
     let cache = MarketplaceCache::from_manifest(sample_manifest(), "catalog", &sample_repo());
-    assert_eq!(cache.source, "github:acme/catalog");
+    assert_eq!(cache.source.to_string(), "github:acme/catalog");
 }
 
 #[test]
@@ -192,7 +192,7 @@ async fn fetch_cache_happy_path_with_none_source_path() {
         .expect("fetch_cache should succeed");
 
     assert_eq!(cache.name, "catalog");
-    assert_eq!(cache.source, "github:acme/catalog");
+    assert_eq!(cache.source.to_string(), "github:acme/catalog");
     assert_eq!(
         client.last_path().as_deref(),
         Some(".claude-plugin/marketplace.json")
@@ -331,6 +331,6 @@ fn parse_legacy_cache_with_original_manifest_ignores_unknown_field() {
     }"#;
     let cache: MarketplaceCache = serde_json::from_str(json).expect("parse must not fail");
     assert_eq!(cache.name, "legacy");
-    assert_eq!(cache.source, "github:o/n");
+    assert_eq!(cache.source.to_string(), "github:o/n");
     assert!(cache.plugins.is_empty());
 }

--- a/src/marketplace/source_ref.rs
+++ b/src/marketplace/source_ref.rs
@@ -1,0 +1,129 @@
+//! マーケットプレイスソース参照の値オブジェクト
+//!
+//! 「マーケットプレイスの取得元 GitHub リポジトリへの参照」を単一の型で表現する。
+//! 保存（内部）形式は `github:owner/repo` に正規化し、読み込みは
+//! プレフィックスなし（`owner/repo`）や URL 形式も受け付ける。
+
+use crate::error::PlmError;
+use crate::host::HostKind;
+use crate::repo::{self, Repo};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::fmt;
+use std::str::FromStr;
+
+/// 内部（保存）形式のプレフィックス
+const GITHUB_PREFIX: &str = "github:";
+
+/// マーケットプレイスの取得元 GitHub リポジトリへの参照
+///
+/// # 不変条件
+///
+/// - `owner` / `name` は空でない
+/// - `owner` / `name` はパス安全（`.` / `..` / パス区切りを含まない）
+///
+/// # 形式
+///
+/// - 内部（保存）形式: `github:owner/repo`（`Display` / `Serialize`）
+/// - 表示形式: `owner/repo`（`full_name()`）
+/// - パース: `github:` プレフィックスあり/なし、URL 形式のいずれも受理
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MarketplaceSourceRef {
+    owner: String,
+    name: String,
+}
+
+impl MarketplaceSourceRef {
+    /// `Repo` から参照を作成する（git ref は保持しない）
+    ///
+    /// # Arguments
+    ///
+    /// * `repo` - Source repository whose owner / name are captured.
+    pub fn from_repo(repo: &Repo) -> Self {
+        Self {
+            owner: repo.owner().to_string(),
+            name: repo.name().to_string(),
+        }
+    }
+
+    /// オーナー名
+    pub fn owner(&self) -> &str {
+        &self.owner
+    }
+
+    /// リポジトリ名
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// ユーザー表示用の `owner/repo` 形式
+    pub fn full_name(&self) -> String {
+        format!("{}/{}", self.owner, self.name)
+    }
+
+    /// GitHub の `Repo` へ変換する（git ref なし）
+    pub fn to_repo(&self) -> Repo {
+        self.to_repo_with_ref(None)
+    }
+
+    /// git ref を指定して `Repo` へ変換する
+    ///
+    /// マーケットプレイスソースは ref を持たないため、archive 取得などで
+    /// ref を確定させたい場合に呼び出し側から渡す。
+    ///
+    /// # Arguments
+    ///
+    /// * `git_ref` - Git reference to embed into the resulting `Repo`.
+    pub fn to_repo_with_ref(&self, git_ref: Option<String>) -> Repo {
+        Repo::new(
+            HostKind::GitHub,
+            self.owner.clone(),
+            self.name.clone(),
+            git_ref,
+        )
+    }
+}
+
+impl FromStr for MarketplaceSourceRef {
+    type Err = PlmError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let stripped = s.strip_prefix(GITHUB_PREFIX).unwrap_or(s);
+        // 正規パーサー（repo::from_url）へ委譲し、パースを一元化する
+        let parsed = repo::from_url(stripped)?;
+
+        // キャッシュディレクトリ名等に使われるため、パス安全性を保証する
+        for part in [parsed.owner(), parsed.name()] {
+            if part == "." || part == ".." || part.contains('\\') {
+                return Err(PlmError::InvalidSource(format!(
+                    "path-unsafe repository reference: {}",
+                    s
+                )));
+            }
+        }
+
+        Ok(Self::from_repo(&parsed))
+    }
+}
+
+impl fmt::Display for MarketplaceSourceRef {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}{}/{}", GITHUB_PREFIX, self.owner, self.name)
+    }
+}
+
+impl Serialize for MarketplaceSourceRef {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for MarketplaceSourceRef {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        s.parse().map_err(serde::de::Error::custom)
+    }
+}
+
+#[cfg(test)]
+#[path = "source_ref_test.rs"]
+mod tests;

--- a/src/marketplace/source_ref_test.rs
+++ b/src/marketplace/source_ref_test.rs
@@ -1,0 +1,112 @@
+use super::MarketplaceSourceRef;
+
+// ==================== parse ====================
+
+#[test]
+fn parse_accepts_internal_form_with_github_prefix() {
+    let source: MarketplaceSourceRef = "github:owner/repo".parse().unwrap();
+    assert_eq!(source.owner(), "owner");
+    assert_eq!(source.name(), "repo");
+}
+
+#[test]
+fn parse_accepts_display_form_without_prefix() {
+    let source: MarketplaceSourceRef = "owner/repo".parse().unwrap();
+    assert_eq!(source.owner(), "owner");
+    assert_eq!(source.name(), "repo");
+}
+
+#[test]
+fn parse_accepts_https_url() {
+    let source: MarketplaceSourceRef = "https://github.com/owner/repo".parse().unwrap();
+    assert_eq!(source.owner(), "owner");
+    assert_eq!(source.name(), "repo");
+}
+
+#[test]
+fn parse_rejects_missing_repo_name() {
+    assert!("owner".parse::<MarketplaceSourceRef>().is_err());
+    assert!("github:owner".parse::<MarketplaceSourceRef>().is_err());
+}
+
+#[test]
+fn parse_rejects_empty() {
+    assert!("".parse::<MarketplaceSourceRef>().is_err());
+    assert!("github:".parse::<MarketplaceSourceRef>().is_err());
+}
+
+#[test]
+fn parse_rejects_path_unsafe_names() {
+    assert!("github:owner/..".parse::<MarketplaceSourceRef>().is_err());
+    assert!("github:owner/.".parse::<MarketplaceSourceRef>().is_err());
+    assert!("github:../repo".parse::<MarketplaceSourceRef>().is_err());
+    assert!(r"github:owner/re\po"
+        .parse::<MarketplaceSourceRef>()
+        .is_err());
+}
+
+// ==================== display / full_name ====================
+
+#[test]
+fn display_uses_canonical_internal_form() {
+    let source: MarketplaceSourceRef = "owner/repo".parse().unwrap();
+    assert_eq!(source.to_string(), "github:owner/repo");
+}
+
+#[test]
+fn full_name_returns_display_form() {
+    let source: MarketplaceSourceRef = "github:owner/repo".parse().unwrap();
+    assert_eq!(source.full_name(), "owner/repo");
+}
+
+// ==================== to_repo / from_repo ====================
+
+#[test]
+fn to_repo_builds_github_repo_without_ref() {
+    let source: MarketplaceSourceRef = "github:owner/repo".parse().unwrap();
+    let repo = source.to_repo();
+    assert_eq!(repo.owner(), "owner");
+    assert_eq!(repo.name(), "repo");
+    assert!(repo.git_ref().is_none());
+}
+
+#[test]
+fn to_repo_with_ref_embeds_git_ref() {
+    let source: MarketplaceSourceRef = "github:owner/repo".parse().unwrap();
+    let repo = source.to_repo_with_ref(Some("main".to_string()));
+    assert_eq!(repo.git_ref(), Some("main"));
+}
+
+#[test]
+fn from_repo_roundtrips_through_to_repo() {
+    let source: MarketplaceSourceRef = "owner/repo".parse().unwrap();
+    let roundtripped = MarketplaceSourceRef::from_repo(&source.to_repo());
+    assert_eq!(roundtripped, source);
+}
+
+// ==================== serde ====================
+
+#[test]
+fn serializes_as_canonical_internal_form() {
+    let source: MarketplaceSourceRef = "owner/repo".parse().unwrap();
+    let json = serde_json::to_string(&source).unwrap();
+    assert_eq!(json, r#""github:owner/repo""#);
+}
+
+#[test]
+fn deserializes_internal_form() {
+    let source: MarketplaceSourceRef = serde_json::from_str(r#""github:owner/repo""#).unwrap();
+    assert_eq!(source.full_name(), "owner/repo");
+}
+
+#[test]
+fn deserializes_legacy_display_form() {
+    // 旧 marketplaces.json はプレフィックスなしで保存されていた
+    let source: MarketplaceSourceRef = serde_json::from_str(r#""owner/repo""#).unwrap();
+    assert_eq!(source.to_string(), "github:owner/repo");
+}
+
+#[test]
+fn deserialize_rejects_invalid_source() {
+    assert!(serde_json::from_str::<MarketplaceSourceRef>(r#""not-a-repo""#).is_err());
+}

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -4,7 +4,9 @@ mod lifecycle;
 pub mod meta;
 
 pub(crate) use cache::{cleanup_legacy_hierarchy, cleanup_plugin_directories, list_installed};
-pub use cache::{CachedPackage, LegacyCacheCleaner, PackageCache, PackageCacheAccess};
+pub use cache::{
+    CachedPackage, GithubCacheId, LegacyCacheCleaner, PackageCache, PackageCacheAccess,
+};
 pub(crate) use content::{load_plugin, Plugin};
 pub use content::{InstalledPlugin, MarketplaceContent};
 pub use lifecycle::{

--- a/src/plugin/cache.rs
+++ b/src/plugin/cache.rs
@@ -2,10 +2,12 @@
 mod cache;
 mod cached_package;
 mod cleanup;
+mod github_cache_id;
 mod legacy_cache_cleaner;
 
 pub(crate) use cache::list_installed;
 pub use cache::{PackageCache, PackageCacheAccess};
 pub use cached_package::CachedPackage;
 pub(crate) use cleanup::{cleanup_legacy_hierarchy, cleanup_plugin_directories};
+pub use github_cache_id::GithubCacheId;
 pub use legacy_cache_cleaner::LegacyCacheCleaner;

--- a/src/plugin/cache/github_cache_id.rs
+++ b/src/plugin/cache/github_cache_id.rs
@@ -1,0 +1,80 @@
+//! 直接 GitHub インストールのキャッシュ ID 値オブジェクト
+//!
+//! 直接 GitHub からインストールしたプラグインのキャッシュディレクトリ名
+//! （`{owner}--{repo}` 形式）のエンコード・デコードを一元化する。
+
+use crate::repo::Repo;
+use std::fmt;
+
+/// owner と repo の区切り文字
+///
+/// GitHub のユーザー名・組織名は連続ハイフンを含められないため、
+/// 最初に現れる `--` が常に owner / repo の境界になる。
+const SEPARATOR: &str = "--";
+
+/// 直接 GitHub インストールのキャッシュ ID（`{owner}--{repo}` 形式）
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GithubCacheId(String);
+
+impl GithubCacheId {
+    /// `Repo` からキャッシュ ID を生成する
+    ///
+    /// # Arguments
+    ///
+    /// * `repo` - Repository whose owner / name compose the cache ID.
+    pub fn from_repo(repo: &Repo) -> Self {
+        Self::from_parts(repo.owner(), repo.name())
+    }
+
+    /// owner / repo 名からキャッシュ ID を生成する
+    ///
+    /// # Arguments
+    ///
+    /// * `owner` - GitHub owner (user or organization).
+    /// * `name` - GitHub repository name.
+    pub fn from_parts(owner: &str, name: &str) -> Self {
+        Self(format!("{}{}{}", owner, SEPARATOR, name))
+    }
+
+    /// 既存のキャッシュディレクトリ名（プラグイン名）をラップする
+    ///
+    /// `{owner}--{repo}` 形式でない名前も受け付ける（その場合 `parts()` は `None`）。
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - Cache directory name to interpret as a cache ID.
+    pub fn from_cache_name(name: &str) -> Self {
+        Self(name.to_string())
+    }
+
+    /// `{owner}--{repo}` 形式なら `(owner, repo)` を返す
+    ///
+    /// 形式に合致しない（区切りがない、owner / repo が空）場合は `None`。
+    pub fn parts(&self) -> Option<(&str, &str)> {
+        let (owner, name) = self.0.split_once(SEPARATOR)?;
+        if owner.is_empty() || name.is_empty() {
+            return None;
+        }
+        Some((owner, name))
+    }
+
+    /// キャッシュディレクトリ名としての文字列表現
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// 文字列へ変換する（キャッシュディレクトリ名）
+    pub fn into_string(self) -> String {
+        self.0
+    }
+}
+
+impl fmt::Display for GithubCacheId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+#[cfg(test)]
+#[path = "github_cache_id_test.rs"]
+mod tests;

--- a/src/plugin/cache/github_cache_id_test.rs
+++ b/src/plugin/cache/github_cache_id_test.rs
@@ -1,0 +1,42 @@
+use super::GithubCacheId;
+use crate::host::HostKind;
+use crate::repo::Repo;
+
+#[test]
+fn from_repo_encodes_owner_and_name() {
+    let repo = Repo::new(HostKind::GitHub, "owner", "repo", None);
+    let id = GithubCacheId::from_repo(&repo);
+    assert_eq!(id.as_str(), "owner--repo");
+}
+
+#[test]
+fn from_parts_encodes_owner_and_name() {
+    let id = GithubCacheId::from_parts("owner", "repo");
+    assert_eq!(id.to_string(), "owner--repo");
+}
+
+#[test]
+fn parts_decodes_encoded_id() {
+    let id = GithubCacheId::from_parts("owner", "repo");
+    assert_eq!(id.parts(), Some(("owner", "repo")));
+}
+
+#[test]
+fn parts_roundtrips_repo_name_containing_separator() {
+    // GitHub の owner 名は連続ハイフンを含められないため、
+    // repo 名に `--` が含まれても最初の区切りで正しく復元できる
+    let id = GithubCacheId::from_parts("owner", "my--repo");
+    assert_eq!(id.parts(), Some(("owner", "my--repo")));
+}
+
+#[test]
+fn parts_returns_none_without_separator() {
+    let id = GithubCacheId::from_cache_name("plain-name");
+    assert_eq!(id.parts(), None);
+}
+
+#[test]
+fn parts_returns_none_for_empty_owner_or_name() {
+    assert_eq!(GithubCacheId::from_cache_name("--repo").parts(), None);
+    assert_eq!(GithubCacheId::from_cache_name("owner--").parts(), None);
+}

--- a/src/plugin/cache/legacy_cache_cleaner.rs
+++ b/src/plugin/cache/legacy_cache_cleaner.rs
@@ -19,9 +19,10 @@ impl LegacyCacheCleaner {
     ///
     /// 検出条件（すべて満たすときのみ削除）:
     /// 1. `mp_cache.plugins.len() > 1`
-    /// 2. `mp_cache.source` から repo.name() を抽出できる
-    /// 3. `<market>/<repo.name()>/` が物理的に存在する
-    /// 4. `<repo.name()>` が `plugins[].name` のどれにも一致しない
+    /// 2. `<market>/<repo.name()>/` が物理的に存在する
+    /// 3. `<repo.name()>` が `plugins[].name` のどれにも一致しない
+    ///
+    /// repo 名のパス安全性は `MarketplaceSourceRef` の不変条件として保証済み。
     ///
     /// # Arguments
     ///
@@ -41,45 +42,21 @@ impl LegacyCacheCleaner {
             return Ok(false);
         }
 
-        let Some(legacy_dir_name) = extract_repo_name(&mp_cache.source) else {
-            return Ok(false);
-        };
+        let legacy_dir_name = mp_cache.source.name();
 
         let plugin_names: HashSet<&str> =
             mp_cache.plugins.iter().map(|p| p.name.as_str()).collect();
-        if plugin_names.contains(legacy_dir_name.as_str()) {
+        if plugin_names.contains(legacy_dir_name) {
             return Ok(false);
         }
 
-        if !cache.has_marketplace_entry(marketplace_name, &legacy_dir_name)? {
+        if !cache.has_marketplace_entry(marketplace_name, legacy_dir_name)? {
             return Ok(false);
         }
 
-        cache.remove_marketplace_entry(marketplace_name, &legacy_dir_name)?;
+        cache.remove_marketplace_entry(marketplace_name, legacy_dir_name)?;
         Ok(true)
     }
-}
-
-/// `"github:owner/repo"` → `Some("repo")`
-///
-/// パストラバーサル防止のため、抽出した名前が空 / `.` / `..` /
-/// パス区切り（`/`, `\`）を含む場合は `None` を返し、clean を無効化する。
-///
-/// # Arguments
-///
-/// * `source` - Marketplace source string in `github:owner/repo` form.
-fn extract_repo_name(source: &str) -> Option<String> {
-    let stripped = source.strip_prefix("github:").unwrap_or(source);
-    let candidate = stripped.rsplit('/').next()?;
-    if candidate.is_empty()
-        || candidate == "."
-        || candidate == ".."
-        || candidate.contains('/')
-        || candidate.contains('\\')
-    {
-        return None;
-    }
-    Some(candidate.to_string())
 }
 
 #[cfg(test)]

--- a/src/plugin/cache/legacy_cache_cleaner_test.rs
+++ b/src/plugin/cache/legacy_cache_cleaner_test.rs
@@ -9,7 +9,7 @@ fn make_cache(plugins: Vec<&str>) -> MarketplaceCache {
     MarketplaceCache {
         name: "d-market".to_string(),
         fetched_at: Utc::now(),
-        source: "github:owner/d-market-git".to_string(),
+        source: "github:owner/d-market-git".parse().unwrap(),
         owner: None,
         plugins: plugins
             .into_iter()

--- a/src/plugin/lifecycle/update.rs
+++ b/src/plugin/lifecycle/update.rs
@@ -7,10 +7,12 @@ use crate::application::enable_plugin;
 use crate::error::{PlmError, Result};
 use crate::host::{HostClient, HostClientFactory, HostKind};
 use crate::http::with_retry;
-use crate::marketplace::{MarketplaceCache, MarketplaceRegistry, PluginSource as MpPluginSource};
+use crate::marketplace::{
+    MarketplaceCache, MarketplaceRegistry, MarketplaceSourceRef, PluginSource as MpPluginSource,
+};
 use crate::plugin::lifecycle::plugin_resolver::{find_by_plugin_name, ResolvedPlugin};
 use crate::plugin::version::needs_update;
-use crate::plugin::{meta, PackageCacheAccess, PluginMeta};
+use crate::plugin::{meta, GithubCacheId, PackageCacheAccess, PluginMeta};
 use crate::repo::{self, Repo};
 use std::path::Path;
 
@@ -165,25 +167,21 @@ fn restore_repo(
         return Ok(repo);
     }
 
-    let parts: Vec<&str> = plugin_name.split("--").collect();
-    if parts.len() == 2 {
-        let repo = Repo::new(
+    match GithubCacheId::from_cache_name(plugin_name).parts() {
+        Some((owner, name)) => Ok(Repo::new(
             HostKind::GitHub,
-            parts[0],
-            parts[1],
+            owner,
+            name,
             Some(git_ref.to_string()),
-        );
-        Ok(repo)
-    } else {
-        Err(format!(
+        )),
+        None => Err(format!(
             "Cannot determine repository from plugin name: {}",
             plugin_name
-        ))
+        )),
     }
 }
 
-/// `MarketplaceCache.source` (`"github:{owner}/{name}"` 形式) と `PluginSource` から
-/// archive 取得用の `Repo` を再構築する。
+/// `MarketplaceCache.source` と `PluginSource` から archive 取得用の `Repo` を再構築する。
 ///
 /// `git_ref` は呼び出し側で必ず渡す（ローカル `PluginMeta.git_ref` を `unwrap_or("HEAD")` 等で解決）。
 /// `MarketplaceCache.source` は ref を持たないため、`Repo` に ref を詰めることで
@@ -191,23 +189,20 @@ fn restore_repo(
 ///
 /// # Arguments
 ///
-/// * `mp_source` - Marketplace source string in `github:owner/repo` form.
+/// * `mp_source` - Marketplace source repository reference.
 /// * `plugin_source` - Plugin source descriptor from the marketplace cache entry.
 /// * `git_ref` - Git reference to embed into the resulting `Repo`.
 fn parse_repo_from_mp_source(
-    mp_source: &str,
+    mp_source: &MarketplaceSourceRef,
     plugin_source: &MpPluginSource,
     git_ref: Option<&str>,
 ) -> Result<Repo> {
     // External は `repo` 文字列を `repo::from_url` で解析（`owner/repo@tag` や HTTPS URL に対応）。
     // 取り出した owner / name を使って、ローカル `PluginMeta.git_ref` で上書きした `Repo` を返す。
-    // Local は marketplace 自体の repo を参照（mp_source の "github:owner/name" を strip して再構築）。
+    // Local は marketplace 自体の repo を参照する。
     let parsed = match plugin_source {
         MpPluginSource::External { repo, .. } => repo::from_url(repo)?,
-        MpPluginSource::Local(_) => {
-            let stripped = mp_source.strip_prefix("github:").unwrap_or(mp_source);
-            repo::from_url(stripped)?
-        }
+        MpPluginSource::Local(_) => mp_source.to_repo(),
     };
     Ok(Repo::new(
         parsed.host(),

--- a/src/plugin/lifecycle/update_test.rs
+++ b/src/plugin/lifecycle/update_test.rs
@@ -289,7 +289,7 @@ mod batch {
             Ok(Some(MarketplaceCache {
                 name: self.market.clone(),
                 fetched_at: chrono::Utc::now(),
-                source: format!("github:owner/{}", self.market),
+                source: format!("github:owner/{}", self.market).parse().unwrap(),
                 owner: None,
                 plugins,
             }))

--- a/src/source/github_source.rs
+++ b/src/source/github_source.rs
@@ -2,28 +2,37 @@
 
 use crate::error::Result;
 use crate::host::HostClientFactory;
-use crate::plugin::{meta, CachedPackage, PackageCacheAccess};
+use crate::plugin::{meta, CachedPackage, GithubCacheId, PackageCacheAccess};
 use crate::repo::Repo;
 use std::future::Future;
 use std::pin::Pin;
 
 use super::PackageSource;
 
+/// ダウンロードの文脈（直接 GitHub か marketplace 経由か）
+///
+/// 有効な組み合わせを型で表現し、不正状態（marketplace なしの
+/// plugin_identifier 等）を表現不能にする。
+enum SourceContext {
+    /// 直接 GitHub install（cache key は `{owner}--{repo}`）
+    Direct,
+    /// marketplace 経由 install
+    Marketplace {
+        /// marketplace 名
+        name: String,
+        /// marketplace 内でユニークなプラグイン識別子（validated 済み、cache key として使用）
+        plugin_identifier: String,
+        /// Local プラグインのソースパス（正規化済み）。External プラグインは `None`
+        source_path: Option<String>,
+    },
+}
+
 /// Git リポジトリからプラグインをダウンロードするソース
 ///
 /// GitHub, GitLab, Bitbucket 等のホスティングサービスに対応。
 pub struct GitHubSource {
     repo: Repo,
-    /// マーケットプレイス経由の場合はその名前
-    marketplace: Option<String>,
-    /// プラグインのソースパス（正規化済み）
-    /// マーケットプレイス内の Local プラグイン用
-    source_path: Option<String>,
-    /// marketplace 内でユニークなプラグイン識別子
-    ///
-    /// marketplace 経由 install のときに `MarketplacePlugin.name` (validated) を入れる。
-    /// `None` の場合は `repo.name()` にフォールバックする（直接 GitHub install 経路）。
-    plugin_identifier: Option<String>,
+    context: SourceContext,
 }
 
 impl GitHubSource {
@@ -35,53 +44,11 @@ impl GitHubSource {
     pub fn new(repo: Repo) -> Self {
         Self {
             repo,
-            marketplace: None,
-            source_path: None,
-            plugin_identifier: None,
+            context: SourceContext::Direct,
         }
     }
 
-    /// マーケットプレイス経由でのソースを作成
-    ///
-    /// # Arguments
-    ///
-    /// * `repo` - Repository descriptor for the underlying Git source.
-    /// * `marketplace` - Name of the marketplace that surfaced this plugin.
-    pub fn with_marketplace(repo: Repo, marketplace: String) -> Self {
-        Self {
-            repo,
-            marketplace: Some(marketplace),
-            source_path: None,
-            plugin_identifier: None,
-        }
-    }
-
-    /// マーケットプレイス経由 + ソースパス指定でのソース作成
-    /// Local プラグイン専用: marketplace と source_path は両方必須
-    ///
-    /// # Arguments
-    ///
-    /// * `repo` - Repository descriptor for the underlying Git source.
-    /// * `marketplace` - Name of the marketplace that surfaced this plugin.
-    /// * `source_path` - Normalized sub-path within the repository pointing at the local plugin.
-    pub fn with_marketplace_and_source_path(
-        repo: Repo,
-        marketplace: String,
-        source_path: String,
-    ) -> Self {
-        Self {
-            repo,
-            marketplace: Some(marketplace),
-            source_path: Some(source_path),
-            plugin_identifier: None,
-        }
-    }
-
-    /// marketplace 経由インストール用フルコンストラクタ。
-    ///
-    /// - `marketplace`: marketplace 名（必須）
-    /// - `source_path`: External プラグインで `None`、Local プラグインで `Some` を渡す
-    /// - `plugin_identifier`: validated 済みのプラグイン識別子（cache key として使用）
+    /// marketplace 経由インストール用コンストラクタ。
     ///
     /// # Arguments
     ///
@@ -97,23 +64,40 @@ impl GitHubSource {
     ) -> Self {
         Self {
             repo,
-            marketplace: Some(marketplace),
-            source_path,
-            plugin_identifier: Some(plugin_identifier),
+            context: SourceContext::Marketplace {
+                name: marketplace,
+                plugin_identifier,
+                source_path,
+            },
+        }
+    }
+
+    /// marketplace 名（直接 GitHub の場合は `None`）
+    fn marketplace_name(&self) -> Option<&str> {
+        match &self.context {
+            SourceContext::Direct => None,
+            SourceContext::Marketplace { name, .. } => Some(name),
+        }
+    }
+
+    /// Local プラグインのソースパス（直接 GitHub / External の場合は `None`）
+    fn source_path(&self) -> Option<&str> {
+        match &self.context {
+            SourceContext::Direct => None,
+            SourceContext::Marketplace { source_path, .. } => source_path.as_deref(),
         }
     }
 
     /// このソースの cache key を算出する
     ///
-    /// - marketplace 経由: `plugin_identifier` を優先。`None` のときは `repo.name()` フォールバック
-    /// - 直接 GitHub: `"{owner}--{repo}"`
+    /// - marketplace 経由: `plugin_identifier`
+    /// - 直接 GitHub: `"{owner}--{repo}"`（`GithubCacheId`）
     fn compute_cache_name(&self) -> String {
-        if self.marketplace.is_none() {
-            format!("{}--{}", self.repo.owner(), self.repo.name())
-        } else {
-            self.plugin_identifier
-                .clone()
-                .unwrap_or_else(|| self.repo.name().to_string())
+        match &self.context {
+            SourceContext::Direct => GithubCacheId::from_repo(&self.repo).into_string(),
+            SourceContext::Marketplace {
+                plugin_identifier, ..
+            } => plugin_identifier.clone(),
         }
     }
 }
@@ -128,10 +112,15 @@ impl PackageSource for GitHubSource {
             let factory = HostClientFactory::with_defaults();
             let client = factory.create(self.repo.host());
             let display_name = self.repo.name();
-            let marketplace = self.marketplace.as_deref();
+            let marketplace = self.marketplace_name();
 
             let cache_name = self.compute_cache_name();
-            let log_label = self.plugin_identifier.as_deref().unwrap_or(display_name);
+            let log_label = match &self.context {
+                SourceContext::Direct => display_name,
+                SourceContext::Marketplace {
+                    plugin_identifier, ..
+                } => plugin_identifier,
+            };
 
             if !force && cache.is_cached(marketplace, &cache_name) {
                 println!(
@@ -150,12 +139,8 @@ impl PackageSource for GitHubSource {
                 client.download_archive_with_sha(&self.repo).await?;
 
             println!("Extracting to cache...");
-            let plugin_path = cache.store_from_archive(
-                marketplace,
-                &cache_name,
-                &archive,
-                self.source_path.as_deref(),
-            )?;
+            let plugin_path =
+                cache.store_from_archive(marketplace, &cache_name, &archive, self.source_path())?;
 
             let manifest = cache.load_manifest(marketplace, &cache_name)?;
 
@@ -171,7 +156,7 @@ impl PackageSource for GitHubSource {
             Ok(CachedPackage {
                 name: manifest.name.clone(),
                 id: Some(cache_name.clone()),
-                marketplace: self.marketplace.clone(),
+                marketplace: self.marketplace_name().map(String::from),
                 path: plugin_path,
                 manifest,
                 git_ref,

--- a/src/source/marketplace_source.rs
+++ b/src/source/marketplace_source.rs
@@ -69,21 +69,7 @@ impl PackageSource for MarketplaceSource {
 
             let mut cached = match &plugin_entry.source {
                 MpPluginSource::Local(path) => {
-                    let parts: Vec<&str> = mp_cache
-                        .source
-                        .strip_prefix("github:")
-                        .unwrap_or(&mp_cache.source)
-                        .split('/')
-                        .collect();
-
-                    if parts.len() < 2 {
-                        return Err(PlmError::InvalidRepoFormat(mp_cache.source.clone()));
-                    }
-
-                    let owner = parts[0];
-                    let repo_name = parts[1];
-                    let repo = repo::from_url(&format!("{}/{}", owner, repo_name))?;
-
+                    let repo = mp_cache.source.to_repo();
                     let source_path: PluginSourcePath = path.parse()?;
 
                     GitHubSource::with_marketplace_plugin(

--- a/src/target.rs
+++ b/src/target.rs
@@ -82,7 +82,7 @@ impl PluginOrigin {
     pub fn from_github(owner: &str, repo: &str) -> Self {
         Self {
             marketplace: "github".to_string(),
-            plugin: format!("{}--{}", owner, repo),
+            plugin: crate::plugin::GithubCacheId::from_parts(owner, repo).into_string(),
         }
     }
 

--- a/src/tui/manager/core/data.rs
+++ b/src/tui/manager/core/data.rs
@@ -5,7 +5,7 @@
 
 use crate::application::{list_installed_plugins, InstalledPlugin};
 use crate::component::ComponentKind;
-use crate::marketplace::{to_display_source, MarketplaceConfig, MarketplaceRegistry};
+use crate::marketplace::{MarketplaceConfig, MarketplaceRegistry};
 use crate::plugin::PackageCache;
 use std::io;
 
@@ -235,7 +235,7 @@ fn load_marketplaces() -> LoadMarketplacesOutcome {
                 .iter()
                 .map(|entry| MarketplaceItem {
                     name: entry.name.clone(),
-                    source: to_display_source(&entry.source),
+                    source: entry.source.full_name(),
                     source_path: entry.source_path.clone(),
                     plugin_count: None,
                     last_updated: None,
@@ -261,7 +261,7 @@ fn load_marketplaces() -> LoadMarketplacesOutcome {
             };
             MarketplaceItem {
                 name: entry.name.clone(),
-                source: to_display_source(&entry.source),
+                source: entry.source.full_name(),
                 source_path: entry.source_path.clone(),
                 plugin_count,
                 last_updated,

--- a/src/tui/manager/screens/marketplaces/actions.rs
+++ b/src/tui/manager/screens/marketplaces/actions.rs
@@ -8,8 +8,8 @@ use crate::component::Scope;
 use crate::host::HostClientFactory;
 use crate::install::{self, PlaceRequest};
 use crate::marketplace::{
-    download_marketplace_plugin_with_cache, to_display_source, to_internal_source,
-    MarketplaceCache, MarketplaceConfig, MarketplaceRegistration, MarketplaceRegistry,
+    download_marketplace_plugin_with_cache, MarketplaceCache, MarketplaceConfig,
+    MarketplaceRegistration, MarketplaceRegistry, MarketplaceSourceRef,
 };
 use crate::plugin::{PackageCache, PackageCacheAccess};
 use crate::repo;
@@ -39,7 +39,7 @@ pub fn add_marketplace(
         .map_err(|_| "No Tokio runtime available".to_string())?;
 
     let repo = repo::from_url(source).map_err(|e| e.to_string())?;
-    let internal_source = to_internal_source(&repo.full_name());
+    let source_ref = MarketplaceSourceRef::from_repo(&repo);
 
     let mut config = MarketplaceConfig::load()?;
 
@@ -49,7 +49,7 @@ pub fn add_marketplace(
 
     let entry = MarketplaceRegistration {
         name: name.to_string(),
-        source: internal_source.clone(),
+        source: source_ref.clone(),
         source_path: source_path.map(|s| s.to_string()),
     };
 
@@ -71,7 +71,7 @@ pub fn add_marketplace(
     Ok(MarketplaceAddOutcome {
         marketplace: MarketplaceItem {
             name: name.to_string(),
-            source: to_display_source(&internal_source),
+            source: source_ref.full_name(),
             source_path: source_path.map(|s| s.to_string()),
             plugin_count: Some(cache.plugins.len()),
             last_updated: Some(cache.fetched_at.format("%Y-%m-%d %H:%M").to_string()),
@@ -123,8 +123,8 @@ fn update_marketplace_registration(
     let handle = tokio::runtime::Handle::try_current()
         .map_err(|_| "No Tokio runtime available".to_string())?;
 
-    let display_source = to_display_source(&entry.source);
-    let repo = repo::from_url(&display_source).map_err(|e| e.to_string())?;
+    let display_source = entry.source.full_name();
+    let repo = entry.source.to_repo();
     let factory = HostClientFactory::with_defaults();
     let client = factory.create(repo.host());
     let registry = MarketplaceRegistry::new().map_err(|e| e.to_string())?;

--- a/src/tui/manager/screens/marketplaces/actions_test.rs
+++ b/src/tui/manager/screens/marketplaces/actions_test.rs
@@ -39,7 +39,7 @@ fn make_cache(name: &str, plugins: Vec<MarketplacePlugin>) -> MarketplaceCache {
     MarketplaceCache {
         name: name.to_string(),
         fetched_at: chrono::Utc::now(),
-        source: "owner/repo".to_string(),
+        source: "owner/repo".parse().unwrap(),
         owner: None,
         plugins,
     }


### PR DESCRIPTION
## 概要

Closes #334

「GitHub リポジトリへの参照」というドメイン概念を値オブジェクトで表現し、生文字列のパース・組み立ての散在を解消するリファクタリングです。Issue の提案 1〜5 をすべて実装しています。

## 変更内容

### 1. `MarketplaceSourceRef` 値オブジェクトを導入（`src/marketplace/source_ref.rs`）

- `github:` プレフィックスあり/なし・URL 形式のパース（`FromStr`、内部で正規パーサー `repo::from_url` へ委譲）、正規形 `github:owner/repo` での `Display` / serde、`owner()` / `name()` / `full_name()` / `to_repo()` / `to_repo_with_ref()` を提供
- `MarketplaceCache::source` / `MarketplaceRegistration::source` をこの型に変更
- strip-and-split が重複していた5箇所（`marketplace_source.rs` / `download.rs` / `update.rs` / `legacy_cache_cleaner.rs` / `config.rs`）を `source.to_repo()` 等に集約。`marketplace_source.rs` の二重パース（split → format → 再パース）も解消
- `PluginSourcePath` と同様の検証付き値オブジェクトとして、パス不安全な名前（`.` / `..` / `\`）をパース時に拒否

### 2. `GithubCacheId` 値オブジェクトを導入（`src/plugin/cache/github_cache_id.rs`）

- `{owner}--{repo}` キャッシュキーの encode 2箇所（`github_source.rs` / `PluginOrigin::from_github`）と decode 箇所（`update.rs::restore_repo`、加えて issue 未記載だった `application/info.rs::restore_github_repo`）を1つの型に集約
- 区切り文字の知識が型に閉じ、変更してもサイレントに壊れない

### 3. 保存形式を `github:owner/repo` に正規化

- 書き込みは常に正規形。読み込みは旧形式（プレフィックスなし `owner/repo`）も受理するため既存の `marketplaces.json` と後方互換
- `to_display_source` / `to_internal_source` のプレフィックス操作を削除（表示は `full_name()`）

### 4. `Repo` 復元を正規経路に統一

- `parse_repo_from_mp_source` の Local 経路は `mp_source.to_repo()` に、`restore_repo` のフォールバックは `GithubCacheId::parts()` 経由に変更し、手組みの strip/split を排除

### 5. `GitHubSource` のテレスコーピングコンストラクタを enum 化

- 4つのコンストラクタを `new`（Direct）と `with_marketplace_plugin`（Marketplace）の2つに削減
- `SourceContext` enum（`Direct | Marketplace { name, plugin_identifier, source_path }`）で不正な組み合わせを型レベルで表現不能に

## テスト

- 新規値オブジェクトに 21 件のユニットテストを追加（パース両形式・正規形シリアライズ・後方互換デシリアライズ・パス安全性・`--` ラウンドトリップ等）
- `cargo fmt` / `cargo check` / `cargo clippy`（新規警告なし）/ `cargo test` **1749 passed, 0 failed** を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GGDjZv8CJtPGTZQoKdRY9B

---
_Generated by [Claude Code](https://claude.ai/code/session_01GGDjZv8CJtPGTZQoKdRY9B)_