### PR TITLE
Set up dev environment (Cursor Cloud instructions)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,3 +63,12 @@ src/
 ## 依存関係とライセンス確認
 - 依存関係変更時は `THIRD_PARTY_LICENSES.md` を同期させます。
 - `cargo-deny` を使う場合は `deny.toml` に対して `cargo deny check` を実行します。
+
+## Cursor Cloud specific instructions
+- 単一の Rust CLI (`plm`) のみのプロジェクト。常駐サービスや DB/Docker は不要。ビルド/リント/テスト/実行コマンドは README.md と Makefile を参照（`make build`/`make lint`/`make test`、`cargo run -- <args>`）。
+- **Rust ツールチェーン**: `ratatui 0.30` が edition2024 を要求するため **Rust 1.85 以上が必須**。update script で `rustup update stable` により最新 stable に更新済み。古い toolchain では `feature edition2024 is required` でビルドが失敗する。
+- CLI に `--version` フラグは無い（`--help` を使う）。サブコマンド省略時と `managed` は TUI で **TTY が必要**なため、非対話環境では動かない。
+- `install` / `import` はネットワーク（GitHub API）が必要。`install` は対象リポジトリのルートに `plugin.json`（または `.claude-plugin/plugin.json`）が必要。`import` は Claude Code Plugin 形式（ルートに `.claude-plugin/plugin.json`）が対象。動作確認用の実在リポジトリ例: `DIO0550/cc-plugin`。
+- 非対話で `install`/`import` を実行するときは TUI 選択を避けるため `--target` と `--scope` を必ず指定する。
+- `plm init` は現状 "not implemented"（テンプレート生成は未実装）。
+- 設定・キャッシュ・インポート履歴は `~/.plm/` 配下（`cache/`, `imports.json` 等）に保存される。


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要
Cursor Cloud 上での開発環境セットアップを行い、`AGENTS.md` に将来のエージェント向けの `## Cursor Cloud specific instructions` を追記しました。Rust ファイルの変更はありません。

## 変更理由
ベースイメージの既定 Rust ツールチェーン (1.83) では、依存関係 `ratatui 0.30` が要求する edition2024 が使えずビルドに失敗します。最新 stable への更新が必須である点や、CLI 実行時の注意点（TTY 要件、ネットワーク要件、`init` 未実装など）を将来のエージェントが把握できるようにします。

## 検証方法
- `cargo build` — 成功（Rust 1.97.1）
- `cargo fmt --all -- --check` — 差分なし
- `cargo clippy -- -D warnings` — 警告なし
- `cargo test` — 1835 passed / 0 failed
- Hello world (E2E): `plm import DIO0550/cc-plugin --type agent --target cursor --scope project` を実行し、GitHub 上の実在する Claude Code Plugin をダウンロード・変換して 7 個の Agent を `.cursor/agents/` に配置、`~/.plm/imports.json` に履歴記録されることを確認。

デモログ:
[plm dev env demo log](https://cursor.com/agents/bc-ad88faf1-dbc6-4b28-87fd-fa5d9ac3ec70/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fplm_dev_env_demo.txt)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ad88faf1-dbc6-4b28-87fd-fa5d9ac3ec70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ad88faf1-dbc6-4b28-87fd-fa5d9ac3ec70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

