### PR TITLE
feat: CursorTarget に Instructions（AGENTS.md）配置を追加 (#360)

### DIFF
--- a/src/target/env/cursor.rs
+++ b/src/target/env/cursor.rs
@@ -1,10 +1,11 @@
-//! Cursor ターゲット実装（Phase 3: Skills / Agents / Commands）
+//! Cursor ターゲット実装（Skills / Agents / Commands / Instructions）
 //!
-//! Instructions / Hooks は後続 Issue（#360〜#361）で対応する。
+//! Hooks は後続 Issue（#361）で対応する。
 
 use crate::component::{ComponentKind, PlacementContext, PlacementLocation, Scope};
 use crate::error::Result;
 use crate::target::paths::base_dir;
+use crate::target::placed_common;
 use crate::target::scanner::{scan_components, ScannedComponent};
 use crate::target::{Target, TargetKind};
 use std::path::{Path, PathBuf};
@@ -29,15 +30,21 @@ impl CursorTarget {
         base_dir(scope, project_root, CURSOR_SUBDIR, CURSOR_SUBDIR)
     }
 
-    /// この組み合わせで配置できるか（Skill / Agent / Command をサポート）
+    /// この組み合わせで配置できるか
+    ///
+    /// Instructions は Project スコープのみ（Personal の User Rules は対象外）。
     ///
     /// # Arguments
     ///
     /// * `kind` - Component kind to check.
-    fn can_place(kind: ComponentKind) -> bool {
+    /// * `scope` - Scope (`Personal` or `Project`) to check.
+    fn can_place(kind: ComponentKind, scope: Scope) -> bool {
         matches!(
-            kind,
-            ComponentKind::Skill | ComponentKind::Agent | ComponentKind::Command
+            (kind, scope),
+            (ComponentKind::Skill, _)
+                | (ComponentKind::Agent, _)
+                | (ComponentKind::Command, _)
+                | (ComponentKind::Instruction, Scope::Project)
         )
     }
 
@@ -96,16 +103,17 @@ impl Target for CursorTarget {
             ComponentKind::Skill,
             ComponentKind::Agent,
             ComponentKind::Command,
+            ComponentKind::Instruction,
         ]
     }
 
     fn placement_location(&self, context: &PlacementContext) -> Option<PlacementLocation> {
         let kind = context.kind();
-        if !Self::can_place(kind) {
+        let scope = context.scope();
+        if !Self::can_place(kind, scope) {
             return None;
         }
 
-        let scope = context.scope();
         let project_root = context.project_root();
         let base = Self::base_dir(scope, project_root);
         let name = context.name();
@@ -121,6 +129,8 @@ impl Target for CursorTarget {
             ComponentKind::Command => {
                 PlacementLocation::file(base.join("commands").join(format!("{name}.md")))
             }
+            // Project scope: AGENTS.md at project root (shared with Codex)
+            ComponentKind::Instruction => PlacementLocation::file(project_root.join("AGENTS.md")),
             _ => return None,
         })
     }
@@ -131,8 +141,17 @@ impl Target for CursorTarget {
         scope: Scope,
         project_root: &Path,
     ) -> Result<Vec<String>> {
-        if !Self::can_place(kind) {
+        if !Self::can_place(kind, scope) {
             return Ok(vec![]);
+        }
+
+        if kind == ComponentKind::Instruction {
+            return Ok(placed_common::list_instruction(
+                self,
+                scope,
+                project_root,
+                "AGENTS.md",
+            ));
         }
 
         let base = Self::base_dir(scope, project_root);

--- a/src/target/env/cursor_test.rs
+++ b/src/target/env/cursor_test.rs
@@ -28,10 +28,11 @@ fn test_cursor_kind() {
 fn test_cursor_supported_components() {
     let target = CursorTarget::new();
     let supported = target.supported_components();
-    assert_eq!(supported.len(), 3);
+    assert_eq!(supported.len(), 4);
     assert!(supported.contains(&ComponentKind::Skill));
     assert!(supported.contains(&ComponentKind::Agent));
     assert!(supported.contains(&ComponentKind::Command));
+    assert!(supported.contains(&ComponentKind::Instruction));
 }
 
 #[test]
@@ -53,9 +54,9 @@ fn test_cursor_supports_command() {
 }
 
 #[test]
-fn test_cursor_not_supports_instruction() {
+fn test_cursor_supports_instruction() {
     let target = CursorTarget::new();
-    assert!(!target.supports(ComponentKind::Instruction));
+    assert!(target.supports(ComponentKind::Instruction));
 }
 
 #[test]
@@ -88,6 +89,18 @@ fn test_cursor_supports_scope_command() {
     let target = CursorTarget::new();
     assert!(target.supports_scope(ComponentKind::Command, Scope::Personal));
     assert!(target.supports_scope(ComponentKind::Command, Scope::Project));
+}
+
+#[test]
+fn test_cursor_supports_scope_instruction_project() {
+    let target = CursorTarget::new();
+    assert!(target.supports_scope(ComponentKind::Instruction, Scope::Project));
+}
+
+#[test]
+fn test_cursor_supports_scope_instruction_personal_returns_false() {
+    let target = CursorTarget::new();
+    assert!(!target.supports_scope(ComponentKind::Instruction, Scope::Personal));
 }
 
 #[test]
@@ -244,7 +257,7 @@ fn test_cursor_placement_location_command_project() {
 }
 
 #[test]
-fn test_cursor_placement_location_instruction_returns_none() {
+fn test_cursor_placement_location_instruction_project() {
     let target = CursorTarget::new();
     let project_root = Path::new("/project");
     let origin = PluginOrigin::from_marketplace("official", "my-plugin");
@@ -253,6 +266,24 @@ fn test_cursor_placement_location_instruction_returns_none() {
         component: ComponentRef::new(ComponentKind::Instruction, "test"),
         origin: &origin,
         scope: PlacementScope::new(Scope::Project),
+        project: ProjectContext::new(project_root),
+    };
+    let location = target.placement_location(&ctx).unwrap();
+
+    assert!(location.is_file());
+    assert_eq!(location.as_path(), Path::new("/project/AGENTS.md"));
+}
+
+#[test]
+fn test_cursor_placement_location_instruction_personal_returns_none() {
+    let target = CursorTarget::new();
+    let project_root = Path::new("/project");
+    let origin = PluginOrigin::from_marketplace("official", "my-plugin");
+
+    let ctx = PlacementContext {
+        component: ComponentRef::new(ComponentKind::Instruction, "test"),
+        origin: &origin,
+        scope: PlacementScope::new(Scope::Personal),
         project: ProjectContext::new(project_root),
     };
     assert!(target.placement_location(&ctx).is_none());
@@ -391,6 +422,46 @@ fn test_cursor_list_placed_ignores_agent_md_suffix() {
 
     let result = target
         .list_placed(ComponentKind::Agent, Scope::Project, project_root)
+        .unwrap();
+    assert!(result.is_empty());
+}
+
+#[test]
+fn test_cursor_list_placed_instruction_exists() {
+    let target = CursorTarget::new();
+    let temp_dir = TempDir::new().unwrap();
+    let project_root = temp_dir.path();
+
+    std::fs::write(project_root.join("AGENTS.md"), "# Agents").unwrap();
+
+    let result = target
+        .list_placed(ComponentKind::Instruction, Scope::Project, project_root)
+        .unwrap();
+    assert_eq!(result, vec!["AGENTS.md".to_string()]);
+}
+
+#[test]
+fn test_cursor_list_placed_instruction_not_exists() {
+    let target = CursorTarget::new();
+    let temp_dir = TempDir::new().unwrap();
+    let project_root = temp_dir.path();
+
+    let result = target
+        .list_placed(ComponentKind::Instruction, Scope::Project, project_root)
+        .unwrap();
+    assert!(result.is_empty());
+}
+
+#[test]
+fn test_cursor_list_placed_instruction_personal_returns_empty() {
+    let target = CursorTarget::new();
+    let temp_dir = TempDir::new().unwrap();
+    let project_root = temp_dir.path();
+
+    std::fs::write(project_root.join("AGENTS.md"), "# Agents").unwrap();
+
+    let result = target
+        .list_placed(ComponentKind::Instruction, Scope::Personal, project_root)
         .unwrap();
     assert!(result.is_empty());
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

Closes #360

`CursorTarget` に Instructions（`AGENTS.md`）の Project スコープ配置を追加します。

## 変更内容

- `can_place(kind, scope)` を Copilot パターンに変更し、Instruction は `Scope::Project` のみ許可
- `placement_location()`: `{project_root}/AGENTS.md`（Codex Project と同一パス）
- `list_placed()`: `placed_common::list_instruction` で `"AGENTS.md"` を返却
- `supported_components` に `Instruction` を追加
- テスト追加（Personal スコープが `None` / 空になること、Project で配置・検出できること）

## 設計判断

- `AGENTS.md` は Codex と共有。既存の Codex 挙動に追随し、`managedFiles` 等の追加所有権管理は行わない
- `scan/placement.rs` の `INSTRUCTION_FILE_NAMES` は変更不要（`AGENTS.md` 登録済み）

## 検証

```bash
cargo check
cargo test cursor
```

50 tests passed（cursor 関連）
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f57efd87-f50b-4a6e-87ca-ec514169ec61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f57efd87-f50b-4a6e-87ca-ec514169ec61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

