### PR TITLE
docs: Cursor ターゲット対応の仕様を追加

### DIFF
--- a/docs/concepts/targets.md
+++ b/docs/concepts/targets.md
@@ -4,25 +4,27 @@ PLMがサポートするAI開発環境（ターゲット）について説明し
 
 ## 対応ターゲット
 
-| ターゲット | 説明 |
-|------------|------|
-| **codex** | OpenAI Codex CLI |
-| **copilot** | VSCode GitHub Copilot |
-| **antigravity** | Google Antigravity IDE |
-| **gemini** | Gemini CLI（ターミナルベースAIエージェント） |
+| ターゲット | 説明 | 状態 |
+|------------|------|------|
+| **codex** | OpenAI Codex CLI | ✅ 対応済み |
+| **copilot** | VSCode GitHub Copilot | ✅ 対応済み |
+| **antigravity** | Google Antigravity IDE | ✅ 対応済み |
+| **gemini** | Gemini CLI（ターミナルベースAIエージェント） | ✅ 対応済み |
+| **cursor** | Cursor（IDE / CLI） | 🚧 計画中（[#356](https://github.com/DIO0550/plugin-manager/issues/356)） |
 
 ## サポートするコンポーネント
 
-| コンポーネント | Codex | Copilot | Antigravity | Gemini CLI |
-|----------------|-------|---------|-------------|------------|
-| Skills | ✅ | ✅ | ✅ | ✅ |
-| Agents | ✅ | ✅ | ❌ | ❌ |
-| Commands | ❌ | ✅ | ❌ | ❌ |
-| Instructions | ✅ | ✅ | ❌* | ✅** |
-| Hooks | ✅ | ✅ | ❌ | ❌ |
+| コンポーネント | Codex | Copilot | Antigravity | Gemini CLI | Cursor 🚧 |
+|----------------|-------|---------|-------------|------------|-----------|
+| Skills | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Agents | ✅ | ✅ | ❌ | ❌ | ✅ |
+| Commands | ❌ | ✅ | ❌ | ❌ | ✅ |
+| Instructions | ✅ | ✅ | ❌* | ✅** | ✅*** |
+| Hooks | ✅ | ✅ | ❌ | ❌ | 🚧 |
 
 > *AntigravityはSkills専用の設計で、Instructionsは別途設定で管理します。
 > **Gemini CLIは`GEMINI.md`による階層的な指示システムを持ちます。
+> ***CursorのInstructionsはProjectスコープ（`AGENTS.md`）のみ。Personalスコープの指示（User Rules）はアプリ設定画面で管理されるため対象外。Hooksは単一設定ファイル（`hooks.json`）のためマージ戦略の設計後に対応（[#361](https://github.com/DIO0550/plugin-manager/issues/361)）。
 
 ## OpenAI Codex
 
@@ -294,6 +296,74 @@ Gemini CLIは `GEMINI.md` ファイルによる階層的な指示システムを
 - **Agents非対応**: `.agent.md` 形式はサポートしない
 - **Prompts非対応**: `.prompt.md` 形式はサポートしない
 
+## Cursor 🚧（計画中）
+
+> **実装状況**: 未実装。実装は Epic [#356](https://github.com/DIO0550/plugin-manager/issues/356) で追跡。本セクションは実装のための仕様であり、「要検証」項目は実装時に確認して本ドキュメントへ反映すること。
+
+### 概要
+
+CursorはAnysphere社のAIコードエディタ。エディタに加えてターミナルから使えるCursor CLI（`cursor-agent`）を持つ。Cursor 2.4でAgent Skills（Anthropic発のopen standard、`SKILL.md`形式）をエディタ・CLIの両方でサポートした。サブエージェント、カスタムスラッシュコマンド、`AGENTS.md`、Hooksもサポートする。
+
+公式ドキュメント:
+- [Agent Skills | Cursor Docs](https://cursor.com/docs/context/skills)
+- [Subagents | Cursor Docs](https://cursor.com/docs/agent/subagents)
+- [Rules / AGENTS.md | Cursor Docs](https://cursor.com/docs/context/rules)
+- [Hooks | Cursor Docs](https://cursor.com/docs/agent/hooks)
+- [Cursor 2.4 Changelog（Subagents / Skills）](https://cursor.com/changelog/2-4)
+
+### 読み込みパスと優先順位
+
+| 種別 | スコープ | パス | 自動読み込み | 備考 |
+|------|---------|------|--------------|------|
+| Skills | User | `~/.cursor/skills/`, `~/.agents/skills/` | ✅ | 互換パスとして `~/.claude/skills/`, `~/.codex/skills/` も読む |
+| Skills | Project | `.cursor/skills/`, `.agents/skills/` | ✅ | 互換パスとして `.claude/skills/`, `.codex/skills/` も読む。skillsルートを**再帰走査**して `SKILL.md` を発見 |
+| Agents | User | `~/.cursor/agents/` | ✅ | 互換: `~/.claude/agents/`, `~/.codex/agents/`（同名時は `.cursor/` 優先） |
+| Agents | Project | `.cursor/agents/` | ✅ | 互換: `.claude/agents/`, `.codex/agents/` |
+| Commands | User | `~/.cursor/commands/` | ✅ | プレーンMarkdown |
+| Commands | Project | `.cursor/commands/` | ✅ | `/` 入力で一覧表示 |
+| Rules | Project | `.cursor/rules/*.mdc` | ✅ | frontmatter（`alwaysApply` / `description` / `globs`）付き |
+| Instructions | Project | `AGENTS.md` | ✅ | プロジェクトルート＋サブディレクトリのネスト対応（深い階層が優先） |
+| Hooks | User | `~/.cursor/hooks.json` | ✅ | 単一ファイル |
+| Hooks | Project | `.cursor/hooks.json` | ✅ | 単一ファイル |
+
+### 重要な特徴
+
+- **SKILL.md形式**: frontmatterは `name`（必須、小文字・数字・ハイフンのみ、フォルダ名と一致）と `description`（必須）に加え、`paths`（globで適用範囲を制限）、`disable-model-invocation`（trueで明示的スラッシュコマンド専用化）、`metadata` をサポート
+- **skillsルートの再帰走査**: ネストしたディレクトリ内の `SKILL.md` も発見されるため、PLMの `<marketplace>/<plugin>/<skill>/` 階層はそのまま読み込まれる見込み
+- **Agents（サブエージェント）**: YAMLフロントマター（`name`, `description`, `model`, `readonly`, `is_background`）付きMarkdown。エディタ・CLI・Cloud Agentsで利用可能
+- **CommandsはSkillsへ移行中**: `/migrate-to-skills` により既存のCommandsは `disable-model-invocation: true` 付きSkillsへ変換される方向。`.cursor/commands/` 自体は引き続き動作する
+- **Claude Code互換**: `.claude/skills/` / `.claude/agents/` を互換パスとして読むため、コンポーネントのフォーマット変換はほぼ不要（`CommandFormat::ClaudeCode` / `AgentFormat::ClaudeCode`）
+
+### Hooks
+
+設定は単一の `hooks.json`（`{"version": 1, "hooks": {"<event>": [{"command": "..."}]}}`）。イベント名は**camelCase**で、Copilot CLI形式（camelCase + `"version": 1`）に近い。
+
+主なイベント: `sessionStart`, `sessionEnd`, `preToolUse`, `postToolUse`, `postToolUseFailure`, `subagentStart`, `subagentStop`, `beforeShellExecution`, `afterShellExecution`, `beforeMCPExecution`, `afterMCPExecution`, `beforeReadFile`, `afterFileEdit`, `beforeSubmitPrompt`, `preCompact`, `stop`, `afterAgentResponse` など。
+
+Claude Code側に対応イベントがないもの（`beforeShellExecution` 等のCursor固有イベント）は変換対象外。単一ファイルのため、複数プラグインのhooksを配置するには非管理エントリを壊さないマージ戦略が必要（[#361](https://github.com/DIO0550/plugin-manager/issues/361)）。
+
+### コンポーネント配置場所（計画）
+
+| 種別 | ファイル形式 | Personal | Project |
+|------|-------------|----------|---------|
+| Skills | `SKILL.md` | `~/.cursor/skills/<marketplace>/<plugin>/<skill>/` | `.cursor/skills/<marketplace>/<plugin>/<skill>/` |
+| Agents | `*.md` | `~/.cursor/agents/<marketplace>/<plugin>/` | `.cursor/agents/<marketplace>/<plugin>/` |
+| Commands | `*.md` | `~/.cursor/commands/<marketplace>/<plugin>/` | `.cursor/commands/<marketplace>/<plugin>/` |
+| Instructions | `AGENTS.md` | - | `AGENTS.md` |
+| Hooks 🚧 | `hooks.json` へマージ | `~/.cursor/hooks.json` | `.cursor/hooks.json` |
+
+### 制約事項
+
+- **Instructions は Project スコープのみ**: Personalスコープの指示（User Rules）はアプリ設定画面で管理され、ファイルベースのグローバルパスがない（Copilotと同型の制約）
+- **`AGENTS.md` は Codex ターゲットと同一ファイルを共有**: 両ターゲット有効時の所有権・削除の扱いは実装時に設計する（[#360](https://github.com/DIO0550/plugin-manager/issues/360)）
+- **Hooks は単一設定ファイル**: ディレクトリ配置ではなく `hooks.json` へのマージが必要
+
+### 要検証（実装時に確認）
+
+- Agents のファイル名: Cursorが期待するのは `<name>.md`。PLMの `.agent.md` サフィックスのままで認識されるか（[#359](https://github.com/DIO0550/plugin-manager/issues/359)）
+- Agents / Commands ディレクトリで `<marketplace>/<plugin>/` のネスト階層が発見されるか（Skillsと異なり再帰走査が明記されていない）
+- Cursor CLI（`cursor-agent`）でどのhooksイベントが発火するか
+
 ## PLMでの対応方針
 
 | ターゲット | Personal インストール | 追加アクション |
@@ -302,10 +372,13 @@ Gemini CLIは `GEMINI.md` ファイルによる階層的な指示システムを
 | Copilot | ファイル配置 + VSCode設定追記 | `settings.json` への参照追加が必要 |
 | Antigravity | `~/.gemini/antigravity/` に配置 | 不要（自動読み込み） |
 | Gemini CLI | `~/.gemini/skills/` に配置 | 不要（自動読み込み、要Settings有効化） |
+| Cursor 🚧 | `~/.cursor/` に配置 | 不要（自動読み込み）。Hooksのみ `hooks.json` へのマージが必要 |
 
 ## 将来の拡張候補
 
-- Cursor（.cursor/）
+対応調査は [#363](https://github.com/DIO0550/plugin-manager/issues/363) で追跡。
+
+- Claude Code（[#96](https://github.com/DIO0550/plugin-manager/issues/96) で計画中）
 - Windsurf
 - Aider
 - その他SKILL.md対応ツール

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -112,16 +112,30 @@ PLMの実装状況と将来の計画について説明します。
 - [x] `plm link` コマンド（シンボリックリンク作成）
 - [x] `plm unlink` コマンド（シンボリックリンク削除）
 
+### Phase 16: Cursor ターゲット対応 🚧
+
+Epic: [#356](https://github.com/DIO0550/plugin-manager/issues/356)（仕様: `docs/concepts/targets.md` の「Cursor」セクション）
+
+- [ ] `TargetKind` に Cursor バリアントを追加（[#357](https://github.com/DIO0550/plugin-manager/issues/357)）
+- [ ] `CursorTarget` 実装（Skills 配置）（[#358](https://github.com/DIO0550/plugin-manager/issues/358)）
+- [ ] Agents / Commands 配置対応（[#359](https://github.com/DIO0550/plugin-manager/issues/359)）
+- [ ] Instructions（AGENTS.md）配置対応（[#360](https://github.com/DIO0550/plugin-manager/issues/360)）
+- [ ] Hooks（hooks.json）変換・配置対応（[#361](https://github.com/DIO0550/plugin-manager/issues/361)）
+- [ ] ドキュメント・整合性更新（[#362](https://github.com/DIO0550/plugin-manager/issues/362)）
+
 ## 将来の拡張
 
 ### 追加ターゲット候補
 
-| ターゲット | 説明 |
-|------------|------|
-| Cursor | .cursor/ ディレクトリ |
-| Windsurf | Windsurf IDE |
-| Aider | Aider CLI |
-| その他 | SKILL.md対応ツール |
+対応調査は [#363](https://github.com/DIO0550/plugin-manager/issues/363) で追跡。
+
+| ターゲット | 説明 | 状態 |
+|------------|------|------|
+| Cursor | .cursor/ ディレクトリ | 🚧 Phase 16 で対応中（[#356](https://github.com/DIO0550/plugin-manager/issues/356)） |
+| Claude Code | .claude/ ディレクトリ | 計画中（[#96](https://github.com/DIO0550/plugin-manager/issues/96)） |
+| Windsurf | Windsurf IDE | 調査対象 |
+| Aider | Aider CLI | 調査対象 |
+| その他 | SKILL.md対応ツール | 調査対象 |
 
 ### GitLab/Bitbucket対応
 
@@ -171,6 +185,13 @@ impl GitRepo {
 - [Plugins Documentation](https://code.claude.com/docs/en/plugins)
 - [Skills Documentation](https://code.claude.com/docs/en/skills)
 - [anthropics/claude-code plugins](https://github.com/anthropics/claude-code/tree/main/plugins)
+
+### Cursor
+
+- [Agent Skills | Cursor Docs](https://cursor.com/docs/context/skills)
+- [Subagents | Cursor Docs](https://cursor.com/docs/agent/subagents)
+- [Rules / AGENTS.md | Cursor Docs](https://cursor.com/docs/context/rules)
+- [Hooks | Cursor Docs](https://cursor.com/docs/agent/hooks)
 
 ### Google Antigravity
 


### PR DESCRIPTION
## 概要

Antigravity 等の既存 4 ターゲットに加えて Cursor（IDE / CLI）へ対応するための仕様をドキュメントに追加する。実装は Epic #356 で追跡。

## 変更内容

### `docs/concepts/targets.md`

- 対応ターゲット表に `cursor` を追加（🚧 計画中マーク付き、#356 へリンク）
- コンポーネント対応マトリクスに Cursor 列を追加（Skills / Agents / Commands ✅、Instructions は Project のみ、Hooks は後続フェーズ）
- 「Cursor」詳細セクションを新設:
  - 読み込みパスと優先順位（`.cursor/skills/`・`~/.cursor/skills/`、`.cursor/agents/`、`.cursor/commands/`、`AGENTS.md`、`hooks.json`。Cursor 公式ドキュメント準拠）
  - SKILL.md frontmatter 仕様、Claude Code 互換パス（`.claude/skills/` 等）、skills ルートの再帰走査
  - Hooks の camelCase イベント一覧と単一ファイル（`hooks.json`）マージの設計課題
  - PLM のコンポーネント配置場所（計画）、制約事項、実装時の要検証項目
- 「PLMでの対応方針」表に Cursor 行を追加
- 「将来の拡張候補」から Cursor を昇格し、残候補（Windsurf / Aider 等）の調査 Issue #363 をリンク

### `docs/roadmap.md`

- Phase 16「Cursor ターゲット対応 🚧」を追加し、サブ Issue #357〜#362 のチェックリストを記載
- 追加ターゲット候補表に状態列を追加（Cursor → 対応中、Claude Code → #96、Windsurf / Aider → 調査対象）
- 参考リンクに Cursor 公式ドキュメントを追加

## 関連 Issue

- Epic: #356（サブ: #357, #358, #359, #360, #361, #362）
- 調査: #363（Windsurf / Aider 等その他 SKILL.md 対応ツール）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0141AtTzc4YZuBV5hjC38EPY

---
_Generated by [Claude Code](https://claude.ai/code/session_0141AtTzc4YZuBV5hjC38EPY)_