### PR TITLE
refactor: centralize default marketplace "github" and turn PluginOrigin into an enum

### DIFF
--- a/src/application/catalog.rs
+++ b/src/application/catalog.rs
@@ -38,9 +38,8 @@ pub fn list_installed_plugins(cache: &dyn PackageCacheAccess) -> Result<Vec<Inst
         .into_iter()
         .filter_map(|pkg| {
             let name = pkg.manifest().name.clone();
-            let marketplace_str = pkg.marketplace().unwrap_or("github");
             let ops_key = pkg.id().unwrap_or(&name);
-            let origin = PluginOrigin::from_marketplace(marketplace_str, ops_key);
+            let origin = PluginOrigin::from_cached_plugin(pkg.marketplace(), ops_key);
             let plugin =
                 Plugin::new(pkg.manifest().clone(), pkg.path().to_path_buf(), origin).ok()?;
             // flatten_name の prefix は manifest.name に基づくため

--- a/src/application/info.rs
+++ b/src/application/info.rs
@@ -3,6 +3,7 @@
 //! 特定のプラグインの詳細情報を取得するユースケースを提供する。
 
 use crate::error::{PlmError, Result};
+use crate::marketplace::MarketplaceRef;
 use crate::plugin::{
     list_installed, meta, GithubCacheId, InstalledPlugin, MarketplaceContent, PackageCacheAccess,
     Plugin,
@@ -132,7 +133,7 @@ fn resolve_single_plugin(
     let filtered: Vec<_> = if let Some(mp) = marketplace_filter {
         candidates
             .into_iter()
-            .filter(|c| c.marketplace().unwrap_or("github") == mp)
+            .filter(|c| MarketplaceRef::from_option(c.marketplace()).dir_name() == mp)
             .collect()
     } else {
         candidates
@@ -147,7 +148,7 @@ fn resolve_single_plugin(
                 .map(|c| {
                     format!(
                         "{}/{}",
-                        c.marketplace().unwrap_or("github"),
+                        MarketplaceRef::from_option(c.marketplace()),
                         c.manifest().name
                     )
                 })
@@ -164,17 +165,16 @@ fn resolve_single_plugin(
 ///
 /// # Arguments
 ///
-/// * `marketplace` - Marketplace key (e.g. `"github"`).
+/// * `marketplace` - Marketplace reference.
 /// * `dir_name` - Cache directory name associated with the plugin.
-fn determine_source(marketplace: &str, dir_name: &str) -> Source {
-    if marketplace == "github" {
-        // owner--repo → owner/repo
-        let repository = restore_github_repo(dir_name);
-        Source::GitHub { repository }
-    } else {
-        Source::Marketplace {
-            name: marketplace.to_string(),
+fn determine_source(marketplace: &MarketplaceRef, dir_name: &str) -> Source {
+    match marketplace {
+        MarketplaceRef::Github => {
+            // owner--repo → owner/repo
+            let repository = restore_github_repo(dir_name);
+            Source::GitHub { repository }
         }
+        MarketplaceRef::Named(name) => Source::Marketplace { name: name.clone() },
     }
 }
 
@@ -204,10 +204,10 @@ fn build_plugin_info(content: MarketplaceContent) -> Result<PluginInfo> {
     let cache_path = content.path().to_path_buf();
     let manifest = content.manifest().clone();
 
-    // GitHub の場合は marketplace() == None。source / enabled 判定用に "github" を既定値とする
-    let marketplace_key = marketplace_opt.as_deref().unwrap_or("github");
+    // GitHub の場合は marketplace() == None。MarketplaceRef が既定値へ正規化する
+    let marketplace_ref = MarketplaceRef::from_option(marketplace_opt.as_deref());
 
-    let source = determine_source(marketplace_key, &dir_name);
+    let source = determine_source(&marketplace_ref, &dir_name);
 
     let installed_at = meta::resolve_installed_at(&cache_path);
 
@@ -217,7 +217,7 @@ fn build_plugin_info(content: MarketplaceContent) -> Result<PluginInfo> {
 
     // InstalledPlugin を組み立てる（list_installed_plugins と同じく marketplace は Option<String> を保つ）
     let id = Some(dir_name.clone());
-    let origin = PluginOrigin::from_marketplace(marketplace_key, &dir_name);
+    let origin = PluginOrigin::from_cached_plugin(marketplace_opt.as_deref(), &dir_name);
     let plugin = Plugin::new(manifest, cache_path, origin)?;
     let installed = InstalledPlugin::from_cached_package(plugin, id, marketplace_opt, enabled);
 

--- a/src/application/info_test.rs
+++ b/src/application/info_test.rs
@@ -301,7 +301,7 @@ fn test_resolve_single_plugin_filtered_not_found() {
 
 #[test]
 fn test_determine_source_github() {
-    let source = determine_source("github", "owner--repo");
+    let source = determine_source(&MarketplaceRef::Github, "owner--repo");
     match source {
         Source::GitHub { repository } => {
             assert_eq!(repository, "owner/repo");
@@ -312,7 +312,10 @@ fn test_determine_source_github() {
 
 #[test]
 fn test_determine_source_marketplace() {
-    let source = determine_source("awesome-plugins", "my-plugin");
+    let source = determine_source(
+        &MarketplaceRef::Named("awesome-plugins".to_string()),
+        "my-plugin",
+    );
     match source {
         Source::Marketplace { name } => {
             assert_eq!(name, "awesome-plugins");

--- a/src/application/lifecycle.rs
+++ b/src/application/lifecycle.rs
@@ -126,7 +126,7 @@ pub fn enable_plugin(
 ///
 /// * `cache` - プラグインを検索するためのパッケージキャッシュアクセサ
 /// * `plugin_name` - プラグインの id（キャッシュディレクトリ名。GitHub なら `owner--repo`、Marketplace でも `cache.is_cached` / `load_plugin` に渡すディレクトリ名で、Marketplace 登録名とは一致しない場合がある。`InstalledPlugin::id()` 相当）
-/// * `marketplace` - マーケットプレイス名（任意、デフォルト: "github"）
+/// * `marketplace` - マーケットプレイス名（確定値。未指定時のデフォルト解決は CLI 境界の `MarketplaceArgs::marketplace_or_default` で行う）
 ///
 /// # Returns
 /// * `Ok(UninstallInfo)` - プラグイン情報
@@ -134,18 +134,16 @@ pub fn enable_plugin(
 pub fn get_uninstall_info(
     cache: &dyn PackageCacheAccess,
     plugin_name: &str,
-    marketplace: Option<&str>,
+    marketplace: &str,
 ) -> Result<UninstallInfo, String> {
-    let marketplace_str = marketplace.unwrap_or("github");
-
-    if !cache.is_cached(Some(marketplace_str), plugin_name) {
+    if !cache.is_cached(Some(marketplace), plugin_name) {
         return Err(format!(
             "Plugin '{}' not found in cache (marketplace: {})",
-            plugin_name, marketplace_str
+            plugin_name, marketplace
         ));
     }
 
-    let plugin = load_plugin(cache, Some(marketplace_str), plugin_name)?;
+    let plugin = load_plugin(cache, Some(marketplace), plugin_name)?;
     let components = plugin.components().to_vec();
 
     let affected_targets = all_targets()
@@ -156,7 +154,7 @@ pub fn get_uninstall_info(
 
     Ok(UninstallInfo {
         plugin_name: plugin_name.to_string(),
-        marketplace: marketplace_str.to_string(),
+        marketplace: marketplace.to_string(),
         components,
         affected_targets,
     })

--- a/src/application/lifecycle_test.rs
+++ b/src/application/lifecycle_test.rs
@@ -29,10 +29,11 @@ fn test_get_uninstall_info_found() {
     let (temp_dir, cache) = create_test_cache();
     setup_plugin_fixture(temp_dir.path(), "github", "my-plugin", "1.0.0");
 
-    let result = get_uninstall_info(&cache, "my-plugin", Some("github"));
+    let result = get_uninstall_info(&cache, "my-plugin", "github");
     assert!(result.is_ok());
     let info = result.unwrap();
     assert_eq!(info.plugin_name, "my-plugin");
+    assert_eq!(info.marketplace, "github");
 }
 
 // ========================================
@@ -103,20 +104,12 @@ fn test_enable_plugin_success() {
 fn test_get_uninstall_info_not_found() {
     // 存在しないプラグインの場合はエラーを返す
     let (_temp_dir, cache) = create_test_cache();
-    let result = get_uninstall_info(&cache, "nonexistent-plugin-12345", Some("github"));
+    let result = get_uninstall_info(&cache, "nonexistent-plugin-12345", "github");
     assert!(result.is_err());
     let err = result.unwrap_err();
     assert!(err.contains("not found"));
     assert!(err.contains("nonexistent-plugin-12345"));
-}
-
-#[test]
-fn test_get_uninstall_info_default_marketplace() {
-    // マーケットプレイス未指定時は "github" がデフォルト
-    let (_temp_dir, cache) = create_test_cache();
-    let result = get_uninstall_info(&cache, "nonexistent-plugin-12345", None);
-    assert!(result.is_err());
-    let err = result.unwrap_err();
+    // エラーメッセージには確定済み marketplace が含まれる
     assert!(err.contains("github"));
 }
 

--- a/src/commands/args/marketplace.rs
+++ b/src/commands/args/marketplace.rs
@@ -1,5 +1,6 @@
 //! `--marketplace` オプション用の共通 Args 部品。
 
+use crate::marketplace::DEFAULT_MARKETPLACE;
 use clap::Args as ClapArgs;
 
 #[derive(Debug, Clone, ClapArgs)]
@@ -10,10 +11,12 @@ pub struct MarketplaceArgs {
 }
 
 impl MarketplaceArgs {
-    /// run 側で使うフォールバック付きアクセッサ。
-    /// 既存 enable/disable の `default_value = "github"` 互換を保つために提供する。
+    /// CLI 境界でのデフォルト解決アクセッサ。
+    ///
+    /// 「未指定 = github」の解決はここで 1 回だけ行い、ドメイン層には
+    /// 確定値を渡す。
     pub fn marketplace_or_default(&self) -> &str {
-        self.marketplace.as_deref().unwrap_or("github")
+        self.marketplace.as_deref().unwrap_or(DEFAULT_MARKETPLACE)
     }
 }
 

--- a/src/commands/lifecycle/uninstall.rs
+++ b/src/commands/lifecycle/uninstall.rs
@@ -26,7 +26,8 @@ pub async fn run(args: Args) -> Result<(), String> {
     let cache = PackageCache::new().map_err(|e| format!("Failed to access cache: {}", e))?;
     let project_root =
         env::current_dir().map_err(|e| format!("Failed to get current dir: {}", e))?;
-    let marketplace = args.marketplace.marketplace.as_deref();
+    // デフォルト解決（未指定 = github）は CLI 境界で 1 回だけ行う（enable/disable と同じ経路）
+    let marketplace = args.marketplace.marketplace_or_default();
 
     let info = application::get_uninstall_info(&cache, &args.name, marketplace)?;
 
@@ -37,7 +38,8 @@ pub async fn run(args: Args) -> Result<(), String> {
         return Ok(());
     }
 
-    let result = application::uninstall_plugin(&cache, &args.name, marketplace, &project_root);
+    let result =
+        application::uninstall_plugin(&cache, &args.name, Some(marketplace), &project_root);
 
     if result.success {
         println!(

--- a/src/marketplace.rs
+++ b/src/marketplace.rs
@@ -1,12 +1,14 @@
 mod config;
 mod download;
 mod path;
+mod reference;
 mod registry;
 mod source_ref;
 
 pub use config::{
     normalize_name, normalize_source_path, MarketplaceConfig, MarketplaceRegistration,
 };
+pub use reference::{MarketplaceRef, DEFAULT_MARKETPLACE};
 // Re-exported for tests
 #[cfg(test)]
 pub use config::validate_name;

--- a/src/marketplace/reference.rs
+++ b/src/marketplace/reference.rs
@@ -1,0 +1,89 @@
+//! マーケットプレイス参照の値オブジェクト
+//!
+//! 「マーケットプレイス未指定 = GitHub 直接インストール」という規約を
+//! `Option<&str>` の暗黙ルールではなく型で表現する。デフォルトの
+//! ディレクトリ名（`"github"`）はここで一元管理する。
+
+/// デフォルトマーケットプレイス（直接 GitHub インストール）のディレクトリ名。
+///
+/// キャッシュ階層 `<cache>/<marketplace>/<plugin>` やデプロイ階層の
+/// marketplace セグメントとして使われる。ベア文字列 `"github"` を
+/// 直接書かず、必ずこの定数（または [`MarketplaceRef`]）を経由すること。
+pub const DEFAULT_MARKETPLACE: &str = "github";
+
+/// マーケットプレイス参照
+///
+/// `None` / `Some("github")` の 2 表現に散っていた「デフォルト = GitHub」を
+/// 1 つの正規形に畳み込む。生成時に正規化されるため、比較・分岐は
+/// variant マッチだけで済む。
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum MarketplaceRef {
+    /// デフォルト（直接 GitHub インストール）
+    Github,
+    /// 名前付きマーケットプレイス
+    Named(String),
+}
+
+impl MarketplaceRef {
+    /// マーケットプレイス名から生成する（`"github"` は `Github` に正規化）。
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - Marketplace name.
+    pub fn parse(name: &str) -> Self {
+        if name == DEFAULT_MARKETPLACE {
+            MarketplaceRef::Github
+        } else {
+            MarketplaceRef::Named(name.to_string())
+        }
+    }
+
+    /// `Option<&str>`（`None` = デフォルト）から生成する。
+    ///
+    /// `cache.list()` などの既存 API が使う「`None` は github の意味」規約の
+    /// 正規化入口。`Some("github")` も `Github` に畳み込む。
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - Optional marketplace name; `None` means the default.
+    pub fn from_option(name: Option<&str>) -> Self {
+        match name {
+            None => MarketplaceRef::Github,
+            Some(n) => Self::parse(n),
+        }
+    }
+
+    /// キャッシュ・デプロイ階層のディレクトリ名。
+    pub fn dir_name(&self) -> &str {
+        match self {
+            MarketplaceRef::Github => DEFAULT_MARKETPLACE,
+            MarketplaceRef::Named(name) => name,
+        }
+    }
+
+    /// デフォルト（直接 GitHub）かどうか。
+    pub fn is_github(&self) -> bool {
+        matches!(self, MarketplaceRef::Github)
+    }
+
+    /// 名前付きマーケットプレイスの場合のみ名前を返す。
+    ///
+    /// `Github`（デフォルト）は `None`。「marketplace 経由か直接 GitHub か」で
+    /// 経路が分かれる処理の分岐に使う。
+    pub fn into_named(self) -> Option<String> {
+        match self {
+            MarketplaceRef::Github => None,
+            MarketplaceRef::Named(name) => Some(name),
+        }
+    }
+}
+
+impl std::fmt::Display for MarketplaceRef {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.dir_name())
+    }
+}
+
+#[cfg(test)]
+#[path = "reference_test.rs"]
+mod tests;

--- a/src/marketplace/reference_test.rs
+++ b/src/marketplace/reference_test.rs
@@ -1,0 +1,74 @@
+use super::*;
+
+#[test]
+fn parse_github_returns_github_variant() {
+    assert_eq!(MarketplaceRef::parse("github"), MarketplaceRef::Github);
+}
+
+#[test]
+fn parse_named_returns_named_variant() {
+    assert_eq!(
+        MarketplaceRef::parse("my-market"),
+        MarketplaceRef::Named("my-market".to_string())
+    );
+}
+
+#[test]
+fn from_option_none_is_github() {
+    assert_eq!(MarketplaceRef::from_option(None), MarketplaceRef::Github);
+}
+
+#[test]
+fn from_option_some_github_is_normalized_to_github() {
+    // None と Some("github") の意味揺れを 1 つの正規形に畳み込む
+    assert_eq!(
+        MarketplaceRef::from_option(Some("github")),
+        MarketplaceRef::Github
+    );
+}
+
+#[test]
+fn from_option_named_is_named() {
+    assert_eq!(
+        MarketplaceRef::from_option(Some("official")),
+        MarketplaceRef::Named("official".to_string())
+    );
+}
+
+#[test]
+fn dir_name_github_is_default_marketplace() {
+    assert_eq!(MarketplaceRef::Github.dir_name(), DEFAULT_MARKETPLACE);
+    assert_eq!(MarketplaceRef::Github.dir_name(), "github");
+}
+
+#[test]
+fn dir_name_named_is_marketplace_name() {
+    assert_eq!(
+        MarketplaceRef::Named("official".to_string()).dir_name(),
+        "official"
+    );
+}
+
+#[test]
+fn is_github() {
+    assert!(MarketplaceRef::Github.is_github());
+    assert!(!MarketplaceRef::Named("official".to_string()).is_github());
+}
+
+#[test]
+fn into_named() {
+    assert_eq!(MarketplaceRef::Github.into_named(), None);
+    assert_eq!(
+        MarketplaceRef::Named("official".to_string()).into_named(),
+        Some("official".to_string())
+    );
+}
+
+#[test]
+fn display_shows_dir_name() {
+    assert_eq!(format!("{}", MarketplaceRef::Github), "github");
+    assert_eq!(
+        format!("{}", MarketplaceRef::Named("official".to_string())),
+        "official"
+    );
+}

--- a/src/plugin/cache/cache.rs
+++ b/src/plugin/cache/cache.rs
@@ -4,6 +4,7 @@
 
 use crate::error::{PlmError, Result};
 use crate::fs::{FileSystem, RealFs};
+use crate::marketplace::MarketplaceRef;
 use crate::plugin::meta::resolve_manifest_path;
 use crate::plugin::MarketplaceContent;
 use crate::plugin::{meta, PluginManifest};
@@ -323,6 +324,30 @@ impl PackageCache {
         Ok(())
     }
 
+    /// `<cache_dir>[/<namespace>]/<marketplace>/<name>` の join 規則を一元化する
+    ///
+    /// marketplace 未指定時のデフォルト解決（`None` → `"github"`）を含め、
+    /// キャッシュ階層のパス構築はすべてこのメソッドを経由する。
+    ///
+    /// # Arguments
+    ///
+    /// * `namespace` - cache 直下のサブ領域（`.backup` / `.temp`）。本体は `None`
+    /// * `marketplace` - marketplace name (`None` uses the default)
+    /// * `name` - plugin name or repository identifier
+    fn entry_path(
+        &self,
+        namespace: Option<&str>,
+        marketplace: Option<&str>,
+        name: &str,
+    ) -> PathBuf {
+        let base = match namespace {
+            Some(ns) => self.cache_dir.join(ns),
+            None => self.cache_dir.clone(),
+        };
+        base.join(MarketplaceRef::from_option(marketplace).dir_name())
+            .join(name)
+    }
+
     /// バックアップパスを取得
     ///
     /// # Arguments
@@ -330,11 +355,7 @@ impl PackageCache {
     /// * `marketplace` - marketplace name (`None` uses `"github"`)
     /// * `name` - plugin name or repository identifier
     fn backup_path(&self, marketplace: Option<&str>, name: &str) -> PathBuf {
-        let marketplace_dir = marketplace.unwrap_or("github");
-        self.cache_dir
-            .join(".backup")
-            .join(marketplace_dir)
-            .join(name)
+        self.entry_path(Some(".backup"), marketplace, name)
     }
 
     /// 一時パスを取得
@@ -344,18 +365,13 @@ impl PackageCache {
     /// * `marketplace` - marketplace name (`None` uses `"github"`)
     /// * `name` - plugin name or repository identifier
     fn temp_path(&self, marketplace: Option<&str>, name: &str) -> PathBuf {
-        let marketplace_dir = marketplace.unwrap_or("github");
-        self.cache_dir
-            .join(".temp")
-            .join(marketplace_dir)
-            .join(name)
+        self.entry_path(Some(".temp"), marketplace, name)
     }
 }
 
 impl PackageCacheAccess for PackageCache {
     fn plugin_path(&self, marketplace: Option<&str>, name: &str) -> PathBuf {
-        let marketplace_dir = marketplace.unwrap_or("github");
-        self.cache_dir.join(marketplace_dir).join(name)
+        self.entry_path(None, marketplace, name)
     }
 
     fn is_cached(&self, marketplace: Option<&str>, name: &str) -> bool {
@@ -437,12 +453,10 @@ impl PackageCacheAccess for PackageCache {
                 if plugin_entry.is_dir() {
                     if let Some(plugin_name) = plugin_entry.path.file_name() {
                         let plugin_name = plugin_name.to_string_lossy().to_string();
-                        // "github" marketplace は None として扱う
-                        let mp = if marketplace_name.as_deref() == Some("github") {
-                            None
-                        } else {
-                            marketplace_name.clone()
-                        };
+                        // デフォルト marketplace（github）は None として扱う
+                        let mp = marketplace_name
+                            .as_deref()
+                            .and_then(|m| MarketplaceRef::parse(m).into_named());
                         plugins.push((mp, plugin_name));
                     }
                 }
@@ -628,13 +642,13 @@ impl PackageCacheAccess for PackageCache {
 
     fn has_marketplace_entry(&self, marketplace: &str, entry: &str) -> Result<bool> {
         let fs = RealFs;
-        let path = self.cache_dir.join(marketplace).join(entry);
+        let path = self.entry_path(None, Some(marketplace), entry);
         Ok(fs.exists(&path))
     }
 
     fn remove_marketplace_entry(&self, marketplace: &str, entry: &str) -> Result<()> {
         let fs = RealFs;
-        let path = self.cache_dir.join(marketplace).join(entry);
+        let path = self.entry_path(None, Some(marketplace), entry);
         if fs.exists(&path) {
             fs.remove_dir_all(&path)?;
         }

--- a/src/plugin/cache/cleanup.rs
+++ b/src/plugin/cache/cleanup.rs
@@ -134,19 +134,20 @@ fn cleanup_specs(
 }
 
 fn cleanup_one(fs: &dyn FileSystem, base: &Path, kind_subdir: &str, origin: &PluginOrigin) {
+    // 出自を復元できない配置物（Unknown）には対応する階層が存在しない
+    let Some((marketplace, plugin)) = origin.dir_names() else {
+        return;
+    };
     // 防御的検証: 不正な marketplace / plugin セグメントが渡された場合、
     // base の外で remove_dir_all が走ってしまうのを防ぐため cleanup をスキップする。
-    if !is_safe_path_segment(&origin.marketplace) || !is_safe_path_segment(&origin.plugin) {
+    if !is_safe_path_segment(marketplace) || !is_safe_path_segment(plugin) {
         return;
     }
 
-    let plugin_dir = base
-        .join(kind_subdir)
-        .join(&origin.marketplace)
-        .join(&origin.plugin);
+    let plugin_dir = base.join(kind_subdir).join(marketplace).join(plugin);
     remove_if_empty(fs, &plugin_dir);
 
-    let marketplace_dir = base.join(kind_subdir).join(&origin.marketplace);
+    let marketplace_dir = base.join(kind_subdir).join(marketplace);
     remove_if_empty(fs, &marketplace_dir);
 
     let kind_root = base.join(kind_subdir);
@@ -227,14 +228,18 @@ pub(crate) fn cleanup_legacy_hierarchy_impl(
 /// `<base>/<kind_subdir>/<mp>/<plg>` を quarantine rename → remove_dir_all で除去し、
 /// 空になった親 (mp_dir / kind_root) を昇格削除する。
 fn sweep_legacy_one(base: &Path, kind_subdir: &str, origin: &PluginOrigin) {
+    // 出自を復元できない配置物（Unknown）には対応する旧階層が存在しない
+    let Some((marketplace, plugin)) = origin.dir_names() else {
+        return;
+    };
     // ガード 1: marketplace / plugin が安全な path-segment か
-    if !is_safe_path_segment(&origin.marketplace) || !is_safe_path_segment(&origin.plugin) {
+    if !is_safe_path_segment(marketplace) || !is_safe_path_segment(plugin) {
         return;
     }
 
     let kind_root = base.join(kind_subdir);
-    let mp_dir = kind_root.join(&origin.marketplace);
-    let legacy = mp_dir.join(&origin.plugin);
+    let mp_dir = kind_root.join(marketplace);
+    let legacy = mp_dir.join(plugin);
 
     // ガード 2: legacy が存在
     if !legacy.exists() {
@@ -274,16 +279,16 @@ fn sweep_legacy_one(base: &Path, kind_subdir: &str, origin: &PluginOrigin) {
     }
 
     // ガード 8-9: file_name 一致
-    if mp_dir.file_name() != Some(OsStr::new(&origin.marketplace)) {
+    if mp_dir.file_name() != Some(OsStr::new(marketplace)) {
         return;
     }
-    if legacy.file_name() != Some(OsStr::new(&origin.plugin)) {
+    if legacy.file_name() != Some(OsStr::new(plugin)) {
         return;
     }
 
     // 全ガード通過 — quarantine rename → remove_dir_all
     let suffix = quarantine_suffix();
-    let quarantine = mp_dir.join(format!("{}.plm-quarantine-{}", origin.plugin, suffix));
+    let quarantine = mp_dir.join(format!("{}.plm-quarantine-{}", plugin, suffix));
     if std::fs::rename(&legacy, &quarantine).is_err() {
         // rename 失敗時は no-op で abort（race 中に削除されたなど誤削除を避ける）。
         return;

--- a/src/plugin/content/loader.rs
+++ b/src/plugin/content/loader.rs
@@ -12,7 +12,7 @@ use crate::target::PluginOrigin;
 /// # Arguments
 ///
 /// * `cache` - package cache access used to read the manifest and path
-/// * `marketplace` - marketplace name (`None` defaults to `"github"`)
+/// * `marketplace` - marketplace name (`None` means the default GitHub marketplace)
 /// * `plugin_name` - id (cache directory name; e.g. `owner--repo` for GitHub)
 pub(crate) fn load_plugin(
     cache: &dyn PackageCacheAccess,

--- a/src/plugin/lifecycle/update.rs
+++ b/src/plugin/lifecycle/update.rs
@@ -8,7 +8,8 @@ use crate::error::{PlmError, Result};
 use crate::host::{HostClient, HostClientFactory, HostKind};
 use crate::http::with_retry;
 use crate::marketplace::{
-    MarketplaceCache, MarketplaceRegistry, MarketplaceSourceRef, PluginSource as MpPluginSource,
+    MarketplaceCache, MarketplaceRef, MarketplaceRegistry, MarketplaceSourceRef,
+    PluginSource as MpPluginSource,
 };
 use crate::plugin::lifecycle::plugin_resolver::{find_by_plugin_name, ResolvedPlugin};
 use crate::plugin::version::needs_update;
@@ -39,7 +40,6 @@ pub enum UpdateStatus {
 #[derive(Debug, Clone)]
 pub struct UpdateOutcome {
     pub plugin_name: String,
-    pub marketplace: String,
     pub status: UpdateStatus,
     pub error: Option<String>,
     /// 再デプロイに成功したターゲット
@@ -67,7 +67,6 @@ impl UpdateOutcome {
     ) -> Self {
         Self {
             plugin_name: name.to_string(),
-            marketplace: "github".to_string(),
             status: UpdateStatus::Updated {
                 from_sha: from,
                 to_sha: to,
@@ -86,7 +85,6 @@ impl UpdateOutcome {
     pub fn up_to_date(name: &str) -> Self {
         Self {
             plugin_name: name.to_string(),
-            marketplace: "github".to_string(),
             status: UpdateStatus::AlreadyUpToDate,
             error: None,
             deployed_targets: vec![],
@@ -103,7 +101,6 @@ impl UpdateOutcome {
     pub fn failed(name: &str, error: String) -> Self {
         Self {
             plugin_name: name.to_string(),
-            marketplace: "github".to_string(),
             status: UpdateStatus::Failed,
             error: Some(error),
             deployed_targets: vec![],
@@ -120,7 +117,6 @@ impl UpdateOutcome {
     pub fn skipped(name: &str, reason: String) -> Self {
         Self {
             plugin_name: name.to_string(),
-            marketplace: "github".to_string(),
             status: UpdateStatus::Skipped { reason },
             error: None,
             deployed_targets: vec![],
@@ -137,7 +133,6 @@ impl UpdateOutcome {
     pub fn rolled_back(name: &str, note: Option<String>) -> Self {
         Self {
             plugin_name: name.to_string(),
-            marketplace: "github".to_string(),
             status: UpdateStatus::RolledBack,
             error: note,
             deployed_targets: vec![],
@@ -331,10 +326,14 @@ pub async fn update_plugin(
         Err(e) => return UpdateOutcome::failed(plugin_input, e.to_string()),
     };
 
-    if let Some(market) = resolved.marketplace.clone() {
-        update_marketplace_plugin(cache, &market, &resolved, project_root, target_filter).await
-    } else {
-        update_github_plugin(cache, &resolved, project_root, target_filter).await
+    // `Some("github")` と `None` の意味揺れを正規化してから経路を分岐する
+    match MarketplaceRef::from_option(resolved.marketplace.as_deref()) {
+        MarketplaceRef::Named(market) => {
+            update_marketplace_plugin(cache, &market, &resolved, project_root, target_filter).await
+        }
+        MarketplaceRef::Github => {
+            update_github_plugin(cache, &resolved, project_root, target_filter).await
+        }
     }
 }
 
@@ -564,7 +563,7 @@ async fn do_safe_update(
 ///
 /// * `cache` - Package cache accessor for the plugin.
 /// * `plugin_name` - Plugin name being redeployed.
-/// * `marketplace` - Marketplace name (`None` falls back to `"github"`).
+/// * `marketplace` - Marketplace name (`None` means the default GitHub marketplace).
 /// * `targets` - Target names to redeploy to.
 /// * `project_root` - Project root path used for redeployment.
 fn redeploy_to_targets(
@@ -578,13 +577,7 @@ fn redeploy_to_targets(
     let mut failed = Vec::new();
 
     for target in targets {
-        let result = enable_plugin(
-            cache,
-            plugin_name,
-            marketplace.or(Some("github")),
-            project_root,
-            Some(target),
-        );
+        let result = enable_plugin(cache, plugin_name, marketplace, project_root, Some(target));
         if result.success {
             deployed.push(target.to_string());
         } else {
@@ -714,8 +707,7 @@ pub(crate) async fn update_all_plugins_with_deps(
         std::collections::HashMap::new();
     let unique_markets: std::collections::HashSet<String> = plugins
         .iter()
-        .filter_map(|(m, _)| m.clone())
-        .filter(|m| m != "github")
+        .filter_map(|(m, _)| MarketplaceRef::from_option(m.as_deref()).into_named())
         .collect();
     for m in unique_markets {
         if let Ok(Some(c)) = resolver.resolve(&m) {
@@ -786,7 +778,7 @@ struct CheckOutcome {
 
 /// CHECK: 全 plugin を走査し、SHA 比較で更新が必要な対象を `UpdateTarget` に確定する。
 ///
-/// marketplace 経由（`market != "github"`）と直接 GitHub（`None` または `"github"`）の 2 経路で
+/// 名前付き marketplace 経由と直接 GitHub（`MarketplaceRef::Github`）の 2 経路で
 /// `repo` / `source_path` の解決方法のみが異なり、SHA 比較・`UpdateTarget` 構築の末尾処理は共通化する。
 /// CHECK で `get_commit_sha` 等が失敗した plugin は従来どおり `error_count` でスキップし、
 /// 他対象のアトミック処理の引き金にはしない。
@@ -816,11 +808,11 @@ async fn check_all(
         let git_ref = plugin_meta.git_ref.as_deref().unwrap_or("HEAD");
 
         // 経路ごとに repo / source_path を解決（早期 continue で skip / up_to_date / error を確定）
-        let (repo, source_path) = if let Some(market) =
-            marketplace.as_deref().filter(|m| *m != "github")
+        let (repo, source_path) = if let MarketplaceRef::Named(market) =
+            MarketplaceRef::from_option(marketplace.as_deref())
         {
             // marketplace 経由
-            let mp_cache = match mp_caches.get(market) {
+            let mp_cache = match mp_caches.get(&market) {
                 Some(c) => c,
                 None => {
                     error_count += 1;
@@ -852,7 +844,7 @@ async fn check_all(
             };
             (repo, source_path)
         } else {
-            // 直接 GitHub 経路（marketplace == None もしくは "github"）
+            // 直接 GitHub 経路（MarketplaceRef::Github）
             if !plugin_meta.is_github() {
                 results.push(UpdateOutcome::skipped(
                     &display_name,

--- a/src/plugin/meta/meta.rs
+++ b/src/plugin/meta/meta.rs
@@ -150,7 +150,7 @@ impl PluginMeta {
 
     /// GitHub プラグインかどうか
     pub fn is_github(&self) -> bool {
-        self.marketplace.as_deref() == Some("github") || self.marketplace.is_none()
+        crate::marketplace::MarketplaceRef::from_option(self.marketplace.as_deref()).is_github()
     }
 
     /// `target` の管理ファイル一覧に `path` を追加する。

--- a/src/source/github_source.rs
+++ b/src/source/github_source.rs
@@ -148,7 +148,7 @@ impl PackageSource for GitHubSource {
             let mut plugin_meta = meta::load_meta(&plugin_path).unwrap_or_default();
             plugin_meta.set_source_repo(self.repo.owner(), self.repo.name());
             plugin_meta.set_git_info(&git_ref, &commit_sha);
-            plugin_meta.marketplace = Some("github".to_string());
+            plugin_meta.marketplace = Some(crate::marketplace::DEFAULT_MARKETPLACE.to_string());
             if let Err(e) = meta::write_meta(&plugin_path, &plugin_meta) {
                 eprintln!("Warning: Failed to save plugin metadata: {}", e);
             }

--- a/src/sync/endpoint.rs
+++ b/src/sync/endpoint.rs
@@ -96,12 +96,12 @@ impl<'a> Endpoint<'a> {
 /// `super::parse_component_name` で参照できる。
 pub(super) fn parse_component_name(name: &str) -> Result<(PluginOrigin, &str)> {
     if is_instruction_file(name) {
-        return Ok((PluginOrigin::from_marketplace("", ""), name));
+        return Ok((PluginOrigin::Unknown, name));
     }
 
     validate_flattened_name(name)?;
 
-    Ok((PluginOrigin::placeholder(), name))
+    Ok((PluginOrigin::Unknown, name))
 }
 
 /// `flattened_name` が単一の安全なパスセグメントであることを検証する。

--- a/src/sync/endpoint/source_test.rs
+++ b/src/sync/endpoint/source_test.rs
@@ -1,35 +1,32 @@
 use super::super::parse_component_name;
+use crate::target::PluginOrigin;
 
 #[test]
 fn test_parse_component_name_single_segment() {
     let (origin, name) = parse_component_name("test-plugin_my-skill").unwrap();
-    // フラット化後は origin は復元できないためプレースホルダ
-    assert_eq!(origin.marketplace, "_");
-    assert_eq!(origin.plugin, "_");
+    // フラット化後は origin は復元できないため Unknown
+    assert!(matches!(origin, PluginOrigin::Unknown));
     assert_eq!(name, "test-plugin_my-skill");
 }
 
 #[test]
 fn test_parse_component_name_instruction_agents() {
     let (origin, name) = parse_component_name("AGENTS.md").unwrap();
-    assert_eq!(origin.marketplace, "");
-    assert_eq!(origin.plugin, "");
+    assert!(matches!(origin, PluginOrigin::Unknown));
     assert_eq!(name, "AGENTS.md");
 }
 
 #[test]
 fn test_parse_component_name_instruction_gemini() {
     let (origin, name) = parse_component_name("GEMINI.md").unwrap();
-    assert_eq!(origin.marketplace, "");
-    assert_eq!(origin.plugin, "");
+    assert!(matches!(origin, PluginOrigin::Unknown));
     assert_eq!(name, "GEMINI.md");
 }
 
 #[test]
 fn test_parse_component_name_instruction_copilot() {
     let (origin, name) = parse_component_name("copilot-instructions.md").unwrap();
-    assert_eq!(origin.marketplace, "");
-    assert_eq!(origin.plugin, "");
+    assert!(matches!(origin, PluginOrigin::Unknown));
     assert_eq!(name, "copilot-instructions.md");
 }
 

--- a/src/target.rs
+++ b/src/target.rs
@@ -43,6 +43,7 @@ use crate::component::{
 };
 use crate::error::{PlmError, Result};
 use crate::fs::{FileSystem, RealFs};
+use crate::marketplace::{MarketplaceRef, DEFAULT_MARKETPLACE};
 use clap::ValueEnum;
 use serde::{Deserialize, Serialize};
 use std::path::Path;
@@ -52,24 +53,46 @@ use std::path::Path;
 /// コンポーネントがどのマーケットプレイス・プラグインから来たかを追跡する。
 /// デプロイ時に `<marketplace>/<plugin>/<component>` 階層を構築するために使用。
 #[derive(Debug, Clone)]
-pub struct PluginOrigin {
-    /// マーケットプレイス名（直接GitHubの場合は "github"）
-    pub marketplace: String,
-    /// プラグイン名（直接GitHubの場合は "owner--repo" 形式）
-    pub plugin: String,
+pub enum PluginOrigin {
+    /// 名前付きマーケットプレイス経由のプラグイン
+    Marketplace {
+        /// マーケットプレイス名
+        marketplace: String,
+        /// マーケットプレイス内でのプラグイン名（キャッシュディレクトリ名）
+        plugin: String,
+    },
+    /// 直接 GitHub 経由のプラグイン
+    Github {
+        /// キャッシュ ID（`{owner}--{repo}` 形式のディレクトリ名）
+        cache_id: crate::plugin::GithubCacheId,
+    },
+    /// 出自を復元できない配置物
+    ///
+    /// フラット 2 階層構造 `<base>/<plural>/<flattened_name>` では配置物から
+    /// marketplace / plugin を復元できない。スキャン層 (`scan_components`)
+    /// と sync ソース (`parse_component_name`) はいずれも `flattened_name`
+    /// 単独でキー化する想定でこの variant を使う。
+    Unknown,
 }
 
 impl PluginOrigin {
     /// マーケットプレイス経由のプラグイン
+    ///
+    /// `marketplace` がデフォルト（`"github"`）の場合は `Github` に正規化する。
     ///
     /// # Arguments
     ///
     /// * `marketplace` - Marketplace name.
     /// * `plugin` - Plugin name within the marketplace.
     pub fn from_marketplace(marketplace: &str, plugin: &str) -> Self {
-        Self {
-            marketplace: marketplace.to_string(),
-            plugin: plugin.to_string(),
+        match MarketplaceRef::parse(marketplace) {
+            MarketplaceRef::Github => Self::Github {
+                cache_id: crate::plugin::GithubCacheId::from_cache_name(plugin),
+            },
+            MarketplaceRef::Named(name) => Self::Marketplace {
+                marketplace: name,
+                plugin: plugin.to_string(),
+            },
         }
     }
 
@@ -80,39 +103,45 @@ impl PluginOrigin {
     /// * `owner` - GitHub owner (user or organization).
     /// * `repo` - GitHub repository name.
     pub fn from_github(owner: &str, repo: &str) -> Self {
-        Self {
-            marketplace: "github".to_string(),
-            plugin: crate::plugin::GithubCacheId::from_parts(owner, repo).into_string(),
+        Self::Github {
+            cache_id: crate::plugin::GithubCacheId::from_parts(owner, repo),
         }
     }
 
     /// キャッシュされたプラグイン情報から PluginOrigin を生成する
     ///
-    /// `marketplace` が `None` の場合は `"github"` を既定値として使用し、
-    /// `plugin_name` は id（ディレクトリ名）としてそのまま保持する。
+    /// `marketplace` が `None`（またはデフォルトの `"github"`）の場合は
+    /// `Github` として扱い、`plugin_name` は id（ディレクトリ名）として
+    /// そのまま保持する。
     ///
     /// # Arguments
     ///
-    /// * `marketplace` - Optional marketplace name; falls back to `"github"` when `None`.
+    /// * `marketplace` - Optional marketplace name; `None` means the default (GitHub).
     /// * `plugin_name` - id (directory name) used as the plugin identifier.
     pub fn from_cached_plugin(marketplace: Option<&str>, plugin_name: &str) -> Self {
-        Self {
-            marketplace: marketplace.unwrap_or("github").to_string(),
-            plugin: plugin_name.to_string(),
+        match MarketplaceRef::from_option(marketplace) {
+            MarketplaceRef::Github => Self::Github {
+                cache_id: crate::plugin::GithubCacheId::from_cache_name(plugin_name),
+            },
+            MarketplaceRef::Named(name) => Self::Marketplace {
+                marketplace: name,
+                plugin: plugin_name.to_string(),
+            },
         }
     }
 
-    /// origin が復元できない場面で埋めるプレースホルダ。
+    /// デプロイ階層 `<marketplace>/<plugin>` のディレクトリ名ペアを返す
     ///
-    /// フラット 2 階層構造 `<base>/<plural>/<flattened_name>` では配置物から
-    /// `marketplace` / `plugin` を復元できない。スキャン層 (`scan_components`)
-    /// と sync ソース (`parse_component_name`) はいずれも `flattened_name`
-    /// 単独でキー化する想定でこのプレースホルダを埋める。利用側はこの
-    /// フィールドを参照してはならない。
-    pub fn placeholder() -> Self {
-        Self {
-            marketplace: "_".to_string(),
-            plugin: "_".to_string(),
+    /// `Unknown`（出自を復元できない配置物）の場合は `None`。呼び出し側は
+    /// 番兵値を読む代わりに `None` を明示的に扱うこと。
+    pub fn dir_names(&self) -> Option<(&str, &str)> {
+        match self {
+            Self::Marketplace {
+                marketplace,
+                plugin,
+            } => Some((marketplace.as_str(), plugin.as_str())),
+            Self::Github { cache_id } => Some((DEFAULT_MARKETPLACE, cache_id.as_str())),
+            Self::Unknown => None,
         }
     }
 }

--- a/src/target/placed/scanner.rs
+++ b/src/target/placed/scanner.rs
@@ -2,8 +2,8 @@
 //!
 //! `<kind>/<flattened_name>` 構造を 1 階層走査する。`Component.name` は
 //! `flatten_name(plugin_name, original_name)` で平坦化済みのため、中間
-//! ディレクトリは存在しない。`origin` は復元できないためプレースホルダ
-//! (`PluginOrigin { marketplace: "_", plugin: "_" }`) を埋めて返す。
+//! ディレクトリは存在しない。`origin` は復元できないため
+//! `PluginOrigin::Unknown` を埋めて返す。
 
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -47,7 +47,7 @@ pub fn scan_components(base_dir: &Path) -> Result<Vec<ScannedComponent>> {
         // 既存挙動維持: path.is_dir() はメタデータエラーを握りつぶす
         let is_dir = path.is_dir();
         results.push(ScannedComponent {
-            origin: PluginOrigin::placeholder(),
+            origin: PluginOrigin::Unknown,
             name: entry_name_lossy(&entry),
             path,
             is_dir,

--- a/src/target/placed/scanner_test.rs
+++ b/src/target/placed/scanner_test.rs
@@ -1,6 +1,7 @@
 //! scanner モジュールのテスト
 
 use super::scan_components;
+use crate::target::PluginOrigin;
 use std::fs;
 use tempfile::TempDir;
 
@@ -18,8 +19,7 @@ fn test_scan_components_flat_dir() {
 
     assert_eq!(results.len(), 1);
     let component = &results[0];
-    assert_eq!(component.origin.marketplace, "_");
-    assert_eq!(component.origin.plugin, "_");
+    assert!(matches!(component.origin, PluginOrigin::Unknown));
     assert_eq!(component.name, "plugin_my-skill");
     assert!(component.is_dir);
     assert_eq!(component.path, component_dir);

--- a/src/target_test.rs
+++ b/src/target_test.rs
@@ -39,3 +39,54 @@ fn test_parse_target_gemini() {
     let target = parse_target("gemini").unwrap();
     assert_eq!(target.name(), "gemini");
 }
+
+// ========================================
+// PluginOrigin tests
+// ========================================
+
+#[test]
+fn test_plugin_origin_from_marketplace_named() {
+    let origin = PluginOrigin::from_marketplace("official", "my-plugin");
+    assert_eq!(origin.dir_names(), Some(("official", "my-plugin")));
+}
+
+#[test]
+fn test_plugin_origin_from_marketplace_github_is_normalized() {
+    // marketplace = "github" は Github variant に正規化される
+    let origin = PluginOrigin::from_marketplace("github", "owner--repo");
+    assert!(matches!(origin, PluginOrigin::Github { .. }));
+    assert_eq!(origin.dir_names(), Some(("github", "owner--repo")));
+}
+
+#[test]
+fn test_plugin_origin_from_github() {
+    let origin = PluginOrigin::from_github("owner", "repo");
+    assert!(matches!(origin, PluginOrigin::Github { .. }));
+    // owner--repo エンコードは GithubCacheId に集約されている
+    assert_eq!(origin.dir_names(), Some(("github", "owner--repo")));
+}
+
+#[test]
+fn test_plugin_origin_from_cached_plugin_none_is_github() {
+    let origin = PluginOrigin::from_cached_plugin(None, "owner--repo");
+    assert!(matches!(origin, PluginOrigin::Github { .. }));
+    assert_eq!(origin.dir_names(), Some(("github", "owner--repo")));
+}
+
+#[test]
+fn test_plugin_origin_from_cached_plugin_some_github_is_github() {
+    // Some("github") と None の意味揺れを 1 つの variant に畳み込む
+    let origin = PluginOrigin::from_cached_plugin(Some("github"), "owner--repo");
+    assert!(matches!(origin, PluginOrigin::Github { .. }));
+}
+
+#[test]
+fn test_plugin_origin_from_cached_plugin_named_marketplace() {
+    let origin = PluginOrigin::from_cached_plugin(Some("official"), "my-plugin");
+    assert_eq!(origin.dir_names(), Some(("official", "my-plugin")));
+}
+
+#[test]
+fn test_plugin_origin_unknown_has_no_dir_names() {
+    assert_eq!(PluginOrigin::Unknown.dir_names(), None);
+}


### PR DESCRIPTION
## 概要

Closes #335

「マーケットプレイス未指定 = `"github"`」という規約がベア文字列 `unwrap_or("github")` として十数箇所に散在していた問題を解消し、`PluginOrigin` を enum 化しました。

## 変更内容

### 1. `MarketplaceRef` enum + `DEFAULT_MARKETPLACE` 定数の導入（`src/marketplace/reference.rs`）

- `enum MarketplaceRef { Github, Named(String) }` を新設。`from_option()` / `parse()` が `None` と `Some("github")` を単一の `Github` variant に正規化し、`dir_name()` がディレクトリ名を一元提供する
- 非テストコードの `"github"` リテラルは定数定義とドキュメントコメントのみに集約

### 2. `PluginOrigin` の enum 化（`src/target.rs`）

- `enum PluginOrigin { Marketplace { marketplace, plugin }, Github { cache_id: GithubCacheId }, Unknown }` に変更
- `"_"` 番兵の `placeholder()` を `Unknown` variant に昇格（利用側は `dir_names() -> Option<(&str, &str)>` で `None` を明示的に扱う）
- `owner--repo` の文字列パッキングは #334 で導入済みの `GithubCacheId` が担う
- `from_marketplace("github", ..)` / `from_cached_plugin(Some("github") | None, ..)` は `Github` variant に正規化

### 3. cache.rs のパス join 規則を1メソッドに集約

- `plugin_path` / `backup_path` / `temp_path` / `has_marketplace_entry` / `remove_marketplace_entry` で5回反復していた `<base>/<marketplace>/<name>` の join を `PackageCache::entry_path` に一元化

### 4. デフォルト解決タイミングの統一（CLI 境界で1回だけ）

- `uninstall` も enable/disable と同じく CLI 層で `marketplace_or_default()` により解決し、`get_uninstall_info` は確定値 `&str` を受け取る（ドメイン内 defaulting を削除）

### 5. 意味揺れバグの修正

- `update_plugin` の経路分岐が `resolved.marketplace == Some("github")` を marketplace 経路として扱っていた（`plm update foo@github` が "Marketplace not found: github" になる）のを、`MarketplaceRef` 正規化により直接 GitHub 経路へ修正
- 常に `"github"` をハードコードし、どこからも読まれていなかった `UpdateOutcome.marketplace` フィールドを削除

## テスト

- `MarketplaceRef` の正規化・`dir_name` のユニットテストを追加（`reference_test.rs`）
- `PluginOrigin` の variant 正規化・`dir_names` のテストを追加（`target_test.rs`）
- `cargo fmt` / `cargo check --all-targets` / `cargo clippy` / `cargo test`（1765 passed, 0 failed）を確認済み

## 関連

- #329（uninstall の marketplace 既定値不統一 — 本 PR で解決経路を CLI 境界に統一）
- #334（`owner--repo` エンコードの値オブジェクト化 — `PluginOrigin::Github` が `GithubCacheId` を保持）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FgWf4yjDhSQXd7ZyrjzbYC

---
_Generated by [Claude Code](https://claude.ai/code/session_01FgWf4yjDhSQXd7ZyrjzbYC)_