### PR TITLE
refactor: introduce TargetStatus enum (#342 Phase 1)

### DIFF
--- a/src/commands/deploy/install_test.rs
+++ b/src/commands/deploy/install_test.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::component::ComponentKind;
 use crate::hooks::converter::{ConversionWarning, SourceFormat};
 use crate::install::{PlaceFailure, PlaceFailureStage, PlaceOutcome, PlaceSuccess};
+use crate::plugin::meta::TargetStatus;
 use crate::target::TargetKind;
 use std::path::PathBuf;
 use tempfile::TempDir;
@@ -243,7 +244,7 @@ fn update_status_after_install_marks_successful_targets_enabled() {
     crate::install::update_meta_after_place(temp.path(), &result);
 
     let plugin_meta = crate::plugin::meta::load_meta(temp.path()).unwrap();
-    assert_eq!(plugin_meta.get_status("codex"), Some("enabled"));
+    assert_eq!(plugin_meta.get_status("codex"), Some(TargetStatus::Enabled));
     // Hook + Codex は所有権としても記録される
     assert!(plugin_meta.manages_file("codex", std::path::Path::new("/dest/codex/hooks.json")));
 }
@@ -254,7 +255,7 @@ fn update_meta_after_place_does_not_rewrite_when_meta_already_up_to_date() {
     // .plm-meta.json の mtime を更新してはならない。
     let temp = TempDir::new().unwrap();
     let mut prepared = crate::plugin::meta::PluginMeta::default();
-    prepared.set_status("codex", "enabled");
+    prepared.set_status("codex", TargetStatus::Enabled);
     prepared.add_managed_file("codex", std::path::Path::new("/dest/codex/hooks.json"));
     crate::plugin::meta::write_meta(temp.path(), &prepared).unwrap();
 
@@ -315,7 +316,7 @@ fn update_meta_after_place_skips_managed_file_for_non_hook_codex_success() {
     crate::install::update_meta_after_place(temp.path(), &result);
 
     let plugin_meta = crate::plugin::meta::load_meta(temp.path()).unwrap();
-    assert_eq!(plugin_meta.get_status("codex"), Some("enabled"));
+    assert_eq!(plugin_meta.get_status("codex"), Some(TargetStatus::Enabled));
     assert!(
         !plugin_meta.manages_file("codex", std::path::Path::new("/dest/codex/hooks.json")),
         "Skill 配置のみで hooks.json の所有権を獲得してはならない"
@@ -366,7 +367,7 @@ fn update_status_after_install_skips_status_when_target_has_failures() {
     );
     assert_ne!(
         plugin_meta.get_status("codex"),
-        Some("enabled"),
+        Some(TargetStatus::Enabled),
         "target に failure があれば statusByTarget は enabled 昇格しない"
     );
 }

--- a/src/commands/lifecycle/disable.rs
+++ b/src/commands/lifecycle/disable.rs
@@ -5,7 +5,7 @@
 
 use crate::application::{disable_plugin, OperationOutcome};
 use crate::commands::args::MarketplaceArgs;
-use crate::plugin::{meta, PackageCache, PackageCacheAccess};
+use crate::plugin::{meta, meta::TargetStatus, PackageCache, PackageCacheAccess};
 use clap::{Parser, ValueEnum};
 use std::env;
 
@@ -99,7 +99,7 @@ fn update_status_after_disable(plugin_path: &std::path::Path, result: &Operation
 
     let target_names = result.affected_targets.target_names();
     for target_name in target_names {
-        plugin_meta.set_status(target_name, "disabled");
+        plugin_meta.set_status(target_name, TargetStatus::Disabled);
     }
 
     // When a filter is given and the target is unsupported, it is not present

--- a/src/commands/lifecycle/enable.rs
+++ b/src/commands/lifecycle/enable.rs
@@ -5,7 +5,7 @@
 
 use crate::application::{enable_plugin, OperationOutcome};
 use crate::commands::args::MarketplaceArgs;
-use crate::plugin::{meta, PackageCache, PackageCacheAccess};
+use crate::plugin::{meta, meta::TargetStatus, PackageCache, PackageCacheAccess};
 use clap::{Parser, ValueEnum};
 use std::env;
 
@@ -98,7 +98,7 @@ fn update_status_after_enable(plugin_path: &std::path::Path, result: &OperationO
 
     let target_names = result.affected_targets.target_names();
     for target_name in target_names {
-        plugin_meta.set_status(target_name, "enabled");
+        plugin_meta.set_status(target_name, TargetStatus::Enabled);
     }
 
     // When a filter is given and the target is unsupported, it is not present

--- a/src/install.rs
+++ b/src/install.rs
@@ -5,7 +5,8 @@ use crate::component::{AgentFormat, CommandFormat, ComponentKind, Scope};
 use crate::component::{Component, ComponentDeployment, ConversionConfig, DeploymentOutput};
 use crate::component::{ComponentRef, PlacementContext, PlacementScope, ProjectContext};
 use crate::plugin::{
-    cleanup_legacy_hierarchy, meta, MarketplaceContent, PackageCache, PackageCacheAccess,
+    cleanup_legacy_hierarchy, meta, meta::TargetStatus, MarketplaceContent, PackageCache,
+    PackageCacheAccess,
 };
 use crate::source::parse_source;
 use crate::target::{CodexTarget, PluginOrigin, Target, TargetKind};
@@ -436,9 +437,9 @@ pub fn update_meta_after_place(plugin_path: &Path, result: &PlaceOutcome) {
         // 既に "enabled" の場合は内容変化なしの no-op 書き込みを避けるため
         // set_status を呼ばずに skip する（mtime 汚染を防ぐ）。
         if !failed_targets.contains(success.target.as_str())
-            && plugin_meta.get_status(&success.target) != Some("enabled")
+            && plugin_meta.get_status(&success.target) != Some(TargetStatus::Enabled)
         {
-            plugin_meta.set_status(&success.target, "enabled");
+            plugin_meta.set_status(&success.target, TargetStatus::Enabled);
             updated = true;
         }
     }
@@ -467,13 +468,13 @@ pub fn update_meta_after_place(plugin_path: &Path, result: &PlaceOutcome) {
 pub fn record_codex_hook_ownership(plugin_path: &Path, hook_path: &Path) {
     let mut plugin_meta = meta::load_meta(plugin_path).unwrap_or_default();
     let was_managed = plugin_meta.manages_file("codex", hook_path);
-    let was_enabled = plugin_meta.get_status("codex") == Some("enabled");
+    let was_enabled = plugin_meta.get_status("codex") == Some(TargetStatus::Enabled);
 
     if was_managed && was_enabled {
         return;
     }
 
-    plugin_meta.set_status("codex", "enabled");
+    plugin_meta.set_status("codex", TargetStatus::Enabled);
     plugin_meta.add_managed_file("codex", hook_path);
 
     if let Err(e) = meta::write_meta(plugin_path, &plugin_meta) {

--- a/src/install_test.rs
+++ b/src/install_test.rs
@@ -6,6 +6,7 @@ use tempfile::TempDir;
 use super::*;
 use crate::component::ComponentKind;
 use crate::hooks::converter::{ConversionWarning, SourceFormat};
+use crate::plugin::meta::TargetStatus;
 use crate::plugin::{CachedPackage, MarketplaceContent, PluginManifest};
 use crate::target::{CodexTarget, CopilotTarget};
 
@@ -594,7 +595,7 @@ fn record_codex_hook_ownership_writes_managed_file_and_status() {
     record_codex_hook_ownership(plugin_dir.path(), &hook_path);
 
     let plugin_meta = crate::plugin::meta::load_meta(plugin_dir.path()).unwrap();
-    assert_eq!(plugin_meta.get_status("codex"), Some("enabled"));
+    assert_eq!(plugin_meta.get_status("codex"), Some(TargetStatus::Enabled));
     assert!(plugin_meta.manages_file("codex", &hook_path));
 }
 

--- a/src/plugin/lifecycle/update.rs
+++ b/src/plugin/lifecycle/update.rs
@@ -13,7 +13,7 @@ use crate::marketplace::{
 };
 use crate::plugin::lifecycle::plugin_resolver::{find_by_plugin_name, ResolvedPlugin};
 use crate::plugin::version::needs_update;
-use crate::plugin::{meta, GithubCacheId, PackageCacheAccess, PluginMeta};
+use crate::plugin::{meta, meta::TargetStatus, GithubCacheId, PackageCacheAccess, PluginMeta};
 use crate::repo::{self, Repo};
 use std::path::Path;
 
@@ -545,7 +545,7 @@ async fn do_safe_update(
     let mut new_meta = old_meta.clone();
     new_meta.set_git_info(git_ref, &archive_sha);
     for t in &failed {
-        new_meta.set_status(t, "disabled");
+        new_meta.set_status(t, TargetStatus::Disabled);
     }
     if let Err(e) = meta::write_meta(&plugin_path, &new_meta) {
         let _ = cache.restore(marketplace, cache_id);
@@ -1039,7 +1039,7 @@ fn commit_all(
         let mut new_meta = s.target.old_meta.clone();
         new_meta.set_git_info(&s.target.git_ref, &s.archive_sha);
         for t in &failed {
-            new_meta.set_status(t, "disabled");
+            new_meta.set_status(t, TargetStatus::Disabled);
         }
         // best-effort: 失敗してもロールバックしない（アトミック境界は swap まで）が、
         // commit SHA がメタに反映されない不整合を無言にしないよう警告する。

--- a/src/plugin/meta/meta.rs
+++ b/src/plugin/meta/meta.rs
@@ -8,9 +8,34 @@ use crate::fs::{FileSystem, RealFs};
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
+use std::fmt;
 use std::io::Write;
 use std::path::Path;
 use tempfile::NamedTempFile;
+
+/// プラグインのターゲット別ステータス
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum TargetStatus {
+    Enabled,
+    Disabled,
+}
+
+impl TargetStatus {
+    /// Returns the string representation of this status.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            TargetStatus::Enabled => "enabled",
+            TargetStatus::Disabled => "disabled",
+        }
+    }
+}
+
+impl fmt::Display for TargetStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
 
 /// メタデータファイル名
 const META_FILE: &str = ".plm-meta.json";
@@ -23,14 +48,14 @@ pub struct PluginMeta {
     #[serde(default, rename = "installedAt")]
     pub installed_at: Option<String>,
 
-    /// ターゲット別ステータス（"enabled" / "disabled"）
+    /// ターゲット別ステータス
     /// 空の場合はシリアライズ時に省略
     #[serde(
         default,
         rename = "statusByTarget",
         skip_serializing_if = "HashMap::is_empty"
     )]
-    pub status_by_target: HashMap<String, String>,
+    pub status_by_target: HashMap<String, TargetStatus>,
 
     /// Git参照（ブランチ名やタグ）
     #[serde(default, rename = "gitRef", skip_serializing_if = "Option::is_none")]
@@ -83,8 +108,8 @@ impl PluginMeta {
     /// # Arguments
     ///
     /// * `target` - Target name (e.g. `"codex"`, `"copilot"`).
-    pub fn get_status(&self, target: &str) -> Option<&str> {
-        self.status_by_target.get(target).map(|s| s.as_str())
+    pub fn get_status(&self, target: &str) -> Option<TargetStatus> {
+        self.status_by_target.get(target).copied()
     }
 
     /// 指定ターゲットのステータスを設定
@@ -92,10 +117,9 @@ impl PluginMeta {
     /// # Arguments
     ///
     /// * `target` - Target name.
-    /// * `status` - Status string (`"enabled"` or `"disabled"`).
-    pub fn set_status(&mut self, target: &str, status: &str) {
-        self.status_by_target
-            .insert(target.to_string(), status.to_string());
+    /// * `status` - Status value (`TargetStatus::Enabled` or `TargetStatus::Disabled`).
+    pub fn set_status(&mut self, target: &str, status: TargetStatus) {
+        self.status_by_target.insert(target.to_string(), status);
     }
 
     /// 指定ターゲットが有効化されているか
@@ -104,12 +128,14 @@ impl PluginMeta {
     ///
     /// * `target` - Target name.
     pub fn is_enabled(&self, target: &str) -> bool {
-        self.get_status(target) == Some("enabled")
+        self.get_status(target) == Some(TargetStatus::Enabled)
     }
 
     /// いずれかのターゲットが有効化されているか
     pub fn any_enabled(&self) -> bool {
-        self.status_by_target.values().any(|s| s == "enabled")
+        self.status_by_target
+            .values()
+            .any(|s| *s == TargetStatus::Enabled)
     }
 
     /// Git参照情報を更新
@@ -128,7 +154,7 @@ impl PluginMeta {
     pub fn enabled_targets(&self) -> Vec<&str> {
         self.status_by_target
             .iter()
-            .filter(|(_, status)| *status == "enabled")
+            .filter(|(_, status)| **status == TargetStatus::Enabled)
             .map(|(target, _)| target.as_str())
             .collect()
     }

--- a/src/plugin/meta/meta_test.rs
+++ b/src/plugin/meta/meta_test.rs
@@ -10,8 +10,8 @@ use tempfile::TempDir;
 fn test_status_by_target_serde_rename() {
     // JSON キー名が "statusByTarget" になることを確認
     let mut meta = PluginMeta::default();
-    meta.set_status("codex", "enabled");
-    meta.set_status("copilot", "disabled");
+    meta.set_status("codex", TargetStatus::Enabled);
+    meta.set_status("copilot", TargetStatus::Disabled);
 
     let json = serde_json::to_string(&meta).unwrap();
     assert!(json.contains("statusByTarget"));
@@ -44,8 +44,8 @@ fn test_status_by_target_deserialize() {
     let json = r#"{"installedAt":"2025-01-15T10:30:00Z","statusByTarget":{"codex":"enabled","copilot":"disabled"}}"#;
     let meta: PluginMeta = serde_json::from_str(json).unwrap();
 
-    assert_eq!(meta.get_status("codex"), Some("enabled"));
-    assert_eq!(meta.get_status("copilot"), Some("disabled"));
+    assert_eq!(meta.get_status("codex"), Some(TargetStatus::Enabled));
+    assert_eq!(meta.get_status("copilot"), Some(TargetStatus::Disabled));
     assert_eq!(meta.get_status("unknown"), None);
 }
 
@@ -55,11 +55,11 @@ fn test_get_set_status() {
 
     assert_eq!(meta.get_status("codex"), None);
 
-    meta.set_status("codex", "enabled");
-    assert_eq!(meta.get_status("codex"), Some("enabled"));
+    meta.set_status("codex", TargetStatus::Enabled);
+    assert_eq!(meta.get_status("codex"), Some(TargetStatus::Enabled));
 
-    meta.set_status("codex", "disabled");
-    assert_eq!(meta.get_status("codex"), Some("disabled"));
+    meta.set_status("codex", TargetStatus::Disabled);
+    assert_eq!(meta.get_status("codex"), Some(TargetStatus::Disabled));
 }
 
 #[test]
@@ -68,10 +68,10 @@ fn test_is_enabled() {
 
     assert!(!meta.is_enabled("codex"));
 
-    meta.set_status("codex", "enabled");
+    meta.set_status("codex", TargetStatus::Enabled);
     assert!(meta.is_enabled("codex"));
 
-    meta.set_status("codex", "disabled");
+    meta.set_status("codex", TargetStatus::Disabled);
     assert!(!meta.is_enabled("codex"));
 }
 
@@ -81,10 +81,10 @@ fn test_any_enabled() {
 
     assert!(!meta.any_enabled());
 
-    meta.set_status("codex", "disabled");
+    meta.set_status("codex", TargetStatus::Disabled);
     assert!(!meta.any_enabled());
 
-    meta.set_status("copilot", "enabled");
+    meta.set_status("copilot", TargetStatus::Enabled);
     assert!(meta.any_enabled());
 }
 
@@ -97,8 +97,8 @@ fn test_write_and_load_meta_with_status() {
         installed_at: Some("2025-01-15T10:30:00Z".to_string()),
         ..Default::default()
     };
-    meta.set_status("codex", "enabled");
-    meta.set_status("copilot", "disabled");
+    meta.set_status("codex", TargetStatus::Enabled);
+    meta.set_status("copilot", TargetStatus::Disabled);
 
     write_meta(plugin_dir, &meta).unwrap();
 
@@ -107,8 +107,8 @@ fn test_write_and_load_meta_with_status() {
         loaded.installed_at,
         Some("2025-01-15T10:30:00Z".to_string())
     );
-    assert_eq!(loaded.get_status("codex"), Some("enabled"));
-    assert_eq!(loaded.get_status("copilot"), Some("disabled"));
+    assert_eq!(loaded.get_status("codex"), Some(TargetStatus::Enabled));
+    assert_eq!(loaded.get_status("copilot"), Some(TargetStatus::Disabled));
 }
 
 // =============================================================================
@@ -299,9 +299,9 @@ fn test_enabled_targets_empty() {
 #[test]
 fn test_enabled_targets_filters_enabled_only() {
     let mut meta = PluginMeta::default();
-    meta.set_status("codex", "enabled");
-    meta.set_status("copilot", "disabled");
-    meta.set_status("claude", "enabled");
+    meta.set_status("codex", TargetStatus::Enabled);
+    meta.set_status("copilot", TargetStatus::Disabled);
+    meta.set_status("claude", TargetStatus::Enabled);
 
     let mut targets = meta.enabled_targets();
     targets.sort();
@@ -445,7 +445,7 @@ fn test_is_enabled_func_with_status_by_target_enabled() {
 
     // statusByTarget が有効な場合
     let mut meta = PluginMeta::default();
-    meta.set_status("codex", "enabled");
+    meta.set_status("codex", TargetStatus::Enabled);
     write_meta(plugin_dir, &meta).unwrap();
 
     let deployed: HashSet<String> = HashSet::new();
@@ -459,7 +459,7 @@ fn test_is_enabled_func_with_status_by_target_disabled() {
 
     // statusByTarget が無効のみの場合
     let mut meta = PluginMeta::default();
-    meta.set_status("codex", "disabled");
+    meta.set_status("codex", TargetStatus::Disabled);
     write_meta(plugin_dir, &meta).unwrap();
 
     let deployed: HashSet<String> = HashSet::new();
@@ -603,7 +603,7 @@ fn test_is_enabled_indexed_uses_status_by_target_when_present() {
     let plugin_dir = temp_dir.path();
 
     let mut meta = PluginMeta::default();
-    meta.set_status("codex", "enabled");
+    meta.set_status("codex", TargetStatus::Enabled);
     write_meta(plugin_dir, &meta).unwrap();
 
     // deployed_plugins が空でも statusByTarget で enabled なら true

--- a/src/target/env/codex_test.rs
+++ b/src/target/env/codex_test.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::component::{ComponentRef, PlacementScope, ProjectContext};
+use crate::plugin::meta::TargetStatus;
 use crate::target::paths::home_dir;
 use crate::target::PluginOrigin;
 
@@ -265,7 +266,7 @@ fn hook_overwrite_error_rejects_when_status_enabled_but_path_not_managed() {
 
     let plugin_root_dir = tempfile::TempDir::new().unwrap();
     let mut meta = crate::plugin::meta::PluginMeta::default();
-    meta.set_status("codex", "enabled");
+    meta.set_status("codex", TargetStatus::Enabled);
     // 別の path のみ管理対象として登録（Skill 配置等で enable はされたが、
     // 実際の hooks.json は別プラグインの所有という想定）
     meta.add_managed_file("codex", std::path::Path::new("/somewhere/else/hooks.json"));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

Issue #342 のうち **Phase 1（`TargetStatus` enum 導入）のみ** を実施しました。

ハンドラ共通化・状態遷移のユースケース層移管・#331 対応はスコープ外とし、別 PR で対応予定です。

## 変更内容

- `TargetStatus { Enabled, Disabled }` を `plugin/meta/meta.rs` に追加
- `status_by_target: HashMap<String, TargetStatus>` に変更
- `get_status` / `set_status` / `is_enabled` / `any_enabled` / `enabled_targets` を型安全化
- serde `rename_all = "lowercase"` で既存 JSON との後方互換を維持
- 呼び出し元（install / enable / disable / update / 各テスト）を `TargetStatus` に追随

## 検証

```bash
rustup run stable cargo test   # 1778 passed
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cf69514a-5314-40a3-a255-75fc6348452e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cf69514a-5314-40a3-a255-75fc6348452e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

