### PR TITLE
docs: Issue #344 実装計画（PLM_HOME パス解決の一元化）

### DIFF
--- a/docs/reviews/issue-344-plm-home.md
+++ b/docs/reviews/issue-344-plm-home.md
@@ -1,0 +1,212 @@
+# レビュー: Issue #344
+
+| 項目 | 内容 |
+|------|------|
+| Issue | [#344 [fix/refactor] HOME/PLM_HOME 解決を一元化する（PLM_HOME が一部のパス解決で無視され、状態が2つのルートに分裂する）](https://github.com/DIO0550/plugin-manager/issues/344) |
+| レビュー日 | 2026-07-20 |
+| 対象ブランチ | `main`（`40f011f` 時点） |
+| ラベル | `refactor` |
+| 関連 | [#333 config.toml 実装](https://github.com/DIO0550/plugin-manager/issues/333)（`PLM_HOME` 一貫性確認を明記） |
+
+## サマリー
+
+Issue が指摘する「`PLM_HOME` 設定時にキャッシュとレジストリが別ルートに分裂する」問題は **現状コードで再現可能であり、修正方針（単一の `plm_home()` / `PlmPaths`）も妥当**。
+
+ただし Issue 本文の対象一覧に **誤分類が2件** あり、そのまま実装すると Personal スコープ配置を壊す。加えて **`PLM_HOME` の意味論が docs と実装で食い違っており、一元化の前に契約を固定する必要がある**。
+
+**結論: 方針承認。実装前に (1) `PLM_HOME` セマンティクス確定、(2) 対象パスの境界划定、(3) 正規化ポリシー統一 を Issue / 実装メモへ追記すること。**
+
+## 問題の再現性（現状コード）
+
+### PLM 状態ルート（`.plm` 配下）— 分裂が実在
+
+| 実装箇所 | 解決方式 | `PLM_HOME` | 組み立てパス |
+|----------|----------|------------|--------------|
+| `src/plugin/cache/cache.rs` `PackageCache::new` | `EnvVar::get("PLM_HOME").or_else(HOME)` | ✓ | `{root}/.plm/cache/plugins/` |
+| `src/marketplace/registry.rs` `MarketplaceRegistry::new` | 同上 | ✓ | `{root}/.plm/cache/marketplaces/` |
+| `src/import/registry.rs` `ImportRegistry::new` | `std::env::var("HOME")` のみ | ✗ | `{HOME}/.plm/imports.json` |
+| `src/marketplace/config.rs` `MarketplaceConfig::load` | 同上 | ✗ | `{HOME}/.plm/marketplaces.json` |
+| `src/target/core/registry.rs` `TargetRegistry::new` | 同上 | ✗ | `{HOME}/.plm/targets.json` |
+
+`PLM_HOME=/tmp/plm-alt` のとき:
+
+- キャッシュ → `/tmp/plm-alt/.plm/cache/...`
+- `targets.json` / `marketplaces.json` / `imports.json` → `$HOME/.plm/...`
+
+ドキュメントもこの不整合を認識済み（`docs/reference/config.md` L21、「全パスで一貫して尊重されるとは限りません」）。
+
+### ユーザー HOME（ターゲット Personal 配置）— Issue 対象に含めるべきでない
+
+| 実装箇所 | 役割 | `PLM_HOME` を見るべきか |
+|----------|------|-------------------------|
+| `src/target/core/paths.rs` `home_dir()` | Personal スコープの `~/.codex` / `~/.cursor` 等の親 | **否**（OS ユーザー HOME） |
+| `src/plugin/cache/cleanup.rs` `resolve_home_dir()` | Personal 配置ディレクトリの掃除 | **否**（同上） |
+
+これらは「PLM の状態ルート」ではなく「各 AI ツールの Personal 配置先の親ディレクトリ」を解決する。`PLM_HOME` をここに流すと、`PLM_HOME` 設定時に Skills/Agents が `$PLM_HOME/.codex/...` へ配置され、実際の Codex/Cursor が見るパスと乖離する。
+
+Issue 提案 3（`paths.rs` の `"~"` フォールバックを単一ポリシーへ吸収）は、**ユーザー HOME 側の正規化ポリシー統一**としては検討余地があるが、`plm_home()` への吸収ではない。後述「境界」。
+
+## 設計ブロッカー: `PLM_HOME` の意味論
+
+### docs と実装の食い違い
+
+| ソース | 解釈 |
+|--------|------|
+| `docs/reference/config.md` 環境変数表 | 「PLMのホームディレクトリ（**デフォルト: `~/.plm`**）」→ `PLM_HOME` **自体が** `.plm` ルート（Cargo の `CARGO_HOME` 型） |
+| `PackageCache` / `MarketplaceRegistry` 実装 | `$PLM_HOME/.plm/...` を組む → `PLM_HOME` は **`HOME` の代替**（未設定時 `$HOME/.plm`） |
+| `docs/architecture/cache.md` | 「`$PLM_HOME/.plm/cache/plugins/`（未設定時は `$HOME`）」→ 実装と同型（HOME 代替） |
+
+**危険な誤用シナリオ（docs 表を信じた場合）:**
+
+```bash
+export PLM_HOME=~/.plm   # docs の「デフォルト」を明示設定したつもり
+# 実装は ~/.plm/.plm/cache/... を作る
+```
+
+一元化の前にセマンティクスを **どちらかに固定**し、docs / コード / テストを揃えること。
+
+### 推奨契約（現状実装互換）
+
+**案 A（推奨・後方互換）: HOME 代替**
+
+```text
+plm_root = $PLM_HOME  if set and valid
+         = $HOME      otherwise
+plm_dir  = {plm_root}/.plm
+```
+
+- 既存のキャッシュ利用者が壊れない
+- docs の環境変数表と README の「デフォルト: `~/.plm`」表現を「未設定時の実効パスは `$HOME/.plm`。`PLM_HOME` は `$HOME` の代替」に修正する
+
+**案 B: CARGO_HOME 型（docs 表寄り）**
+
+```text
+plm_dir = $PLM_HOME  if set and valid
+        = $HOME/.plm otherwise
+```
+
+- 直感的で docs 表と一致
+- **既存の `PLM_HOME` 利用者は破壊的変更**（パスが `.plm` 一段深くなる/浅くなる）
+- キャッシュ実装の書き換えが必須
+
+**レビュー推奨は案 A**。案 B にするなら Issue に破壊的変更とマイグレーション方針を明記すること。
+
+## 設計判断のレビュー
+
+### 1. `plm_home()`（または同等）を1箇所に置く
+
+#### 結論: **承認。配置は `src/env.rs` が適切**
+
+| 観点 | 評価 |
+|------|------|
+| 重複除去 | ◎ 現状の2系統（`EnvVar` 連鎖 vs 生 `var("HOME")`）を解消 |
+| `path_ext` への配置 | △ `PathExt` はパス操作トレイト。環境変数解決は責務外 |
+| `env.rs` | ◎ 既存 `EnvVar` の延長。`plm_root()` / `plm_home()` を同モジュールに追加 |
+
+推奨シグネチャ例:
+
+```rust
+/// PLM 状態の親ディレクトリ（HOME 代替セマンティクス）。
+/// 未設定・空・空白のみはエラー（または Option）。
+pub fn plm_root() -> Result<PathBuf, PlmError> { /* PLM_HOME → HOME */ }
+
+/// `{plm_root}/.plm`
+pub fn plm_dir() -> Result<PathBuf, PlmError> {
+    Ok(plm_root()?.join(".plm"))
+}
+```
+
+命名は `plm_home()` でもよいが、docs の「`PLM_HOME` = `.plm` そのもの」誤解を避けるなら **`plm_root()` + `plm_dir()`** の二段が明確。
+
+### 2. `PlmPaths` 型付きアクセサ
+
+#### 結論: **承認。対象は `.plm` 配下のみに限定する**
+
+```text
+PlmPaths
+  ├── dir()                 → {root}/.plm
+  ├── config_toml()         → {root}/.plm/config.toml   (#333 準備)
+  ├── targets_json()        → {root}/.plm/targets.json
+  ├── marketplaces_json()   → {root}/.plm/marketplaces.json
+  ├── imports_json()        → {root}/.plm/imports.json
+  ├── plugins_cache_dir()   → {root}/.plm/cache/plugins
+  └── marketplaces_cache_dir() → {root}/.plm/cache/marketplaces
+```
+
+呼び出し側は `PackageCache::new` / `MarketplaceRegistry::new` / 各 `*Registry::new` / `MarketplaceConfig::load` が `PlmPaths`（または `plm_dir()`）経由に切り替える。
+
+テスト用に既にある `with_cache_dir` / `with_path` / `load_from` は維持し、デフォルト経路だけを一元化する。
+
+### 3. `paths.rs` / `cleanup.rs` を `plm_home()` に吸収しない
+
+#### 結論: **Issue 対象から除外（ブロッカー級の境界）**
+
+| パス族 | 環境変数 | 用途 |
+|--------|----------|------|
+| PLM 状態 | `PLM_HOME` → `HOME` | `~/.plm/**` |
+| ユーザー HOME | `HOME` のみ（将来 `CODEX_HOME` 等は別） | Personal 配置・掃除 |
+
+`paths.rs` の `"~"` リテラルフォールバックと `cleanup.rs` の「絶対パス必須・`None` で personal スキップ」は、**ユーザー HOME 正規化**の問題として別 Issue または本 Issue の「付録スコープ」で扱う。混ぜると責務が再び分散する。
+
+ユーザー HOME 側を触る場合の推奨:
+
+- `paths::home_dir()` と `cleanup::resolve_home_dir()` の正規化を共通 helper（例: `user_home_dir() -> Option<PathBuf>`）に寄せる
+- `"~"` フォールバックは残すか、呼び出し側で `Option` にするかを別判断（現状ドキュメントは「HOME 確実前提」）
+- **`PLM_HOME` は参照しない**
+
+### 4. 正規化ポリシーの統一（PLM ルート側）
+
+現状の差:
+
+| 実装 | 空文字 | 空白のみ | trim | 相対パス | 非 UTF-8 |
+|------|--------|----------|------|----------|----------|
+| `EnvVar::get` | `None` | 受理（非空なら） | なし | 受理 | `var` なので不可 |
+| `std::env::var("HOME")`（registry 系） | 受理 | 受理 | なし | 受理 | エラー |
+| `paths::home_dir` | `"~"` | `"~"` | あり | 受理 | 不可 |
+| `cleanup::resolve_home_dir` | `None` | `None` | あり | `None` | `OsString` 受理 |
+
+`plm_root()` では最低限次を固定する:
+
+1. 未設定 / 空 / 空白のみ → エラー（または次候補へフォールバック）
+2. trim してから使用（`EnvVar::get` の強化、または専用 getter）
+3. 相対パス: **拒否してエラー**を推奨（テストで CWD 依存の状態分裂を防ぐ）。許容するなら明示ドキュメント化
+4. エラー型: `MarketplaceConfig::load` の `Result<_, String>` も `PlmError` 系へ寄せると呼び出しが揃う（本 Issue の必須ではないが隣接改善）
+
+## 推奨実装ステップ
+
+1. **契約固定**: Issue に案 A/B の決定を追記。docs（`reference/config.md` / `architecture/cache.md`）を同期
+2. **Red**: `PLM_HOME` 設定時に `targets.json` / `marketplaces.json` / `imports.json` / 両キャッシュが同一 `{root}/.plm` 配下になるテスト
+3. **Green**: `env::plm_root` / `plm_dir`（± `PlmPaths`）を追加し、5 箇所のデフォルト構築を置換
+4. **境界テスト**: `PLM_HOME` 設定下でも `paths::home_dir()` / Personal 配置が `$HOME` を見ることを回帰で固定
+5. **#333 接続**: `config.toml` 実装時は `PlmPaths::config_toml()` を前提にし、再度独自の HOME 解決を増やさない
+
+## テスト観点
+
+| ID | ケース | 期待 |
+|----|--------|------|
+| T1 | `PLM_HOME` 未設定、`HOME=/h` | 全 PLM 状態が `/h/.plm/...` |
+| T2 | `PLM_HOME=/p`、`HOME=/h` | 全 PLM 状態が `/p/.plm/...`（レジストリ含む） |
+| T3 | `PLM_HOME=""` | `HOME` へフォールバック（`EnvVar` 現行互換） |
+| T4 | `PLM_HOME="   "` | フォールバックまたはエラー（方針どおり一貫） |
+| T5 | `PLM_HOME` も `HOME` も無し | 明確なエラー（キャッシュと同文言系統） |
+| T6 | T2 条件下で Codex Personal Skill 配置 | パスが `/h/.codex/...`（`/p` 配下に行かない） |
+| T7 | 既存 `with_path` / `with_cache_dir` | 挙動不変 |
+
+## Issue 本文への追記推奨
+
+1. **対象から外す**: `target/core/paths.rs`、`plugin/cache/cleanup.rs`（ユーザー HOME）。必要なら「ユーザー HOME 正規化は別タスク」と明記
+2. **セマンティクス決定**: 案 A（HOME 代替）か案 B（CARGO_HOME 型）か。破壊的変更の有無
+3. **docs 修正を DoD に含める**: `reference/config.md` の「デフォルト: `~/.plm`」表現と実装の一致
+4. **非目標**: ターゲット別 `CODEX_HOME` / `COPILOT_HOME` 等の尊重（将来・#333 第3段階）
+
+## 結論
+
+| 項目 | 判定 |
+|------|------|
+| 問題の実在性 | ✅ 確認 |
+| `plm_home` / `PlmPaths` 集約 | ✅ 承認（`.plm` 配下のみ） |
+| Issue 一覧の `paths.rs` / `cleanup.rs` | ❌ 対象外にすべき（誤分類） |
+| `PLM_HOME` 意味論 | ⚠ 実装前に確定必須（推奨: HOME 代替 = 案 A） |
+| #333 との関係 | 本 Issue を先に閉じると config.toml 実装が安全 |
+
+**実装着手前の必須アクション:** Issue コメントでセマンティクス（案 A/B）と対象境界を確定する。それが済めばリファクタの技術リスクは低い。

--- a/docs/specs/001-plm-home-unification/README.md
+++ b/docs/specs/001-plm-home-unification/README.md
@@ -1,0 +1,33 @@
+# Spec 001: PLM_HOME / HOME 解決の一元化
+
+Issue: [#344](https://github.com/DIO0550/plugin-manager/issues/344)  
+事前レビュー: [docs/reviews/issue-344-plm-home.md](../../reviews/issue-344-plm-home.md)
+
+## ファイル
+
+| ファイル | 説明 |
+|----------|------|
+| [hearing-notes.md](./hearing-notes.md) | ヒアリング結果 |
+| [exploration-report.md](./exploration-report.md) | コードベース探索 |
+| [requirements.md](./requirements.md) | ユースケース・要件（確定済み） |
+| [implementation-plan.md](./implementation-plan.md) | 実装計画 |
+| [tasks.md](./tasks.md) | TDD タスクリスト |
+| [test-cases.html](./test-cases.html) | テストケース詳細（ブラウザで開く） |
+| [tech-reference.md](./tech-reference.md) | 技術リファレンス |
+| [understanding-quiz-plan.html](./understanding-quiz-plan.html) | 実装前理解度クイズ |
+
+## 確定した設計判断
+
+- **案 A**: `PLM_HOME` は `$HOME` の代替 → 実効パス `{root}/.plm`
+- **対象外**: `paths.rs` / `cleanup.rs`（ユーザー HOME / Personal 配置）
+- **エラー**: `plm_root` は `PlmError::General`、呼び出し側でドメイン別 `map_err`
+- **MarketplaceConfig**: `Result<_, String>` 維持
+
+## 実装開始
+
+作業コピーのガード解除（ローカル）:
+
+```bash
+rm .plugin-workspace/.specs/.guard/cloud-agent-344 \
+   .plugin-workspace/.specs/001-plm-home-unification/PLANNING
+```

--- a/docs/specs/001-plm-home-unification/exploration-report.md
+++ b/docs/specs/001-plm-home-unification/exploration-report.md
@@ -1,0 +1,544 @@
+# Codebase Exploration Report: PLM_HOME / HOME 解決の一元化
+
+**探索目的**: `PLM_HOME` 設定時にプラグインキャッシュとレジストリ／設定 JSON が別ルートに分裂する不整合を解消し、PLM 状態（`~/.plm` 相当）のパス解決を単一ポリシー（`plm_root` / `PlmPaths`）に集約する。
+
+---
+
+## 0. エグゼクティブサマリー
+
+**重要な発見（Top 5）**:
+
+1. **バグの分布が明確**: 5 種のファイルが `~/.plm` 配下のパスを自前で構築しているが、そのうち **3 つ（`MarketplaceConfig`・`TargetRegistry`・`ImportRegistry`）が `PLM_HOME` を無視**して生の `std::env::var("HOME")` を使っており、`PackageCache` / `MarketplaceRegistry` の 2 つだけが正しく `EnvVar::get("PLM_HOME")` → `HOME` フォールバックを実装している。
+2. **正解パターンはコードベース内に既存**: `PackageCache::new()` と `MarketplaceRegistry::new()` が実装している `EnvVar::get("PLM_HOME").or_else(|| EnvVar::get("HOME"))` が「案 A 相当」の正しいパターン。`plm_root()` 関数はこのロジックの抽出で済む。
+3. **テスト注入 API が全 5 つに揃っている**: `with_cache_dir()` / `with_path()` / `load_from()` 系のテスト専用コンストラクタが全レジストリに整備済み。`PlmPaths` にも同様の `with_root(PathBuf)` を追加するだけでテストが書ける。
+4. **`MarketplaceConfig` のエラー型が不統一**: 他の 4 つは `crate::error::Result<T>` を返すが `MarketplaceConfig` だけ `Result<Self, String>` を返す。一元化の際の **必須でない** 改善候補だが、ユーザー体験に影響。
+5. **Personal スコープ用の `home_dir()` / `resolve_home_dir()` は意図的スコープ外**: `src/target/core/paths.rs` と `src/plugin/cache/cleanup.rs` の両関数は `HOME` のみを使う（Target の Personal 配置用）。本機能では **変更しない**。
+
+**推奨される次のステップ**:
+- `src/env.rs` に `plm_root()` 関数（または `PlmPaths` 構造体の `new()` / `with_root()`）を追加し、3 つのバグ箇所を置き換える（TDD: Red → Green）
+- `MarketplaceConfig::load()` の `String` エラーは `plm_root()` 導入と同時に `PlmError` 寄せ可能だが、ヒアリングでは必須でないとされているため判断が必要
+
+---
+
+## 1. アーキテクチャ概要
+
+### 1.1 ディレクトリ構造
+
+```
+src/
+├── main.rs             # エントリポイント（tokio::main）
+├── cli.rs              # clap CLI 定義（16コマンド）
+├── commands.rs         # コマンドディスパッチ
+├── env.rs              # EnvVar ユーティリティ（PLM_HOME 解決の起点）
+├── env_test.rs
+├── config.rs           # HTTP設定・AuthProvider（PLM_HOME 無関係）
+├── path_ext.rs         # PathExt トレイト（Path 拡張）
+├── install.rs          # インストール処理（PackageCache を使用）
+├── application.rs      # アプリケーション層
+├── plugin/
+│   ├── cache/
+│   │   ├── cache.rs    # PackageCache（PLM_HOME → HOME 済み ✓）
+│   │   ├── cache_test.rs
+│   │   └── cleanup.rs  # resolve_home_dir（HOME のみ・スコープ外）
+│   └── ...
+├── marketplace/
+│   ├── registry.rs     # MarketplaceRegistry（PLM_HOME → HOME 済み ✓）
+│   ├── registry_test.rs
+│   └── config.rs       # MarketplaceConfig（HOME のみ ← バグ）
+├── import/
+│   ├── registry.rs     # ImportRegistry（HOME のみ ← バグ）
+│   └── registry_test.rs
+├── target/
+│   └── core/
+│       ├── registry.rs # TargetRegistry（HOME のみ ← バグ）
+│       ├── registry_test.rs
+│       ├── paths.rs    # home_dir()（HOME のみ・スコープ外）
+│       └── paths_test.rs
+└── commands/
+    └── manage/
+        └── marketplace.rs  # MarketplaceConfig + MarketplaceRegistry 両方を呼ぶ
+```
+
+**構造の特徴**:
+- Feature ベース（domain/application/infrastructure 分離なし）
+- テストファイルは `foo_test.rs` として分離（`#[cfg(test)] #[path = "foo_test.rs"]` パターン）
+
+### 1.2 主要ファイル
+
+| ファイルパス | 役割 | 重要度 |
+|---|---|---|
+| `src/env.rs` | `EnvVar::get()` 提供・`plm_root()` の追加先 | 高 |
+| `src/plugin/cache/cache.rs` | `PackageCache` — 正しいパターンの参考実装 | 高 |
+| `src/marketplace/registry.rs` | `MarketplaceRegistry` — 正しいパターンの参考実装 | 高 |
+| `src/marketplace/config.rs` | `MarketplaceConfig` — `HOME` のみ（バグ修正対象） | 高 |
+| `src/import/registry.rs` | `ImportRegistry` — `HOME` のみ（バグ修正対象） | 高 |
+| `src/target/core/registry.rs` | `TargetRegistry` — `HOME` のみ（バグ修正対象） | 高 |
+| `src/target/core/paths.rs` | `home_dir()` — スコープ外（変更しない） | 中 |
+| `src/plugin/cache/cleanup.rs` | `resolve_home_dir()` — スコープ外（変更しない） | 中 |
+| `src/commands/manage/marketplace.rs` | 両 registry の呼び出し元 | 中 |
+
+### 1.3 レイヤー構成
+
+```
+CLI (clap)
+   ↓
+commands/ (コマンドハンドラ)
+   ↓
+registries / config  ← ここが修正の核
+   ├── PackageCache         ($PLM_HOME → $HOME → .plm/cache/plugins/)   ✓
+   ├── MarketplaceRegistry  ($PLM_HOME → $HOME → .plm/cache/marketplaces/) ✓
+   ├── MarketplaceConfig    ($HOME のみ → .plm/marketplaces.json)  ← バグ
+   ├── TargetRegistry       ($HOME のみ → .plm/targets.json)       ← バグ
+   └── ImportRegistry       ($HOME のみ → .plm/imports.json)       ← バグ
+```
+
+### 1.4 依存関係
+
+```
+src/env.rs  ←──── PackageCache::new()
+                └── MarketplaceRegistry::new()
+                (MarketplaceConfig / TargetRegistry / ImportRegistry は未使用 ← バグ)
+
+std::env::var("HOME")  ←── MarketplaceConfig::load()
+                         ├── TargetRegistry::new()
+                         └── ImportRegistry::new()
+```
+
+**循環依存**: なし  
+**主要な外部依存**: `clap 4`, `tokio 1`, `reqwest 0.12`, `serde 1`, `serde_json 1`, `tempfile 3`（テスト用）, `assert_cmd 2`（統合テスト）
+
+---
+
+## 2. 関連コード分析
+
+### 2.1 変更対象に関連する既存コード
+
+| ファイルパス | 関連内容 | 関連度 |
+|---|---|---|
+| `src/env.rs` | `EnvVar::get()` — `plm_root()` の追加先 | 高 |
+| `src/plugin/cache/cache.rs` | `PackageCache::new()` — 正しいパターンの参考実装 | 高 |
+| `src/marketplace/registry.rs` | `MarketplaceRegistry::new()` — 正しいパターンの参考実装 | 高 |
+| `src/marketplace/config.rs` | `MarketplaceConfig::load()` — `HOME` のみバグ | 高 |
+| `src/import/registry.rs` | `ImportRegistry::new()` — `HOME` のみバグ | 高 |
+| `src/target/core/registry.rs` | `TargetRegistry::new()` — `HOME` のみバグ | 高 |
+| `src/target/core/paths.rs` | `home_dir()` — Personal 配置用、スコープ外 | 低 |
+| `src/plugin/cache/cleanup.rs` | `resolve_home_dir()` — Personal cleanup 用、スコープ外 | 低 |
+
+### 2.2 再利用可能なパターン
+
+#### パターン: PLM_HOME → HOME フォールバック（PackageCache / MarketplaceRegistry 実装済み）
+
+**場所**: `src/plugin/cache/cache.rs`, `src/marketplace/registry.rs`  
+**概要**: `EnvVar::get("PLM_HOME").or_else(|| EnvVar::get("HOME"))` で PLM_HOME 優先の HOME フォールバックを実現。空文字列を自動フィルタ。  
+**再利用方法**: このロジックを `plm_root()` として `src/env.rs` に抽出し、全 5 レジストリから呼ぶ。
+
+```rust
+// src/plugin/cache/cache.rs （PackageCache::new — 正しいパターン）
+pub fn new() -> Result<Self> {
+    let fs = RealFs;
+    let home = crate::env::EnvVar::get("PLM_HOME")
+        .or_else(|| crate::env::EnvVar::get("HOME"))
+        .ok_or_else(|| {
+            PlmError::Cache(
+                "PLM_HOME and HOME environment variables not set or empty".to_string(),
+            )
+        })?;
+    let cache_dir = PathBuf::from(home)
+        .join(".plm")
+        .join("cache")
+        .join("plugins");
+    fs.create_dir_all(&cache_dir)?;
+    Ok(Self { cache_dir })
+}
+```
+
+#### パターン: テスト用コンストラクタ（カスタムパス注入）
+
+**場所**: 全 5 レジストリ  
+**概要**: 本番コンストラクタ（`new()` / `load()`）とは別に、テスト用のパス注入 API が揃っている。  
+**再利用方法**: `PlmPaths::with_root(root: PathBuf)` を同様のパターンで追加。
+
+```rust
+// PackageCache — with_cache_dir パターン
+pub fn with_cache_dir(cache_dir: PathBuf) -> Result<Self> {
+    let fs = RealFs;
+    fs.create_dir_all(&cache_dir)?;
+    Ok(Self { cache_dir })
+}
+
+// MarketplaceRegistry — with_cache_dir パターン（同上）
+
+// TargetRegistry — with_path パターン
+pub fn with_path(path: PathBuf) -> Self {
+    Self { config_path: path, state: State::Idle, config: None }
+}
+
+// ImportRegistry — with_path パターン（同上）
+
+// MarketplaceConfig — load_from パターン
+pub fn load_from(path: PathBuf) -> Result<Self, String> { ... }
+```
+
+#### パターン: 状態マシン（TargetRegistry / ImportRegistry）
+
+**場所**: `src/target/core/registry.rs`, `src/import/registry.rs`  
+**概要**: Idle → Loaded → Modified → Idle の状態遷移で、不整合な操作を防ぎつつ NamedTempFile による耐障害性のある保存を実現。  
+**再利用方法**: 新モジュールでも踏襲可能。`PlmPaths` 自体はパス計算のみで状態は持たないため直接は不要。
+
+```rust
+// src/target/core/registry.rs の状態マシン例
+fn save(&mut self) -> Result<()> {
+    // ...
+    let parent = self.config_path.parent().unwrap_or(Path::new("."));
+    let mut temp_file = NamedTempFile::new_in(parent)
+        .map_err(|e| PlmError::TargetRegistry(format!("Failed to create temp file: {}", e)))?;
+    let content = serde_json::to_string_pretty(config)?;
+    temp_file.write_all(content.as_bytes())?;
+    temp_file.persist(&self.config_path)
+        .map_err(|e| PlmError::TargetRegistry(format!("Failed to persist config: {}", e)))?;
+    self.state = State::Idle;
+    Ok(())
+}
+```
+
+### 2.3 類似実装の参考例
+
+#### 参考: `EnvVar::get()` 空文字フィルタ
+
+**実装ファイル**: `src/env.rs`  
+**類似点**: PLM_HOME が設定されているが空文字の場合も `None` として扱い、HOME フォールバックに進む。  
+**参考になる点**: `plm_root()` でも同じく空文字を `None` 相当として扱うべき。
+
+```rust
+// src/env.rs
+pub fn get(key: &str) -> Option<String> {
+    std::env::var(key).ok().filter(|s| !s.is_empty())
+}
+```
+
+#### 参考: `resolve_home_dir()` のエッジケース処理（スコープ外だが参考）
+
+**実装ファイル**: `src/plugin/cache/cleanup.rs`  
+**類似点**: 空白のみ / 相対パス / 非 UTF-8 / 空文字を `None` として扱い、Personal scope の誤操作を防ぐ。  
+**参考になる点**: `plm_root()` でも相対パス拒否ロジックを入れることを hearing-notes が推奨。
+
+```rust
+// src/plugin/cache/cleanup.rs
+fn resolve_home_dir() -> Option<PathBuf> {
+    let home = std::env::var_os("HOME")?;
+    let home = match home.to_str() {
+        Some(s) => {
+            let trimmed = s.trim();
+            if trimmed.is_empty() { return None; }
+            PathBuf::from(trimmed)
+        }
+        None => { /* OsString フォールバック */ }
+    };
+    home.is_absolute().then_some(home)
+}
+```
+
+### 2.4 命名規則・コーディングスタイル
+
+- **ファイル命名**: `snake_case`（`registry.rs`, `cache.rs`）、テストは `*_test.rs` に分離
+- **変数命名**: `snake_case`（`cache_dir`, `config_path`）、型は `CamelCase`（`PlmPaths`, `PackageCache`）
+- **インデント**: 4 スペース（rustfmt 準拠）
+- **エラー型**: `crate::error::Result<T>` が基本。`MarketplaceConfig` だけ `Result<Self, String>` という例外がある
+- **`*Outcome` 命名**: `AddOutcome`, `RemoveOutcome` — 成果レポート型に `Outcome` 接尾辞（CLAUDE.md 規約）
+
+### 2.6 再探索: [NEW] 項目の類似実装検証
+
+**目的**: 実装計画の [NEW] 項目（`plm_root()` / `PlmPaths struct` / パスアクセサ群）について、類似の既存実装が初回探索で見落とされていないかを確認する。
+
+**追加検索キーワード**: `struct.*Paths`, `CachePaths`, `AppPaths`, `HomePaths`, `RootPath`, `fn plm_root`, `fn get_home`, `fn resolve.*home`, `fn get_root`, `fn app_dir`, `fn state_dir`, `PlmPaths`, `with_root`, `plm_dir`, `join(".plm")`（全ファイル横断）、`utils/`, `helpers/`, `shared/` ディレクトリ探索
+
+#### [NEW-1] `plm_root()` 関数 — **類似実装なし**
+
+コードベース全体で `plm_root` に相当する関数は存在しない。最も近い既存実装:
+
+- `home_dir()` (`src/target/core/paths.rs`) — `HOME` のみ・`PathBuf` 返却（`Result` でない）・Personal 配置専用
+- `resolve_home_dir()` (`src/plugin/cache/cleanup.rs`) — `HOME` のみ・`Option<PathBuf>` 返却・cleanup 専用
+
+どちらも `PLM_HOME` を扱わず、用途・シグネチャ・エラー処理が計画の `plm_root() -> Result<PathBuf>` と異なる。**再利用不可**。
+
+```rust
+// src/target/core/paths.rs — 「HOMEのみ・フォールバックに"~"を返す」という仕様が plm_root と異なる
+pub(crate) fn home_dir() -> PathBuf {
+    std::env::var("HOME")
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("~"))  // ← Result でなくフォールバック
+}
+```
+
+#### [NEW-2] `PlmPaths struct + new/with_root` — **類似実装なし**
+
+コードベース全体でパス集約 struct は以下の 2 つのみ:
+
+- `ScopedPath` (`src/component/model/scoped_path.rs`) — プロジェクトルート配下のトラバーサル防止用型。PLM 状態パスとは無関係。
+- `PluginSourcePath` (`src/marketplace/path/plugin_source_path.rs`) — マーケットプレイスのプラグインパス文字列ラッパー。PLM 状態パスとは無関係。
+
+`utils/`, `helpers/`, `shared/`, `lib/` ディレクトリは存在しない。**再利用できる構造体はゼロ**。
+
+#### [NEW-3] パスアクセサ群（`plm_dir/targets_json/marketplaces_json/imports_json/plugins_cache_dir/marketplaces_cache_dir`）— **類似実装なし**
+
+`.join(".plm")` の全出現箇所を横断検索した結果、5 箇所のみ（全て既知のバグ・正解箇所）:
+
+| ファイル | 構築するパス | 状態 |
+|---|---|---|
+| `src/target/core/registry.rs` | `{HOME}/.plm/targets.json` | バグ（HOME のみ） |
+| `src/import/registry.rs` | `{HOME}/.plm/imports.json` | バグ（HOME のみ） |
+| `src/marketplace/config.rs` | `{HOME}/.plm/marketplaces.json` | バグ（HOME のみ） |
+| `src/plugin/cache/cache.rs` | `{PLM_HOME\|HOME}/.plm/cache/plugins` | 正解パターン |
+| `src/marketplace/registry.rs` | `{PLM_HOME\|HOME}/.plm/cache/marketplaces` | 正解パターン |
+
+各箇所が個別にパス文字列を組み立てており、**集約アクセサは存在しない**。計画通り `PlmPaths` への集約が必要。
+
+#### 計画の「PackageCache のパターンを抽出」方針の評価
+
+初回探索で特定した `PackageCache::new()` / `MarketplaceRegistry::new()` の `EnvVar::get("PLM_HOME").or_else(|| EnvVar::get("HOME"))` パターンが、**コードベース内で唯一の正解実装**であることを再確認。
+
+計画が「このロジックを `plm_root()` として `src/env.rs` に抽出する」としている方針は **十分かつ正確**。他に抽出・再利用すべき隠れた実装は存在しない。
+
+**結論: 3つの [NEW] 項目すべてについて類似の既存実装は存在しない。計画の新規作成は妥当。**
+
+---
+
+### 2.5 既存構造の問題点・技術的負債
+
+| 問題のあるパターン / 場所 | 問題の内容 | 新実装での扱い |
+|---|---|---|
+| `MarketplaceConfig::load()` / `src/marketplace/config.rs:32` | `std::env::var("HOME")` 直接使用・PLM_HOME を無視・エラー型が `String`（不統一） | 避ける。`plm_root()` を使い、`PlmError` 寄せも検討 |
+| `TargetRegistry::new()` / `src/target/core/registry.rs:104` | `std::env::var("HOME")` 直接使用・PLM_HOME を無視 | 避ける。`plm_root()` を使う |
+| `ImportRegistry::new()` / `src/import/registry.rs:93` | `std::env::var("HOME")` 直接使用・PLM_HOME を無視 | 避ける。`plm_root()` を使う |
+| 各 `::new()` 内でのパス文字列リテラル重複 | `".plm"`, `"cache"`, `"plugins"` 等がコードに散在 | 避ける。`PlmPaths` に集約する |
+
+**「避ける」とした場合の代替方針**: 新実装では `EnvVar::get("PLM_HOME").or_else(|| EnvVar::get("HOME"))` ロジックを `plm_root()` として `src/env.rs` に抽出し、全 5 つの `::new()` / `::load()` から呼ぶ。パス文字列は `PlmPaths` に集約。
+
+---
+
+## 3. 技術的制約・リスク
+
+### 3.1 既存の制約
+
+**型システム・リンター**:
+- Rust 2021 edition。`cargo clippy -- -D warnings` で警告をエラー扱い（CI 設定）
+- `pub(crate)` / `pub` の可視性を適切に設定する必要がある（`TargetsConfig` は `pub(crate)`）
+- `EnvVar` は `pub struct` として公開されているため `plm_root()` も同モジュールに追加可能
+
+**ビルド設定**:
+- ビルドツール: `cargo build` / `cargo build --release`
+- テスト: `cargo test`（CI では `cargo build` → `cargo test` の順序）
+
+### 3.2 互換性の問題
+
+| ライブラリ | バージョン | リスク |
+|---|---|---|
+| `tempfile` | 3 | テスト用 TempDir が全テストで使用中。`PlmPaths::with_root()` でも同様に使用可能 |
+| `serde_json` | 1 | JSON シリアライズ。既存パターンと同一 |
+| `thiserror` | 2 | `PlmError` 定義に使用。`MarketplaceConfig` のエラー型変更時に関係 |
+
+**`MarketplaceConfig` エラー型リスク**: `load()` の戻り値型が `Result<Self, String>` であり、呼び出し元 `commands/manage/marketplace.rs` が `.map_err(|e| e.to_string())` / `?` で処理している。`PlmError` に変更する場合は呼び出し元の変更も必要。
+
+### 3.3 パフォーマンスボトルネック
+
+- 環境変数読み取りのみ（起動時 1 回）。パフォーマンス問題なし（hearing-notes で「対象外」）
+
+### 3.4 セキュリティ考慮点
+
+- `PLM_HOME` に相対パスが渡された場合の挙動: hearing-notes では「拒否してエラー」を推奨
+- `resolve_home_dir()` が `is_absolute()` チェックを行っているパターンが参考になる
+- `PlmPaths` に相対パス拒否チェックを入れる必要あり
+
+---
+
+## 4. 変更影響範囲
+
+### 4.1 波及ファイル
+
+**直接影響**（修正が必須）:
+
+| ファイルパス | 理由 | 影響の種類 |
+|---|---|---|
+| `src/env.rs` | `plm_root()` / `PlmPaths` の追加先 | 追加 |
+| `src/marketplace/config.rs` | `MarketplaceConfig::load()` の HOME 解決をバグ修正 | 修正 |
+| `src/import/registry.rs` | `ImportRegistry::new()` の HOME 解決をバグ修正 | 修正 |
+| `src/target/core/registry.rs` | `TargetRegistry::new()` の HOME 解決をバグ修正 | 修正 |
+| `src/plugin/cache/cache.rs` | `PackageCache::new()` — `plm_root()` 抽出後に呼び出し側を変更 | 修正（ロジック統一） |
+| `src/marketplace/registry.rs` | `MarketplaceRegistry::new()` — 同上 | 修正（ロジック統一） |
+
+**間接影響**（確認が必要）:
+
+| ファイルパス | 理由 | 確認内容 |
+|---|---|---|
+| `src/commands/manage/marketplace.rs` | `MarketplaceConfig::load()` のエラー型が変わる場合 | `String` → `PlmError` 対応 |
+| `src/commands/manage/target.rs` | `TargetRegistry::new()` 呼び出し元 | エラーハンドリング影響なし（`Result<>` 戻り値は同じ）のはずだが要確認 |
+| `src/source.rs`, `src/source/marketplace_source.rs` | `MarketplaceRegistry::new()` / `PackageCache::new()` 呼び出し元 | パス解決の変更が正しく反映されるか |
+| `src/install.rs` | `PackageCache::new()` 呼び出し元 | 同上 |
+| `src/tui/manager/core/data.rs` | 各 registry の `new()` 呼び出し元 | 同上 |
+
+### 4.2 テスト範囲
+
+**既存テストファイル**:
+
+| テストファイルパス | テスト対象 | 修正の必要性 |
+|---|---|---|
+| `src/env_test.rs` | `EnvVar::get()` | 中（`plm_root()` の新テスト追加） |
+| `src/plugin/cache/cache_test.rs` | `PackageCache` | 低（`with_cache_dir()` で分離済み、`new()` テストは追加） |
+| `src/marketplace/registry_test.rs` | `MarketplaceRegistry` | 低（同上） |
+| `src/target/core/registry_test.rs` | `TargetRegistry` | 低（`with_path()` で分離済み） |
+| `src/import/registry_test.rs` | `ImportRegistry` | 低（同上） |
+| `src/commands/lifecycle/disable_test.rs` | `plm disable`（統合テスト） | 中（PLM_HOME を環境変数で設定するテストを追加） |
+| `src/commands/lifecycle/enable_test.rs` | `plm enable`（統合テスト） | 中（同上） |
+
+**新規テストの必要性**:
+- [x] ユニットテスト: `plm_root()` — PLM_HOME 設定あり / なし / 空 / 相対パス / 両方未設定
+- [x] ユニットテスト: `PlmPaths` のパス計算（`targets_json` / `marketplaces_json` / `imports_json` / `plugins_cache_dir` / `marketplaces_cache_dir`）
+- [x] ユニットテスト: `PLM_HOME` 設定下でも Personal 配置（`home_dir()`）が `HOME` を使う回帰テスト
+- [ ] 統合テスト: `PLM_HOME` 設定時に全 PLM 状態が同一ルートに収まることを検証（`plm install` ← `plm list` 等）
+
+### 4.3 破壊的変更の可能性
+
+| API / 関数 | 変更内容 | 影響範囲 |
+|---|---|---|
+| `MarketplaceConfig::load()` | `HOME` → `PLM_HOME` 優先（動作変更） | `marketplace` コマンド使用者（PLM_HOME 設定時のみ） |
+| `TargetRegistry::new()` | 同上 | `target` コマンド使用者（同上） |
+| `ImportRegistry::new()` | 同上 | `import` コマンド使用者（同上） |
+| `MarketplaceConfig` エラー型 | `String` → `PlmError`（任意） | `commands/manage/marketplace.rs` の `.map_err(|e| e.to_string())` |
+
+### 4.4 移行計画の必要性
+
+- 段階的リリース: 不要（`PLM_HOME` 未設定のデフォルト動作は変わらない）
+- ロールバック計画: Git リバートで十分
+
+---
+
+## 5. テストインフラストラクチャ
+
+### 5.1 テスト環境
+
+- **テストフレームワーク**: `cargo test`（標準）
+- **テストランナーコマンド**: `cargo test` / `cargo test <test_name>`
+- **アサーションライブラリ**: 標準 `assert!`, `assert_eq!`（ユニット）; `assert_cmd` + `predicates`（統合テスト）
+- **モックライブラリ**: 手書きモック（`MockHostClient` 等）。`vi.mock` 相当はなし。テスト注入は `with_path()` / `with_cache_dir()` / `load_from()` パターン
+
+### 5.2 テストファイル構成
+
+- **配置パターン**: `foo.rs` のテストは `foo_test.rs` に分離（`#[cfg(test)] #[path = "foo_test.rs"] mod tests;`）
+- **命名規則**: `*_test.rs`（ユニット）、`tests/` ディレクトリ（統合テストは `assert_cmd` 使用）
+- **テストヘルパー**: TempDir ファクトリ関数（`fn create_test_registry() -> (TargetRegistry, TempDir)` 等）
+
+### 5.3 既存テストパターン
+
+| テストファイル | テスト対象 | パターン |
+|---|---|---|
+| `src/env_test.rs` | `EnvVar::get()` | Unit — `std::env::set_var` / `remove_var` で環境変数を制御 |
+| `src/target/core/registry_test.rs` | `TargetRegistry` | Unit — `TempDir` + `with_path()` で分離 |
+| `src/import/registry_test.rs` | `ImportRegistry` | Unit — `TempDir` + `with_path()` で分離 |
+| `src/plugin/cache/cache_test.rs` | `PackageCache` | Unit — `TempDir` + `with_cache_dir()` で分離 |
+| `src/commands/lifecycle/disable_test.rs` | `plm disable` | Integration — `assert_cmd::Command` + `.env("HOME", ...)` / `.env_remove("PLM_HOME")` |
+| `src/commands/lifecycle/enable_test.rs` | `plm enable` | Integration — 同上 |
+
+**統合テストで確立された環境変数パターン**（再利用必須）:
+
+```rust
+// src/commands/lifecycle/disable_test.rs（統合テスト）
+fn test_disable_cache_not_found_shows_error_once() {
+    let home = TempDir::new().unwrap();
+    plm()
+        .env_remove("PLM_HOME")       // PLM_HOME を確実にクリア
+        .env("HOME", home.path())     // HOME を TempDir に向ける
+        .args(["disable", "nonexistent-plugin"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("not found in cache").count(1));
+}
+```
+
+`PLM_HOME` のテストでは逆パターン（`.env_remove("HOME").env("PLM_HOME", temp_dir)` または両方設定して PLM_HOME が優先されることを検証）が新規テストの雛形になる。
+
+**ユニットテストで確立された環境変数パターン**:
+
+```rust
+// src/env_test.rs — 環境変数操作パターン
+#[test]
+fn test_get_existing_var() {
+    std::env::set_var("TEST_ENV_VAR", "test_value");
+    assert_eq!(EnvVar::get("TEST_ENV_VAR"), Some("test_value".to_string()));
+    std::env::remove_var("TEST_ENV_VAR");
+}
+```
+
+> 注意: ユニットテストでの `std::env::set_var` は並列テスト実行で競合するリスクがある。`plm_root()` のユニットテストは `cargo test -- --test-threads=1` か、環境変数操作を避けて `with_root()` 経由のテストを優先すること。
+
+### 5.4 カバレッジ・CI
+
+- **カバレッジツール**: 設定ファイル未確認（`.nycrc` / `lcov.info` なし）
+- **CI テストジョブ**: `.github/workflows/ci.yml` の `test` ジョブが `cargo build && cargo test` を実行。`check` / `fmt` / `clippy` / `audit` の 5 ジョブが並列実行
+
+---
+
+## 6. 追加調査が必要な項目
+
+- [ ] `src/commands/manage/target.rs` の `TargetRegistry::new()` 呼び出し箇所（エラーハンドリングの詳細確認）
+- [ ] `src/tui/manager/core/data.rs` での各 registry 使用パターン（TUI からの呼び出しが `PLM_HOME` 設定下で正しく動くか）
+- [ ] 統合テスト（`tests/` ディレクトリ）の有無 — `assert_cmd` は `src/commands/lifecycle/` 内のインラインテストでのみ確認。`tests/` ディレクトリは未探索
+- [ ] `MarketplaceConfig` エラー型を `PlmError` に変える場合の呼び出し元の全数調査（`commands/manage/marketplace.rs` 以外の呼び出し箇所）
+- [ ] `docs/reference/config.md` / `docs/architecture/cache.md` の存在確認（ドキュメント更新対象）
+
+---
+
+## 7. ユーザー判断が必要な論点
+
+> このセクションは探索中に浮かんだ、ユーザー判断が必要そうな論点のメモ。
+> Step 3.5 で requirements.md の「未解決の確認事項」へ転記して解消する。論点が無ければ「該当なし」と記載する。
+
+hearing-notes / 事前レビュー（Issue #344）で以下は確定済みのため、requirements の未解決確認事項には載せない:
+
+1. **`PLM_HOME` セマンティクス**: 案 A（HOME 代替）。`plm_root = PLM_HOME ?? HOME`、`plm_dir = {plm_root}/.plm`
+2. **対象境界**: `paths.rs` / `cleanup.rs` は対象外（ユーザー HOME）
+3. **`MarketplaceConfig` エラー型**: 本 Issue では `String` のまま維持（必須ではない。呼び出し元変更を避ける）
+4. **相対パス**: `plm_root` は相対パスを拒否してエラー
+
+---
+
+## 8. 探索メトリクス（自己検証用）
+
+| 指標 | 基準 | 初回実績 | 再探索後 |
+|---|---|---|---|
+| Read したファイル数 | 10 以上 | 16 | 21（+5: `env.rs`, `env_test.rs`, `target/env.rs`, `path_ext.rs`, `application.rs`, `cleanup.rs`全文） |
+| Grep 検索キーワード数 | 5 以上 | 8 | 21（+13: `struct.*Paths`, `CachePaths`, `fn plm_root`, `fn get_home`, `fn get_root`, `fn app_dir`, `fn state_dir`, `PlmPaths`, `with_root`, `plm_dir`, `join(".plm")`, `utils/`, `helpers/` 等） |
+| コードスニペット数 | 5 以上 | 7 | 9（+2: `home_dir()` 全文、再探索確認コード） |
+| 逆引き検索実施 | 必須 | 実施済み | 実施済み（全 join(".plm") 箇所横断確認） |
+| [NEW] 類似実装発見数 | — | — | 0（3項目すべて類似なし） |
+
+**再探索追加キーワード**: `struct.*Paths`, `CachePaths`, `AppPaths`, `HomePaths`, `RootPath`, `fn plm_root`, `fn get_home`, `fn resolve.*home`, `fn get_root`, `fn app_dir`, `fn state_dir`, `PlmPaths`, `with_root`, `plm_dir`, `join(".plm")`, `utils/` ディレクトリ, `helpers/` ディレクトリ, `shared/` ディレクトリ
+
+**探索キーワード一覧（全）**: `PLM_HOME`, `plm_root`, `PlmPaths`, `plm_dir`, `EnvVar`, `home_dir`, `resolve_home_dir`, `std::env::var("HOME")`, `PackageCache::new`, `MarketplaceRegistry::new`, `ImportRegistry::new`, `TargetRegistry::new`, `MarketplaceConfig::load`, `\.plm`, `crate::env::EnvVar`, `TODO|FIXME|HACK`, `struct.*Paths`, `CachePaths`, `fn get_home`, `fn get_root`, `join(".plm")`（全体横断）
+
+**Read したファイル一覧**:
+- `src/env.rs`
+- `src/env_test.rs`
+- `src/plugin/cache/cache.rs`
+- `src/marketplace/registry.rs`
+- `src/marketplace/config.rs`
+- `src/import/registry.rs`
+- `src/target/core/registry.rs`
+- `src/target/core/registry_test.rs`
+- `src/target/core/paths.rs`
+- `src/target/core/paths_test.rs`
+- `src/plugin/cache/cleanup.rs`
+- `src/config.rs`
+- `src/application.rs`
+- `src/path_ext.rs`
+- `src/plugin/cache/cache_test.rs`（先頭 60 行）
+- `src/marketplace/registry_test.rs`（先頭 60 行）
+- `src/import/registry_test.rs`
+- `src/commands/lifecycle/disable_test.rs`
+- `src/commands/lifecycle/enable_test.rs`
+- `src/commands/manage/marketplace.rs`（部分）
+- `src/install.rs`（先頭 60 行）
+- `.github/workflows/ci.yml`
+- `Cargo.toml`（先頭 60 行）

--- a/docs/specs/001-plm-home-unification/hearing-notes.md
+++ b/docs/specs/001-plm-home-unification/hearing-notes.md
@@ -1,0 +1,50 @@
+# Hearing Notes: PLM_HOME / HOME 解決の一元化
+
+## 目的
+
+`PLM_HOME` 設定時にプラグインキャッシュとレジストリ／設定 JSON が別ルートに分裂する不整合を解消し、PLM 状態（`~/.plm` 相当）のパス解決を単一ポリシーに集約する。
+
+## スコープ
+
+- **種別**: リファクタリング / バグ修正（挙動不整合の解消）
+- **影響範囲**: 既存修正（`PackageCache` / `MarketplaceRegistry` / `ImportRegistry` / `MarketplaceConfig` / `TargetRegistry` のデフォルトパス構築）。新規モジュールとして `plm_root` / `PlmPaths` を追加
+- **優先度**: 高（#333 config.toml 実装の前提、テスト時のルート差し替えにも必要）
+- **非スコープ**:
+  - `target/core/paths.rs` の `home_dir()`（ユーザー HOME / Personal 配置用）
+  - `plugin/cache/cleanup.rs` の `resolve_home_dir()`（同上）
+  - ターゲット別 `CODEX_HOME` 等の尊重（#333 第3段階）
+  - `config.toml` 本体の実装（#333）
+
+## 技術的詳細
+
+- **技術スタック**: Rust 2021
+- **フレームワーク**: 既存 CLI（clap / tokio）。新規依存なし
+- **依存関係**: 既存 `crate::env::EnvVar` を拡張。`path_ext` には置かない
+- **データ構造**:
+  - `plm_root()` → `PLM_HOME`（有効時）else `HOME`（HOME 代替セマンティクス = レビュー案 A）
+  - `plm_dir()` → `{plm_root}/.plm`
+  - `PlmPaths`（または同等のアクセサ）: `targets_json` / `marketplaces_json` / `imports_json` / `plugins_cache_dir` / `marketplaces_cache_dir` /（将来）`config_toml`
+- **確定セマンティクス（案 A）**:
+  ```text
+  plm_root = $PLM_HOME if set and valid, else $HOME
+  plm_dir  = {plm_root}/.plm
+  ```
+  docs の「デフォルト: `~/.plm`」表現は「未設定時の実効パス」に合わせて修正する（破壊的変更なし）
+
+## 品質要件
+
+- **エッジケース**:
+  - `PLM_HOME` / `HOME` 未設定・空・空白のみ
+  - 相対パスの `PLM_HOME`（拒否してエラーを推奨）
+  - `PLM_HOME` 設定下でも Personal 配置は `$HOME` を見ること（回帰）
+- **エラーハンドリング**: 既存キャッシュと同様、両方未設定なら明確なエラー。`MarketplaceConfig` の `String` エラーは可能なら `PlmError` 寄せ（必須ではない）
+- **テスト要件**: TDD。ユニットでパス解決、統合で「同一 `{root}/.plm` 配下」を検証。Personal 配置が `PLM_HOME` に引きずられない回帰テスト
+- **パフォーマンス**: 対象外（起動時の環境変数読み取りのみ）
+
+## 追加コンテキスト
+
+- Issue: https://github.com/DIO0550/plugin-manager/issues/344
+- 関連: #333（config.toml — `PLM_HOME` 一貫性確認）
+- 事前レビュー: `docs/reviews/issue-344-plm-home.md`（PR #389）の推奨を本ヒアリングの確定値として採用
+- クラウドエージェント環境のため AskUserQuestion 不可。レビュー推奨（案 A・対象境界）をユーザー確認済み前提として進行
+- レビューツール: none（`.config.yml`）

--- a/docs/specs/001-plm-home-unification/implementation-plan.md
+++ b/docs/specs/001-plm-home-unification/implementation-plan.md
@@ -1,0 +1,632 @@
+# PLM_HOME / HOME 解決の一元化
+
+**関連Issue**: #344（関連: #333 config.toml）
+
+`PLM_HOME` 設定時にプラグインキャッシュとレジストリ／設定 JSON が別ルートに分裂する不整合を解消するため、PLM 状態パスの解決を `plm_root()` / `PlmPaths` に集約する。バグ箇所（`MarketplaceConfig` / `TargetRegistry` / `ImportRegistry`）が `std::env::var("HOME")` を直接使って `PLM_HOME` を無視している問題を修正し、全 5 レジストリが同一の解決ポリシーを用いるよう統一する。
+
+## ユーザーレビューが必要な点
+
+> **NOTE**
+> - 破壊的変更は **PLM_HOME を設定しているユーザーのみ** に影響します（未設定時の実効パスは不変）。
+> - `MarketplaceConfig` の戻り値型 `Result<_, String>` は本 Issue で維持（C-4 制約）。内部で `PlmPaths::new()` を呼ぶが `map_err(|e| e.to_string())` で変換します。
+> - `src/target/core/paths.rs` と `src/plugin/cache/cleanup.rs` は **変更しません**（Personal 配置用 HOME は意図的スコープ外）。
+
+---
+
+## システム図
+
+### 状態マシン / フロー図
+
+```
+                    plm_root() 呼び出し
+                           │
+                           ▼
+              ┌────────────────────────┐
+              │ EnvVar::get("PLM_HOME")│
+              │ （空文字フィルタ済み）  │
+              └────────────────────────┘
+                           │
+               ┌───────────┴───────────┐
+               ▼                       ▼
+           Some(val)                 None
+               │                       │
+         trim → 空チェック             │
+               │                       │
+         ┌─────┴─────┐                 │
+         ▼           ▼                 │
+      非空文字     空白のみ            │
+         │           │                 │
+         │           └─────────────────┤
+         │                             ▼
+         │              ┌────────────────────────┐
+         │              │  EnvVar::get("HOME")   │
+         │              │ （空文字フィルタ済み）  │
+         │              └────────────────────────┘
+         │                             │
+         │               ┌─────────────┴─────────────┐
+         │               ▼                             ▼
+         │           Some(val)                       None
+         │               │                             │
+         │         trim → 空チェック                   │
+         │               │                             │
+         │         ┌─────┴─────┐                      │
+         │         ▼           ▼                       │
+         │      非空文字     空白のみ                  │
+         │         │           └────────────────────── ┤
+         │         │                                   ▼
+         │         │                   PlmError（両方無効: 明確なエラー）
+         │         │
+         ├─────────┘
+         ▼
+  PathBuf::from(value)
+         │
+   is_absolute() ?
+         │
+    ┌────┴──────────────┐
+    ▼                   ▼
+  true                false
+    │                   │
+    ▼                   ▼
+plm_root 確定    PlmError（相対パス拒否: "PLM_HOME/HOME must be absolute path"）
+    │
+    ▼
+PlmPaths { root: PathBuf }
+    │
+    ├─ plm_dir()              → {root}/.plm
+    ├─ targets_json()         → {root}/.plm/targets.json
+    ├─ marketplaces_json()    → {root}/.plm/marketplaces.json
+    ├─ imports_json()         → {root}/.plm/imports.json
+    ├─ plugins_cache_dir()    → {root}/.plm/cache/plugins
+    └─ marketplaces_cache_dir()→ {root}/.plm/cache/marketplaces
+```
+
+### データフロー
+
+```
+CLIコマンド実行（plm install / plm target add / plm import ...）
+         │
+         ▼
+各 Registry / Config の new() / load()
+         │
+         ▼
+    PlmPaths::new()                    ← 全 5 レジストリの統一入口
+         │
+         ▼
+    plm_root()  [src/env.rs]
+         │
+    ┌────┴──────────────────────────────┐
+    ▼                                   ▼
+EnvVar::get("PLM_HOME")          EnvVar::get("HOME")
+（trim + 空白チェック）          （フォールバック）
+    │                                   │
+    └─────────────┬─────────────────────┘
+                  ▼
+         is_absolute() チェック
+                  │
+         ┌────────┴────────┐
+         ▼                 ▼
+       OK                Err
+         │                 │
+         ▼                 ▼
+  PlmPaths { root }   エラー返却
+         │
+    ┌────┼────────────────────────────────────────┐
+    │    │                                        │
+    ▼    ▼                                        ▼
+PackageCache           MarketplaceRegistry    MarketplaceConfig
+plugins_cache_dir()    marketplaces_cache_dir() marketplaces_json()
+    │                         │                        │
+    └─────────────────────────┴────────────────────────┘
+                  ▼
+    全 PLM 状態が {PLM_HOME ?? HOME}/.plm/ 配下に収まる
+                  │
+    ┌─────────────┴──────────────────┐
+    ▼                                ▼
+TargetRegistry                  ImportRegistry
+targets_json()                  imports_json()
+```
+
+---
+
+## 変更案
+
+### カテゴリ 1: `plm_root()` / `PlmPaths` の追加（新規 API）
+
+#### [MODIFY] `src/env.rs`
+
+`plm_root()` 関数と `PlmPaths` 構造体を追加する。`EnvVar::get()` と密接に連携するため同ファイルに配置（C-3 制約準拠）。
+
+- `plm_root()`: `PLM_HOME`（有効時）→ `HOME` の順で解決、相対パス拒否
+- `PlmPaths::new()`: 本番コンストラクタ（`plm_root()` を内部で呼ぶ）
+- `PlmPaths::with_root(root: PathBuf)`: テスト用コンストラクタ
+- 各パスアクセサ: `plm_dir` / `targets_json` / `marketplaces_json` / `imports_json` / `plugins_cache_dir` / `marketplaces_cache_dir`
+
+```rust
+// src/env.rs（追加分）
+
+use std::path::PathBuf;
+use crate::error::{PlmError, Result};
+
+/// PLM の状態ルートディレクトリを返す（案 A: HOME 代替セマンティクス）
+///
+/// 解決順: `PLM_HOME`（有効時 = 非空・非空白・絶対パス）→ `HOME`
+/// - 空・空白のみは無効扱い（`EnvVar::get` 互換 + trim）
+/// - 相対パスはエラーとして返す
+/// - 両方無効なら明確なエラー
+pub(crate) fn plm_root() -> Result<PathBuf> {
+    let raw = EnvVar::get("PLM_HOME")
+        .filter(|s| !s.trim().is_empty())
+        .or_else(|| EnvVar::get("HOME").filter(|s| !s.trim().is_empty()))
+        .ok_or_else(|| {
+            // 実在バリアントのみ使用（`PlmError::Config` は存在しない）。
+            // 共有リゾルバのため `General` を返し、呼び出し側でドメイン別バリアントへマップ可能。
+            PlmError::General(
+                "PLM_HOME and HOME environment variables are not set or empty".to_string(),
+            )
+        })?;
+
+    let path = PathBuf::from(raw.trim());
+    if !path.is_absolute() {
+        return Err(PlmError::General(format!(
+            "PLM_HOME/HOME must be an absolute path, got: {}",
+            path.display()
+        )));
+    }
+    Ok(path)
+}
+
+/// PLM 状態ファイル群のパスを集約する値オブジェクト
+///
+/// `new()` で本番環境変数から構築、`with_root()` でテスト用パスを注入する。
+/// バイナリクレートのため可視性は `pub(crate)`（過剰公開を避ける）。
+pub(crate) struct PlmPaths {
+    root: PathBuf,
+}
+
+impl PlmPaths {
+    /// 環境変数（PLM_HOME → HOME）からパスを解決して構築する
+    pub(crate) fn new() -> Result<Self> {
+        Ok(Self { root: plm_root()? })
+    }
+
+    /// カスタムルートを指定して構築する（テスト用）
+    ///
+    /// # Arguments
+    /// * `root` - PLM の状態ルートディレクトリ（`~` 相当）
+    pub(crate) fn with_root(root: PathBuf) -> Self {
+        Self { root }
+    }
+
+    /// PLM の状態ディレクトリ: `{root}/.plm`
+    pub(crate) fn plm_dir(&self) -> PathBuf {
+        self.root.join(".plm")
+    }
+
+    /// ターゲットレジストリのパス: `{plm_dir}/targets.json`
+    pub(crate) fn targets_json(&self) -> PathBuf {
+        self.plm_dir().join("targets.json")
+    }
+
+    /// マーケットプレイス設定のパス: `{plm_dir}/marketplaces.json`
+    pub(crate) fn marketplaces_json(&self) -> PathBuf {
+        self.plm_dir().join("marketplaces.json")
+    }
+
+    /// インポートレジストリのパス: `{plm_dir}/imports.json`
+    pub(crate) fn imports_json(&self) -> PathBuf {
+        self.plm_dir().join("imports.json")
+    }
+
+    /// プラグインキャッシュディレクトリ: `{plm_dir}/cache/plugins`
+    pub(crate) fn plugins_cache_dir(&self) -> PathBuf {
+        self.plm_dir().join("cache").join("plugins")
+    }
+
+    /// マーケットプレイスキャッシュディレクトリ: `{plm_dir}/cache/marketplaces`
+    pub(crate) fn marketplaces_cache_dir(&self) -> PathBuf {
+        self.plm_dir().join("cache").join("marketplaces")
+    }
+}
+```
+
+---
+
+### カテゴリ 2: バグ修正（`std::env::var("HOME")` 直接使用の置き換え）
+
+#### [MODIFY] `src/marketplace/config.rs`
+
+`MarketplaceConfig::load()` の HOME 直接参照を `PlmPaths` 経由に変更する。エラー型は `Result<_, String>` のまま維持（C-4）。
+
+- `std::env::var("HOME")` → `crate::env::PlmPaths::new().map_err(|e| e.to_string())`
+
+```rust
+// before:
+pub fn load() -> Result<Self, String> {
+    let home = std::env::var("HOME").map_err(|_| "HOME environment variable not set")?;
+    let path = PathBuf::from(home).join(".plm").join("marketplaces.json");
+    Self::load_from(path)
+}
+```
+
+```rust
+// after:
+pub fn load() -> Result<Self, String> {
+    let paths = crate::env::PlmPaths::new().map_err(|e| e.to_string())?;
+    Self::load_from(paths.marketplaces_json())
+}
+```
+
+#### [MODIFY] `src/target/core/registry.rs`
+
+`TargetRegistry::new()` の HOME 直接参照を `PlmPaths` 経由に変更する。
+
+- `std::env::var("HOME")` → `crate::env::PlmPaths::new()?`
+
+```rust
+// before:
+pub fn new() -> Result<Self> {
+    let home = std::env::var("HOME").map_err(|_| {
+        PlmError::TargetRegistry("HOME environment variable not set".to_string())
+    })?;
+    let config_path = PathBuf::from(home).join(".plm").join("targets.json");
+    Ok(Self {
+        config_path,
+        state: State::Idle,
+        config: None,
+    })
+}
+```
+
+```rust
+// after:
+pub fn new() -> Result<Self> {
+    // ドメイン文脈を保持するため General → TargetRegistry にマップ
+    let paths = crate::env::PlmPaths::new()
+        .map_err(|e| PlmError::TargetRegistry(e.to_string()))?;
+    Ok(Self {
+        config_path: paths.targets_json(),
+        state: State::Idle,
+        config: None,
+    })
+}
+```
+
+#### [MODIFY] `src/import/registry.rs`
+
+`ImportRegistry::new()` の HOME 直接参照を `PlmPaths` 経由に変更する。
+
+- `std::env::var("HOME")` → `crate::env::PlmPaths::new()` + `ImportRegistry` への map_err
+
+```rust
+// before:
+pub fn new() -> Result<Self> {
+    let home = std::env::var("HOME").map_err(|_| {
+        PlmError::ImportRegistry("HOME environment variable not set".to_string())
+    })?;
+    let config_path = PathBuf::from(home).join(".plm").join("imports.json");
+    Ok(Self {
+        config_path,
+        state: State::Idle,
+        config: None,
+    })
+}
+```
+
+```rust
+// after:
+pub fn new() -> Result<Self> {
+    let paths = crate::env::PlmPaths::new()
+        .map_err(|e| PlmError::ImportRegistry(e.to_string()))?;
+    Ok(Self {
+        config_path: paths.imports_json(),
+        state: State::Idle,
+        config: None,
+    })
+}
+```
+
+---
+
+### カテゴリ 3: 既存正解パターンの統一（ロジック抽出）
+
+#### [MODIFY] `src/plugin/cache/cache.rs`
+
+`PackageCache::new()` の `EnvVar::get("PLM_HOME").or_else(...)` を `PlmPaths::new()` に統一する。
+
+```rust
+// before:
+pub fn new() -> Result<Self> {
+    let fs = RealFs;
+    let home = crate::env::EnvVar::get("PLM_HOME")
+        .or_else(|| crate::env::EnvVar::get("HOME"))
+        .ok_or_else(|| {
+            PlmError::Cache(
+                "PLM_HOME and HOME environment variables not set or empty".to_string(),
+            )
+        })?;
+    let cache_dir = PathBuf::from(home)
+        .join(".plm")
+        .join("cache")
+        .join("plugins");
+    fs.create_dir_all(&cache_dir)?;
+    Ok(Self { cache_dir })
+}
+```
+
+```rust
+// after:
+pub fn new() -> Result<Self> {
+    let fs = RealFs;
+    // 従来どおり Cache バリアントでドメイン文脈を保持（General からの map）
+    let paths = crate::env::PlmPaths::new()
+        .map_err(|e| PlmError::Cache(e.to_string()))?;
+    let cache_dir = paths.plugins_cache_dir();
+    fs.create_dir_all(&cache_dir)?;
+    Ok(Self { cache_dir })
+}
+```
+
+#### [MODIFY] `src/marketplace/registry.rs`
+
+`MarketplaceRegistry::new()` の `EnvVar::get("PLM_HOME").or_else(...)` を `PlmPaths::new()` に統一する。
+
+```rust
+// before:
+pub fn new() -> Result<Self> {
+    let home = crate::env::EnvVar::get("PLM_HOME")
+        .or_else(|| crate::env::EnvVar::get("HOME"))
+        .ok_or_else(|| {
+            PlmError::Cache(
+                "PLM_HOME and HOME environment variables not set or empty".to_string(),
+            )
+        })?;
+    let cache_dir = PathBuf::from(home)
+        .join(".plm")
+        .join("cache")
+        .join("marketplaces");
+
+    fs::create_dir_all(&cache_dir)?;
+
+    Ok(Self { cache_dir })
+}
+```
+
+```rust
+// after:
+pub fn new() -> Result<Self> {
+    let paths = crate::env::PlmPaths::new()
+        .map_err(|e| PlmError::Cache(e.to_string()))?;
+    let cache_dir = paths.marketplaces_cache_dir();
+    fs::create_dir_all(&cache_dir)?;
+    Ok(Self { cache_dir })
+}
+```
+
+---
+
+### カテゴリ 4: テストファイルの追加・拡張
+
+#### [MODIFY] `src/env_test.rs`
+
+`plm_root()` と `PlmPaths` のユニットテストを追加する。既存の `EnvVar::get()` テストは維持。
+
+- **注意**: 環境変数操作（`std::env::set_var`）は並列テストで競合するリスクがある。`PlmPaths::with_root()` によるパス計算テストを優先し、`plm_root()` のユニットテストは `#[serial_test]` または `-- --test-threads=1` で保護する（NFR-4）。
+- 環境変数操作テストは必要最小限（正常系 1 ケース・フォールバック 1 ケース・エラー系）にとどめ、パス計算の大半は `with_root()` 経由で実施。
+
+```rust
+// src/env_test.rs（追加分の骨格）
+
+use super::*;
+use std::path::PathBuf;
+use tempfile::TempDir;
+
+// ── PlmPaths: with_root() によるパス計算テスト（環境変数操作なし・並列安全）──
+
+#[test]
+fn test_plm_paths_plm_dir() { /* {root}/.plm */ }
+
+#[test]
+fn test_plm_paths_targets_json() { /* {root}/.plm/targets.json */ }
+
+#[test]
+fn test_plm_paths_marketplaces_json() { /* {root}/.plm/marketplaces.json */ }
+
+#[test]
+fn test_plm_paths_imports_json() { /* {root}/.plm/imports.json */ }
+
+#[test]
+fn test_plm_paths_plugins_cache_dir() { /* {root}/.plm/cache/plugins */ }
+
+#[test]
+fn test_plm_paths_marketplaces_cache_dir() { /* {root}/.plm/cache/marketplaces */ }
+
+// ── plm_root(): 環境変数制御テスト（test-threads=1 で実行）──
+
+#[test]
+fn test_plm_root_uses_plm_home_when_set() { /* PLM_HOME 有効 → PLM_HOME を返す */ }
+
+#[test]
+fn test_plm_root_falls_back_to_home() { /* PLM_HOME なし → HOME */ }
+
+#[test]
+fn test_plm_root_ignores_empty_plm_home() { /* PLM_HOME="" → HOME フォールバック */ }
+
+#[test]
+fn test_plm_root_ignores_whitespace_only_plm_home() { /* PLM_HOME="  " → HOME フォールバック */ }
+
+#[test]
+fn test_plm_root_plm_home_takes_priority_over_home() { /* 両方設定 → PLM_HOME 優先 */ }
+
+#[test]
+fn test_plm_root_rejects_relative_plm_home() { /* PLM_HOME="relative/path" → Err */ }
+
+#[test]
+fn test_plm_root_rejects_relative_home() { /* HOME="relative/path", PLM_HOME なし → Err */ }
+
+#[test]
+fn test_plm_root_errors_when_both_unset() { /* 両方未設定 → Err */ }
+```
+
+---
+
+## 検証計画
+
+### テスト戦略
+
+**機能タイプ**: Pure Logic（主）/ Configuration（副）
+
+**テスト方針**: TDD（Red-Green-Refactor サイクル）
+
+**根拠**: `plm_root()` はバリデーション・フォールバック・優先順位解決を含む純粋ロジック（Pure Logic）であり、hearing-notes.md にも「TDD」が明記されている。test-design-patterns.md の決定フローで Pure Logic → TDD 推奨に該当。
+
+---
+
+### 自動テスト
+
+#### `src/env_test.rs`
+
+**役割**: `plm_root()` の環境変数解決ロジック（優先順位・フォールバック・バリデーション）および `PlmPaths` のパス計算結果を検証する。
+
+| カテゴリ | テストケース | ユースケース / 想定シナリオ | 期待結果 |
+|----------|------------|--------------------------|---------|
+| 正常系 | PLM_HOME 有効時の plm_root() | PLM_HOME に絶対パスを設定して呼び出す | PLM_HOME の PathBuf を返す |
+| 正常系 | PLM_HOME 未設定時の HOME フォールバック | PLM_HOME を unset、HOME に絶対パスを設定 | HOME の PathBuf を返す |
+| 正常系 | PlmPaths::plm_dir() の計算 | `with_root("/tmp/foo")` でパス確認 | `/tmp/foo/.plm` |
+| 正常系 | PlmPaths::targets_json() の計算 | `with_root("/tmp/foo")` でパス確認 | `/tmp/foo/.plm/targets.json` |
+| 正常系 | PlmPaths::marketplaces_json() の計算 | `with_root("/tmp/foo")` でパス確認 | `/tmp/foo/.plm/marketplaces.json` |
+| 正常系 | PlmPaths::imports_json() の計算 | `with_root("/tmp/foo")` でパス確認 | `/tmp/foo/.plm/imports.json` |
+| 正常系 | PlmPaths::plugins_cache_dir() の計算 | `with_root("/tmp/foo")` でパス確認 | `/tmp/foo/.plm/cache/plugins` |
+| 正常系 | PlmPaths::marketplaces_cache_dir() の計算 | `with_root("/tmp/foo")` でパス確認 | `/tmp/foo/.plm/cache/marketplaces` |
+| 正常系 | PLM_HOME と HOME 両方設定時の優先順位 | 両方に有効な絶対パスを設定 | PLM_HOME が優先される |
+| 境界値 | PLM_HOME が空文字 | `PLM_HOME=""` 設定で呼び出す | HOME フォールバック |
+| 境界値 | PLM_HOME が空白のみ | `PLM_HOME="   "` 設定で呼び出す | HOME フォールバック |
+| 異常系 | PLM_HOME が相対パス | `PLM_HOME="relative/path"` 設定で呼び出す | `Err`（相対パス拒否メッセージ） |
+| 異常系 | HOME が相対パス（PLM_HOME なし） | `HOME="relative"` かつ PLM_HOME なし | `Err`（相対パス拒否） |
+| 異常系 | 両方未設定 | PLM_HOME・HOME ともに unset | `Err`（両方未設定エラー） |
+| 異常系 | 両方が空白のみ | PLM_HOME・HOME ともに空白 | `Err` |
+| エッジケース（回帰） | PLM_HOME 設定下での paths.rs home_dir() | PLM_HOME ≠ HOME の状態でも `home_dir()` は HOME を返す | HOME の値を返す（スコープ外不変の回帰確認） |
+
+**テスト実行コマンド**
+
+```bash
+# パス計算テスト（並列実行可能）
+cargo test plm_paths
+
+# 環境変数制御テスト（並列競合を避けるため threads=1）
+cargo test plm_root -- --test-threads=1
+
+# 全ユニットテスト
+cargo test
+```
+
+#### `src/target/core/registry_test.rs`
+
+**役割**: `TargetRegistry::new()` が `PlmPaths` 経由のパスを使うことを検証する（修正確認）。
+
+| カテゴリ | テストケース | ユースケース / 想定シナリオ | 期待結果 |
+|----------|------------|--------------------------|---------|
+| 正常系 | `new()` がデフォルトパスを構築 | HOME を TempDir に向けて `new()` を呼ぶ | `{HOME}/.plm/targets.json` が config_path になる |
+| 正常系 | `PLM_HOME` 設定下の `new()` | PLM_HOME を TempDir、HOME を別パスに設定 | `{PLM_HOME}/.plm/targets.json` が config_path になる |
+| 異常系 | 両方未設定で `new()` | PLM_HOME・HOME ともに unset | `Err(PlmError::TargetRegistry(...))` |
+
+#### `src/import/registry_test.rs`
+
+**役割**: `ImportRegistry::new()` が `PlmPaths` 経由のパスを使うことを検証する（修正確認）。
+
+| カテゴリ | テストケース | ユースケース / 想定シナリオ | 期待結果 |
+|----------|------------|--------------------------|---------|
+| 正常系 | `new()` がデフォルトパスを構築 | HOME を TempDir に向けて `new()` を呼ぶ | `{HOME}/.plm/imports.json` が config_path になる |
+| 正常系 | `PLM_HOME` 設定下の `new()` | PLM_HOME を TempDir、HOME を別パスに設定 | `{PLM_HOME}/.plm/imports.json` が config_path になる |
+| 異常系 | 両方未設定で `new()` | PLM_HOME・HOME ともに unset | `Err(PlmError::ImportRegistry(...))` |
+
+#### `src/marketplace/config_test.rs`
+
+**役割**: `MarketplaceConfig::load()` が `PlmPaths` 経由のパスを使うこと、および `String` エラー型が維持されることを検証する（FR-3 / C-4）。
+
+| カテゴリ | テストケース | ユースケース / 想定シナリオ | 期待結果 |
+|----------|------------|--------------------------|---------|
+| 正常系 | `PLM_HOME` 設定下の `load()` | PLM_HOME を TempDir、HOME を別パスに設定 | `{PLM_HOME}/.plm/marketplaces.json` を読む（無ければ空） |
+| 正常系 | HOME のみの `load()` | PLM_HOME unset、HOME=TempDir | `{HOME}/.plm/marketplaces.json` |
+| 異常系 | 両方未設定の `load()` | PLM_HOME・HOME ともに unset | `Err(String)`（`map_err` 後） |
+
+#### `src/plugin/cache/cache_test.rs`
+
+**役割**: `PackageCache::new()` が `PlmPaths` 経由でキャッシュパスを構築することを検証する（`PlmPaths` への統一確認）。
+
+| カテゴリ | テストケース | ユースケース / 想定シナリオ | 期待結果 |
+|----------|------------|--------------------------|---------|
+| 正常系 | `PLM_HOME` 設定下の `new()` | PLM_HOME を TempDir に向けて `new()` を呼ぶ | `{PLM_HOME}/.plm/cache/plugins` が cache_dir になる |
+| 異常系 | 両方未設定で `new()` | PLM_HOME・HOME ともに unset | `Err` |
+
+#### `src/marketplace/registry_test.rs`
+
+**役割**: `MarketplaceRegistry::new()` が `PlmPaths` 経由でキャッシュパスを構築することを検証する（`PlmPaths` への統一確認）。
+
+| カテゴリ | テストケース | ユースケース / 想定シナリオ | 期待結果 |
+|----------|------------|--------------------------|---------|
+| 正常系 | `PLM_HOME` 設定下の `new()` | PLM_HOME を TempDir に向けて `new()` を呼ぶ | `{PLM_HOME}/.plm/cache/marketplaces` が cache_dir になる |
+| 異常系 | 両方未設定で `new()` | PLM_HOME・HOME ともに unset | `Err` |
+
+#### `src/env_test.rs`（横断整合性・UC-1）
+
+**役割**: 同一 `PLM_HOME` 下で 5 経路のパスが同一 `{root}/.plm` 配下に揃うことを 1 テストで検証する（hearing-notes の統合検証要件）。
+
+| カテゴリ | テストケース | ユースケース / 想定シナリオ | 期待結果 |
+|----------|------------|--------------------------|---------|
+| 正常系（整合性） | 5 パスが同一 root 配下 | `PlmPaths::with_root(root)` で 5 アクセサを取得 | すべて `{root}/.plm/...` でプレフィックス一致 |
+| べき等性 | `plm_root()` 連続呼び出し | 環境固定で 2 回呼ぶ | 同一 PathBuf |
+
+---
+
+### 手動検証
+
+1. `PLM_HOME=/tmp/plm-test plm target list` を実行し、`/tmp/plm-test/.plm/targets.json` が生成されることを確認（`~/.plm/targets.json` に書かれないこと）
+2. `PLM_HOME=/tmp/plm-test plm marketplace add` を実行し、`/tmp/plm-test/.plm/marketplaces.json` に記録されることを確認
+3. `PLM_HOME` 未設定で `plm target list` を実行し、`$HOME/.plm/targets.json` を使うことを確認（後方互換）
+4. `PLM_HOME` 設定下で `plm install <plugin>` を実行し、Personal 配置先が `$HOME/.codex/` 等になることを確認（`$PLM_HOME/.codex` にならないこと）
+
+---
+
+### ドキュメント更新（FR-7）
+
+#### [MODIFY] `docs/reference/config.md`
+
+- 環境変数表の「デフォルト: `~/.plm`」を「`PLM_HOME` は `$HOME` の代替。未設定時の実効パスは `$HOME/.plm`」に修正
+- 「全パスで一貫して尊重されるとは限りません」を、本修正後は一貫する旨に更新
+
+#### [MODIFY] `docs/architecture/cache.md`
+
+- ルート解決の記述を案 A（HOME 代替）と揃える
+
+---
+
+## 技術的制約・リスク（exploration-report より反映）
+
+| リスク | 詳細 | 対応策 |
+|--------|------|--------|
+| 環境変数並列競合 | `std::env::set_var` を使うユニットテストは並列実行で競合する | `PlmPaths::with_root()` テストを優先; 環境変数操作テストは `--test-threads=1` |
+| `MarketplaceConfig` エラー型 | `Result<_, String>` のまま維持（C-4）。`PlmPaths::new()` の `PlmError` を `.map_err(|e| e.to_string())` で変換 | 呼び出し元 `commands/manage/marketplace.rs` の変更不要 |
+| `clippy` 警告 | `cargo clippy -- -D warnings` が CI で有効 | `PlmPaths` に `Default` trait が必要な場合は `new()` → `Default::default()` を検討 |
+| エラーバリアント | `PlmError::Config` は存在しない。共有リゾルバは `General` を返す | 全呼び出し側で `map_err` しドメインバリアントへ（TargetRegistry / ImportRegistry / Cache） |
+| 可視性 | バイナリクレートのため過剰公開不要 | `plm_root` / `PlmPaths` とも `pub(crate)` |
+
+---
+
+## Definition of Done
+
+以下をすべて満たした時点で本機能の実装完了とする。
+
+- [ ] すべてのタスク（tasks.md）が ■ になっている
+- [ ] `PlmPaths::new()` が `plm_root()` を通じて `PLM_HOME`（有効時）→ `HOME` の順でパスを解決する（UC-1 / FR-1）
+- [ ] `PLM_HOME` 未設定時の実効パスが従来の `$HOME/.plm` と同一（UC-2 / NFR-3・後方互換）
+- [ ] `targets.json` / `marketplaces.json` / `imports.json` / `cache/plugins` / `cache/marketplaces` が すべて `{plm_root}/.plm/...` に解決される（UC-1 / FR-3）
+- [ ] `std::env::var("HOME")` の直接使用が `src/marketplace/config.rs` / `src/target/core/registry.rs` / `src/import/registry.rs` から除去されている（FR-3）
+- [ ] `src/target/core/paths.rs` / `src/plugin/cache/cleanup.rs` が変更されていない（C-2）
+- [ ] 相対パスの `PLM_HOME` / `HOME` に対してエラーを返す（FR-5）
+- [ ] `PlmPaths::with_root()` でテスト用ルートを注入できる（FR-8 相当）
+- [ ] `cargo test` が全テストグリーン
+- [ ] `cargo clippy -- -D warnings` が警告ゼロ
+- [ ] 手動検証 4 項目が完了している
+- [ ] 既存の `with_cache_dir` / `with_path` / `load_from` API が破壊されていない（FR-8）
+- [ ] `docs/reference/config.md` / `docs/architecture/cache.md` の `PLM_HOME` 説明が案 A に更新されている（FR-7）
+- [ ] `plm_root()` は実在する `PlmError` バリアント（`General`）のみを返す

--- a/docs/specs/001-plm-home-unification/requirements.md
+++ b/docs/specs/001-plm-home-unification/requirements.md
@@ -1,0 +1,73 @@
+# Requirements: PLM_HOME / HOME 解決の一元化
+
+> research（exploration-report）と plan（implementation-plan）の間で、
+> 「誰が・何のために・どう使うか」と要件・制約を確定する中間ドキュメント。
+> ユースケースを起点に、技術計画に進む前の前提を固める。
+
+## ユースケース
+
+### UC-1: PLM_HOME で状態ルートを差し替える
+
+- **アクター**: PLM 利用者（開発者・CI）
+- **状況/前提**: `PLM_HOME` を一時ディレクトリや専用ルートに設定して `plm` を実行する
+- **達成したいこと**: キャッシュ・レジストリ・設定 JSON がすべて同一ルート配下に収まり、ホストの `~/.plm` と混ざらない
+- **成功条件**: `targets.json` / `marketplaces.json` / `imports.json` / `cache/plugins` / `cache/marketplaces` がすべて `{PLM_HOME}/.plm/...` に解決される
+
+### UC-2: PLM_HOME 未設定時は従来どおり HOME 配下
+
+- **アクター**: 通常利用者
+- **状況/前提**: `PLM_HOME` 未設定（または空）
+- **達成したいこと**: 既存どおり `$HOME/.plm/...` に状態が置かれる
+- **成功条件**: デフォルトパスが現状ドキュメントの「実効パス `$HOME/.plm`」と一致し、破壊的変更がない
+
+### UC-3: Personal 配置は PLM_HOME に引きずられない
+
+- **アクター**: Personal スコープで install / enable する利用者
+- **状況/前提**: `PLM_HOME` と `HOME` が異なる値
+- **達成したいこと**: Codex / Cursor 等の Personal 配置先は引き続き `$HOME` 配下（例: `~/.codex`）
+- **成功条件**: `home_dir()` / Personal `placement_location` が `$HOME` を参照し、`$PLM_HOME/.codex` 等に書かない
+
+### UC-4: 実装者・テストが単一のパス API を使う
+
+- **アクター**: メンテナ / 将来の #333 実装
+- **状況/前提**: 新しい PLM 状態ファイルやキャッシュパスを追加する
+- **達成したいこと**: `PlmPaths`（または `plm_dir()`）経由だけでパスを組み立て、`HOME` / `PLM_HOME` の直読みを増やさない
+- **成功条件**: デフォルト構築経路に `std::env::var("HOME")` の散在がなく、テストは `with_root` / 既存 `with_path` で差し替え可能
+
+## 要件・制約
+
+### 機能要件
+
+- FR-1: `plm_root()` は `PLM_HOME`（有効時）→ `HOME` の順で親ディレクトリを返す（案 A: HOME 代替）
+- FR-2: `plm_dir()` は `{plm_root}/.plm` を返す
+- FR-3: 次のデフォルト構築がすべて `plm_root` / `PlmPaths` 経由になること
+  - `PackageCache::new` → `{plm_dir}/cache/plugins`
+  - `MarketplaceRegistry::new` → `{plm_dir}/cache/marketplaces`
+  - `MarketplaceConfig::load` → `{plm_dir}/marketplaces.json`
+  - `TargetRegistry::new` → `{plm_dir}/targets.json`
+  - `ImportRegistry::new` → `{plm_dir}/imports.json`
+- FR-4: 未設定・空・空白のみの `PLM_HOME` は無効扱いとし `HOME` へフォールバック（現行 `EnvVar::get` 互換を拡張して trim）
+- FR-5: 相対パスの `PLM_HOME` / `HOME` は拒否してエラー
+- FR-6: 両方無効なら明確なエラー（既存キャッシュと同系統のメッセージ）
+- FR-7: `docs/reference/config.md` / `docs/architecture/cache.md` の `PLM_HOME` 説明を案 A に合わせて更新する
+- FR-8: 既存の `with_cache_dir` / `with_path` / `load_from` は維持する
+
+### 非機能要件
+
+- NFR-1: 新規クレート依存を追加しない
+- NFR-2: TDD（Red → Green → Refactor）で進める
+- NFR-3: `PLM_HOME` 未設定時の実効パスは現状と同一（後方互換）
+- NFR-4: 環境変数操作を伴うユニットテストは並列競合に注意（`with_root` 優先、または必要なら threads=1）
+
+### 制約・設計方針
+
+- C-1: `PLM_HOME` セマンティクスは **案 A（HOME 代替）**。CARGO_HOME 型（案 B）は採用しない
+- C-2: `src/target/core/paths.rs` と `src/plugin/cache/cleanup.rs` は **変更しない**（ユーザー HOME）
+- C-3: `plm_root` / `PlmPaths` の配置は `src/env.rs`（または同 Feature の隣接モジュール）。`path_ext` には置かない
+- C-4: `MarketplaceConfig` の戻り値型 `Result<_, String>` は本 Issue では変更しない
+- C-5: Feature ベースのモジュール構成・`*_test.rs` 分離を踏襲
+- C-6: #333（config.toml）は本 Issue のスコープ外。ただし `PlmPaths` に将来の `config_toml()` を載せられる形にしてよい
+
+## 未解決の確認事項
+
+なし

--- a/docs/specs/001-plm-home-unification/tasks.md
+++ b/docs/specs/001-plm-home-unification/tasks.md
@@ -1,0 +1,124 @@
+# Task: PLM_HOME / HOME 解決の一元化
+
+## Research & Planning
+
+- □ `src/env_test.rs` の既存テストパターンを確認し、並列競合リスクを再評価する
+- □ テストTODOリストの作成（implementation-plan.md の検証計画と照合）
+  - 正常系: PLM_HOME 有効 → PLM_HOME を返す
+  - 正常系: PLM_HOME 未設定 → HOME フォールバック
+  - 正常系: PLM_HOME 空 / 空白のみ → HOME フォールバック
+  - 正常系: 両方設定 → PLM_HOME 優先
+  - 正常系: `PlmPaths` の全パスアクセサが正しいパスを返す（6 ケース）
+  - 境界値: PLM_HOME 空文字 / 空白のみの各ケース
+  - 異常系: PLM_HOME 相対パス → エラー
+  - 異常系: HOME 相対パス（PLM_HOME なし）→ エラー
+  - 異常系: 両方未設定 → エラー
+  - 回帰: PLM_HOME 設定下でも `home_dir()`（paths.rs）は HOME を返す
+- □ 各バグ修正対象レジストリの `new()` / `load()` メソッドの現在のエラーメッセージ文言を確認する
+
+## Implementation (TDD サイクル)
+
+### PlmPaths::with_root() によるパス計算（環境変数操作なし・並列安全）
+
+- □ RED: `PlmPaths::with_root(root)` が存在しないためコンパイルエラーになることを確認
+- □ RED: `plm_dir()` = `{root}/.plm` を期待するテストを `src/env_test.rs` に書く
+- □ RED: `targets_json()` = `{root}/.plm/targets.json` を期待するテストを書く
+- □ RED: `marketplaces_json()` = `{root}/.plm/marketplaces.json` を期待するテストを書く
+- □ RED: `imports_json()` = `{root}/.plm/imports.json` を期待するテストを書く
+- □ RED: `plugins_cache_dir()` = `{root}/.plm/cache/plugins` を期待するテストを書く
+- □ RED: `marketplaces_cache_dir()` = `{root}/.plm/cache/marketplaces` を期待するテストを書く
+- □ GREEN: `PlmPaths` 構造体と `with_root()` / 全アクセサを `src/env.rs` に追加してテストを通す
+- □ REFACTOR: アクセサの実装を整理（`plm_dir()` を基点に統一されているか確認）
+
+### plm_root() 正常系・フォールバック
+
+- □ RED: `PLM_HOME` 有効時に `plm_root()` が PLM_HOME の PathBuf を返すテストを書く
+- □ RED: `PLM_HOME` 未設定時に HOME を返すテストを書く
+- □ GREEN: `plm_root()` 関数を `src/env.rs` に追加（`EnvVar::get("PLM_HOME").filter(trim 非空).or_else(HOME フォールバック)`）してテストを通す
+- □ REFACTOR: `PlmPaths::new()` から `plm_root()` を呼ぶよう接続する
+
+### plm_root() フォールバック境界値
+
+- □ RED: `PLM_HOME=""` の場合に HOME フォールバックになるテストを書く
+- □ RED: `PLM_HOME="   "` （空白のみ）の場合に HOME フォールバックになるテストを書く
+- □ GREEN: `trim().is_empty()` フィルタを実装してテストを通す（既存の `EnvVar::get` の空文字フィルタを拡張）
+- □ REFACTOR: 不要
+
+### plm_root() 優先順位
+
+- □ RED: `PLM_HOME` と `HOME` が両方設定されている場合に `PLM_HOME` が優先されるテストを書く
+- □ GREEN: テストを通す（`or_else()` チェーンの順序を確認）
+- □ REFACTOR: 不要（正しい順序は GREEN で確立済み）
+
+### plm_root() 異常系・相対パス拒否
+
+- □ RED: `PLM_HOME` に相対パスを渡すと `Err` を返すテストを書く
+- □ RED: `HOME` に相対パス（`PLM_HOME` なし）を渡すと `Err` を返すテストを書く
+- □ RED: `PLM_HOME`・`HOME` 両方未設定で `Err` を返すテストを書く
+- □ GREEN: `is_absolute()` チェックを追加してエラーを返すよう実装し、両方未設定のエラーも実装する
+- □ REFACTOR: エラーメッセージの文言を統一する（`PlmError::General` — `Config` バリアントは存在しない）
+
+### バグ修正: MarketplaceConfig（HOME 直接参照を PlmPaths に置き換え）
+
+- □ RED: `PLM_HOME` を設定した状態で `MarketplaceConfig::load()` を呼ぶと `PLM_HOME/.plm/marketplaces.json` パスが使われることを期待するテストを `src/marketplace/config_test.rs` に書く
+- □ RED: 両方未設定で `load()` が `Err(String)` を返すテストを書く
+- □ GREEN: `src/marketplace/config.rs` の `load()` を `PlmPaths::new().map_err(|e| e.to_string())?` に置き換えてテストを通す
+- □ REFACTOR: 不要
+
+### バグ修正: TargetRegistry（HOME 直接参照を PlmPaths に置き換え）
+
+- □ RED: `PLM_HOME` を設定した状態で `TargetRegistry::new()` が `PLM_HOME/.plm/targets.json` を `config_path` にするテストを書く
+- □ RED: 両方未設定で `new()` が `Err(TargetRegistry)` を返すテストを書く
+- □ GREEN: `src/target/core/registry.rs` の `new()` を `PlmPaths::new().map_err(|e| PlmError::TargetRegistry(e.to_string()))?` に置き換えてテストを通す
+- □ REFACTOR: 不要
+
+### バグ修正: ImportRegistry（HOME 直接参照を PlmPaths に置き換え）
+
+- □ RED: `PLM_HOME` を設定した状態で `ImportRegistry::new()` が `PLM_HOME/.plm/imports.json` を `config_path` にするテストを書く
+- □ RED: 両方未設定で `new()` が `Err(ImportRegistry)` を返すテストを書く
+- □ GREEN: `src/import/registry.rs` の `new()` を `PlmPaths::new().map_err(|e| PlmError::ImportRegistry(e.to_string()))?` に置き換えてテストを通す
+- □ REFACTOR: 不要
+
+### 統一: PackageCache（既存正解パターンを PlmPaths に移行）
+
+- □ RED: `PLM_HOME` を設定して `PackageCache::new()` を呼ぶと `PLM_HOME/.plm/cache/plugins` が `cache_dir` になることを確認するテストを書く（既存テストの補完）
+- □ RED: 両方未設定で `new()` が `Err` を返すテストを書く
+- □ GREEN: `src/plugin/cache/cache.rs` の `new()` を `PlmPaths::new()?` に統一してテストを通す
+- □ REFACTOR: 不要
+
+### 統一: MarketplaceRegistry（既存正解パターンを PlmPaths に移行）
+
+- □ RED: `PLM_HOME` を設定して `MarketplaceRegistry::new()` を呼ぶと `PLM_HOME/.plm/cache/marketplaces` が `cache_dir` になることを確認するテストを書く（既存テストの補完）
+- □ RED: 両方未設定で `new()` が `Err` を返すテストを書く
+- □ GREEN: `src/marketplace/registry.rs` の `new()` を `PlmPaths::new()?` に統一してテストを通す
+- □ REFACTOR: 不要
+
+### 横断整合性（UC-1）
+
+- □ RED: `PlmPaths::with_root` で 5 アクセサが同一 `{root}/.plm` プレフィックスを持つテストを書く
+- □ RED: `plm_root()` のべき等性テストを書く
+- □ GREEN: パス計算実装で通す
+- □ REFACTOR: 不要
+
+### 回帰テスト: Personal 配置は PLM_HOME に引きずられない
+
+- □ RED: `PLM_HOME` に TempDir を設定した状態で `home_dir()` (paths.rs) が `HOME` を返すことを確認するテストを書く（`src/target/core/paths_test.rs` を確認・追加）
+- □ GREEN: `paths.rs` は変更不要なのでテストがそのままパスすることを確認する（スコープ外の不変確認）
+- □ REFACTOR: 不要
+
+### ドキュメント（FR-7）
+
+- □ `docs/reference/config.md` の PLM_HOME 説明を案 A（HOME 代替）に更新する
+- □ `docs/architecture/cache.md` のルート解決記述を案 A に揃える
+
+## Verification
+
+- □ `cargo test -- --test-threads=1` を実行して全テストがパスすることを確認する
+- □ `cargo clippy -- -D warnings` を実行して警告ゼロを確認する
+- □ `cargo fmt` を実行してフォーマットを整える
+- □ `src/target/core/paths.rs` / `src/plugin/cache/cleanup.rs` が変更されていないことを確認する（git diff で確認）
+- □ `std::env::var("HOME")` の直接使用が `src/marketplace/config.rs` / `src/target/core/registry.rs` / `src/import/registry.rs` から除去されていることを確認する（`rg 'std::env::var\("HOME"\)'` で検索）
+- □ `plm_root` が `PlmError::Config` を使っていないことを確認する（実在バリアントのみ）
+- □ 手動検証: `PLM_HOME=/tmp/plm-test plm target list` を実行し `/tmp/plm-test/.plm/targets.json` が生成されることを確認する
+- □ 手動検証: `PLM_HOME` 未設定で `plm target list` が `$HOME/.plm/targets.json` を使うことを確認する（後方互換）
+- □ 手動検証: `PLM_HOME` 設定下で Personal 配置先が `$HOME/.codex/` 等のままであることを確認する（`$PLM_HOME/.codex` にならない）

--- a/docs/specs/001-plm-home-unification/tech-reference.md
+++ b/docs/specs/001-plm-home-unification/tech-reference.md
@@ -1,0 +1,588 @@
+# PLM_HOME / HOME 解決の一元化 · 実装の手引き
+
+> このページは implementation-plan を読んで実装に取りかかったときに
+> 「ここがよく分からない」となりがちな箇所を、
+> ライブラリドキュメントの体裁でまとめたものです。
+> 順番に読む必要はなく、詰まったセクションだけ拾い読みできます。
+
+---
+
+## 概要
+
+PLM（Plugin Manager CLI）は、インストールしたプラグインのキャッシュや、ターゲット・マーケットプレイス・インポートなどの設定 JSON を、ディスク上の決まった場所に保存します。その「決まった場所」の親ディレクトリを、これまで複数のモジュールがそれぞれ別々のやり方で決めていました。ある場所は `PLM_HOME` を見て、別の場所は `HOME` だけを見る、という状態です。結果として、利用者が `PLM_HOME` を設定しても、キャッシュは新ルートに、設定 JSON は旧ルートに、と状態が分裂することがありました。
+
+この機能の目的は、その親ディレクトリの決め方を一箇所に集約することです。新しい入口は `plm_root()` と、そこから派生する `PlmPaths` です。解決のルールは単純で、有効な `PLM_HOME` があればそれを使い、なければ `HOME` にフォールバックします（案 A: HOME 代替）。どちらも空・空白のみ・相対パスならエラーです。全 5 つのレジストリ／キャッシュ（`PackageCache`・`MarketplaceRegistry`・`MarketplaceConfig`・`TargetRegistry`・`ImportRegistry`）が、この同じポリシーを通るよう書き換えます。
+
+一方で、Codex や Cursor といった AI 環境本体の Personal 配置（例: `~/.codex`）は、利用者の本当のホームディレクトリを指し続ける必要があります。そのため `src/target/core/paths.rs` や `src/plugin/cache/cleanup.rs` の HOME 参照は意図的に触りません。PLM の「状態」だけを差し替え、環境本体の配置先は従来どおり、という境界がこの変更の肝です。
+
+```
+  利用者 / CI
+       │
+       │  PLM_HOME=/tmp/plm-test  （任意）
+       │  HOME=/home/alice        （通常は OS が設定）
+       ▼
+  plm コマンド（install / target / marketplace / import …）
+       │
+       ▼
+  ┌─────────────────────────────────────┐
+  │  PlmPaths::new()                    │  ← 全 5 経路の統一入口
+  │       │                             │
+  │       ▼                             │
+  │  plm_root()                         │
+  │   PLM_HOME（有効時）→ HOME          │
+  │   絶対パス必須・空/空白は無効       │
+  └─────────────────────────────────────┘
+       │
+       ▼
+  {root}/.plm/
+       ├── targets.json
+       ├── marketplaces.json
+       ├── imports.json
+       └── cache/
+            ├── plugins/
+            └── marketplaces/
+
+  ※ Personal 配置（~/.codex 等）は別経路で HOME を参照（変更しない）
+```
+
+上の図は、「どのコマンドを叩いても、PLM の状態ファイルは同じルート解決を通る」という全体像です。以降の各セクションは、この流れの中で出てくる技術を一つずつ掘り下げます。
+
+---
+
+## `CONCEPT` 環境変数（`PLM_HOME` / `HOME`）
+
+環境変数は、プログラムの外側（シェルや CI の設定）から内側へ渡す「名前付きの文字列」です。パスや設定をコードにハードコードせず、実行時に差し替えられるようにする仕組みだと考えてください。
+
+この機能では特に次の 2 つが重要です。
+
+- **`HOME`** — 利用者のホームディレクトリ。Linux / macOS では通常 `/home/ユーザー名` や `/Users/ユーザー名` です。未設定の `PLM_HOME` があるときのフォールバック先になります。
+- **`PLM_HOME`** — PLM 専用の「状態ルート」を差し替えるための変数。設定すると、その値が `HOME` の代わりに使われ、`{PLM_HOME}/.plm/...` 配下にキャッシュや JSON が集まります。
+
+シェルでの設定例は次のとおりです。
+
+```bash
+# 一時ルートで PLM を動かす（ホストの ~/.plm と混ぜない）
+export PLM_HOME=/tmp/plm-test
+plm target list
+```
+
+```
+シェル / CI
+   │  export PLM_HOME=/tmp/plm-test
+   │  （プロセスの環境に文字列が載る）
+   ▼
+plm プロセス起動
+   │
+   ▼
+EnvVar::get("PLM_HOME")  →  Some("/tmp/plm-test")
+EnvVar::get("HOME")      →  Some("/home/alice")
+```
+
+> **メモ**: `PLM_HOME` 未設定（または空・空白のみ）のときは、実効パスは従来どおり `$HOME/.plm` です。破壊的変更は「`PLM_HOME` を設定している利用者」にだけ影響します。
+
+> **注意**: ここでいう「差し替え」は **PLM の状態ルート** だけです。Codex / Cursor などの Personal 配置先は引き続き `HOME` を見ます。`PLM_HOME=/tmp/x` でも `~/.codex` は `/tmp/x/.codex` にはなりません。
+
+---
+
+## `CONCEPT` 案 A（HOME 代替セマンティクス）
+
+「`PLM_HOME` をどう解釈するか」には設計上の選択肢があります。本 Issue で採用するのは **案 A: HOME 代替** です。
+
+案 A では、`PLM_HOME` は「ホームディレクトリそのものの代わり」です。プログラムはまず `{root}/.plm` を組み立てるので、ルートが `/tmp/plm-test` なら状態は `/tmp/plm-test/.plm` に置かれます。Cargo の `CARGO_HOME` のように「すでに `.cargo` 相当のディレクトリを直接指す」案 B とは違います。
+
+```
+案 A（採用）                         案 B（不採用・CARGO_HOME 型）
+─────────────                       ──────────────────────────
+PLM_HOME=/tmp/plm-test              PLM_HOME=/tmp/plm-test/.plm
+         │                                   │
+         ▼                                   ▼
+  /tmp/plm-test/.plm/...              /tmp/plm-test/.plm/...
+  （ルートの下に .plm を足す）         （変数が既に .plm を含む想定）
+```
+
+実装・ドキュメント・テストはすべて案 A に揃えます。将来の `config.toml`（#333）も、同じ `PlmPaths` に載せられる形を想定しています。
+
+---
+
+## `LANGUAGE` Rust の `PathBuf` とパス結合
+
+`PathBuf` は、ファイルシステムのパスを表す所有型（所有権を持つ文字列バッファに近いもの）です。生の `String` で `"/home/a" + "/.plm"` のように連結すると、区切り文字の過不足や OS 差で壊れやすいのに対し、`PathBuf` は `join` で安全に部品を足せます。
+
+この機能では、環境変数から得た文字列を `PathBuf::from(...)` でパスにし、`plm_dir()` や `targets_json()` などが `join` で `.plm` やファイル名を積み上げます。
+
+```rust
+use std::path::PathBuf;
+
+let root = PathBuf::from("/tmp/plm-test");
+let plm_dir = root.join(".plm");                    // /tmp/plm-test/.plm
+let targets = plm_dir.join("targets.json");         // .../targets.json
+let plugins = plm_dir.join("cache").join("plugins"); // .../cache/plugins
+```
+
+```
+PathBuf::from("/tmp/plm-test")
+        │
+        ▼ join(".plm")
+   /tmp/plm-test/.plm
+        │
+        ├─ join("targets.json")      → .../targets.json
+        ├─ join("marketplaces.json") → .../marketplaces.json
+        └─ join("cache").join("plugins")
+                                     → .../cache/plugins
+```
+
+> **メモ**: `join` の引数が絶対パスだと、左側が捨てられて右側だけになる、という Rust のルールがあります。本機能では相対の部品（`.plm` やファイル名）だけを足すので、その落とし穴には通常当たりません。
+
+### `PathBuf::from` / `join` / `is_absolute` / `display`
+
+```
+PathBuf::from(s: impl AsRef<OsStr>) -> PathBuf
+path.join(path: impl AsRef<Path>) -> PathBuf
+path.is_absolute() -> bool
+path.display() -> Display
+```
+
+| 操作 | 役割 |
+|------|------|
+| `from` | 文字列からパスを作る |
+| `join` | 子パスを足した新しい `PathBuf` を返す（元は変更しない） |
+| `is_absolute` | 先頭が `/`（Unix）などで始まる絶対パスかどうか |
+| `display` | エラーメッセージ用に人間が読める形で表示する |
+
+---
+
+## `CONCEPT` 絶対パスと相対パス
+
+**絶対パス**は、ファイルシステムの頂点（Unix では `/`）から一意に場所を指します。例: `/home/alice`、`/tmp/plm-test`。
+
+**相対パス**は、「今いる場所」からの相対です。例: `relative/path`、`./data`、`../foo`。同じ文字列でも、カレントディレクトリが変わると別の場所を指してしまいます。
+
+本機能では、`PLM_HOME` / `HOME` のどちらも **絶対パスでなければならない** と決めます（FR-5）。状態ルートが実行時のカレントディレクトリに引きずられると、同じコマンドでも保存先がぶれ、デバッグが困難になるためです。
+
+```
+OK（絶対）          NG（相対）
+──────────          ──────────
+/tmp/plm-test       relative/path
+/home/alice         ./plm-home
+                    ../somewhere
+```
+
+```rust
+let path = PathBuf::from(raw.trim());
+if !path.is_absolute() {
+    return Err(PlmError::General(format!(
+        "PLM_HOME/HOME must be an absolute path, got: {}",
+        path.display()
+    )));
+}
+```
+
+> **注意**: 「相対っぽく見えるが絶対」というケースはほぼありません。迷ったら `is_absolute()` の結果を信じ、拒否メッセージをそのまま利用者に返します。
+
+---
+
+## `LIBRARY` `EnvVar`（PLM の環境変数ラッパ）
+
+`std::env::var("HOME")` を生で呼ぶと、未設定は `Err`、設定済みは `Ok(String)` です。一方 PLM には、空文字を「未設定と同じ」とみなす既存のラッパ `EnvVar::get` があります。`plm_root()` はこのラッパを使い、さらに **前後の空白を trim したうえで空なら無効** というルールを足します（FR-4）。
+
+こうすると、「変数が無い」「空文字」「空白だけ」がすべて同じフォールバック経路に流れ、呼び出し側がバラバラの判定を書かずに済みます。
+
+```
+EnvVar::get("PLM_HOME")
+        │
+        ▼
+   Option<String>
+        │
+        ▼ filter(|s| !s.trim().is_empty())
+   有効な非空文字だけ残る
+        │
+        ▼ or_else(|| EnvVar::get("HOME").filter(...))
+   PLM_HOME 無効なら HOME を試す
+```
+
+```rust
+let raw = EnvVar::get("PLM_HOME")
+    .filter(|s| !s.trim().is_empty())
+    .or_else(|| EnvVar::get("HOME").filter(|s| !s.trim().is_empty()))
+    .ok_or_else(|| {
+        PlmError::General(
+            "PLM_HOME and HOME environment variables are not set or empty".to_string(),
+        )
+    })?;
+```
+
+> **メモ**: バグの本体は、一部モジュールが `EnvVar` を使わず `std::env::var("HOME")` だけを見ていたことです。`PLM_HOME` を設定しても無視される経路が残っていました。今回はすべて `PlmPaths` 経由に寄せます。
+
+> **注意**: `EnvVar::get` 自体の空文字扱いに加え、`plm_root` 側で `trim` 後の空白のみも無効にします。`"  "` のような値は HOME へ落ちます。
+
+---
+
+## `LANGUAGE` `Option`・`filter`・`or_else`・`trim`
+
+`plm_root()` の核は、Rust 標準の小さな部品の組み合わせです。初めて読む人向けに、役割だけ押さえます。
+
+**`Option<T>`** は「値がある（`Some`）」か「無い（`None`）」を表します。環境変数が取れたかどうか、その直後のフィルタ結果などに使います。
+
+**`filter`** は、`Some` の中身が条件を満たさなければ `None` に落とします。ここでは「trim 後に空でない」ことが条件です。
+
+**`or_else`** は、左側が `None` のときだけクロージャを評価して別の `Option` を足します。`PLM_HOME` が無効なら `HOME` を試す、というフォールバックそのものです。
+
+**`trim`** は文字列の前後空白を除いたビューを返します。`"  /tmp/x  "` のように誤って空白が入っても、パス化の前に整えられます（空になる場合は無効扱い）。
+
+```
+Some("  ")  ──filter(!trim.is_empty)──►  None
+Some("/tmp/x") ──filter──►  Some("/tmp/x")
+None ──or_else(HOME)──►  HOME 側の Option
+```
+
+```rust
+.some_value
+    .filter(|s| !s.trim().is_empty())  // 無効なら None
+    .or_else(|| alternative);            // None のときだけ代替
+```
+
+> **メモ**: `ok_or_else` は「`Option` を `Result` に変える」変換です。両方とも無効なら、ここで初めてエラーになります。
+
+---
+
+## `LANGUAGE` `Result`・`?`・`PlmError`・`map_err`
+
+Rust では、失敗しうる処理の戻り値に `Result<T, E>` を使います。成功は `Ok(値)`、失敗は `Err(エラー)` です。PLM では共通のエラー型として `PlmError` があり、クレート内の `Result<T>` は多くの場合 `Result<T, PlmError>` を指します。
+
+`plm_root()` は共有リゾルバなので、ドメイン固有のバリアント（`TargetRegistry` や `Cache`）ではなく、実在する **`PlmError::General`** を返します。`PlmError::Config` は存在しないため使いません。呼び出し側が自分の文脈に合わせて `map_err` で載せ替えます。
+
+`?` 演算子は、「`Err` なら即座に関数から返す。`Ok` なら中身を取り出す」糖衣です。ネストした `match` を減らせます。
+
+```
+PlmPaths::new()
+    │  内部で plm_root() → Err(PlmError::General(...))
+    ▼
+呼び出し側
+    │  .map_err(|e| PlmError::TargetRegistry(e.to_string()))
+    ▼
+Err(PlmError::TargetRegistry(...))   ← ドメイン文脈を保持
+```
+
+```rust
+// TargetRegistry: General → TargetRegistry
+let paths = crate::env::PlmPaths::new()
+    .map_err(|e| PlmError::TargetRegistry(e.to_string()))?;
+
+// PackageCache: General → Cache
+let paths = crate::env::PlmPaths::new()
+    .map_err(|e| PlmError::Cache(e.to_string()))?;
+
+// MarketplaceConfig: PlmError → String（C-4 で型を維持）
+let paths = crate::env::PlmPaths::new().map_err(|e| e.to_string())?;
+```
+
+| 呼び出し側 | `map_err` 後の型 | 理由 |
+|------------|------------------|------|
+| `TargetRegistry::new` | `PlmError::TargetRegistry` | ターゲット領域のエラーとして報告 |
+| `ImportRegistry::new` | `PlmError::ImportRegistry` | インポート領域のエラーとして報告 |
+| `PackageCache` / `MarketplaceRegistry` | `PlmError::Cache` | キャッシュ領域の既存バリアントに合わせる |
+| `MarketplaceConfig::load` | `String` | 公開 API の `Result<_, String>` を壊さない（C-4） |
+
+> **注意**: 共有層で最初から `TargetRegistry` を返すと、キャッシュ側が不自然なバリアントを抱えることになります。`General` → 呼び出し側マップ、が意図された分担です。
+
+---
+
+## `CONCEPT` `plm_root()` — 状態ルートの単一リゾルバ
+
+`plm_root()` は、「PLM 状態の親ディレクトリはどこか？」という問いに答える関数です。優先順位とバリデーションを一箇所に閉じ込めることで、5 つの利用箇所が同じ答えを共有します。
+
+解決の流れは次のとおりです。
+
+1. `PLM_HOME` を読む（空・空白のみは無効）
+2. 無効なら `HOME` を読む（同様）
+3. どちらも無効なら `Err`
+4. 得られた文字列を trim して `PathBuf` にし、絶対パスでなければ `Err`
+5. 絶対パスなら `Ok(path)`
+
+```
+         plm_root()
+              │
+              ▼
+     PLM_HOME 有効？ ──Yes──► 候補
+              │No
+              ▼
+       HOME 有効？ ──Yes──► 候補
+              │No
+              ▼
+            Err
+              │
+     候補が絶対パス？ ──No──► Err
+              │Yes
+              ▼
+             Ok
+```
+
+### `plm_root`
+
+```
+plm_root() -> Result<PathBuf>
+```
+
+環境変数から PLM 状態ルートを解決して返します。引数はありません。副作用は環境の読み取りだけです。
+
+| パラメータ | 型 | 説明 |
+|-----------|-----|------|
+| （なし） | — | プロセス環境の `PLM_HOME` / `HOME` を参照 |
+
+戻り値は、成功時に絶対パスの `PathBuf`、失敗時に `PlmError::General` を含む `Err` です。
+
+可視性は `pub(crate)` です。バイナリクレート内部でのみ使い、外部クレートへは公開しません。
+
+> **メモ**: パスの「計算」（`.plm` を足すなど）は `PlmPaths` の仕事です。`plm_root` はルート文字列の正規化と検証に専念します。
+
+---
+
+## `CONCEPT` `PlmPaths` — 状態パスの値オブジェクト
+
+`PlmPaths` は、「ルートが決まれば、あとの JSON やキャッシュの場所は機械的に決まる」という事実を型にしたものです。中身は実質 `root: PathBuf` 一つで、メソッドが決まった相対位置を返します。このような、識別子ではなく値そのもので意味を持つ小さな型を、ここでは **値オブジェクト** と呼びます。
+
+本番では `PlmPaths::new()` が `plm_root()` を呼びます。テストでは環境変数をいじらず、`with_root(temp_dir)` でルートを注入できます。これにより、パス結合の正しさは並列安全に検証し、環境変数の優先順位テストだけを必要最小限にできます（NFR-4）。
+
+```
+PlmPaths { root }
+    │
+    ├─ plm_dir()               → {root}/.plm
+    ├─ targets_json()          → {root}/.plm/targets.json
+    ├─ marketplaces_json()     → {root}/.plm/marketplaces.json
+    ├─ imports_json()          → {root}/.plm/imports.json
+    ├─ plugins_cache_dir()     → {root}/.plm/cache/plugins
+    └─ marketplaces_cache_dir()→ {root}/.plm/cache/marketplaces
+```
+
+```rust
+impl PlmPaths {
+    pub(crate) fn new() -> Result<Self> {
+        Ok(Self { root: plm_root()? })
+    }
+
+    pub(crate) fn with_root(root: PathBuf) -> Self {
+        Self { root }
+    }
+
+    pub(crate) fn plm_dir(&self) -> PathBuf {
+        self.root.join(".plm")
+    }
+
+    pub(crate) fn targets_json(&self) -> PathBuf {
+        self.plm_dir().join("targets.json")
+    }
+    // marketplaces_json / imports_json / plugins_cache_dir /
+    // marketplaces_cache_dir も同様に join で組み立てる
+}
+```
+
+### `PlmPaths::new`
+
+```
+PlmPaths::new() -> Result<PlmPaths>
+```
+
+環境変数からルートを解決して構築します。失敗時は `plm_root` と同じ `PlmError::General` 系です。
+
+### `PlmPaths::with_root`
+
+```
+PlmPaths::with_root(root: PathBuf) -> PlmPaths
+```
+
+| パラメータ | 型 | 説明 |
+|-----------|-----|------|
+| `root` | `PathBuf` | テストや特殊用途で注入する状態ルート（`~` 相当） |
+
+環境を読まないため、ユニットテストの主戦力になります。絶対パス検証は `plm_root` 側の責務なので、`with_root` に相対パスを渡すと結合結果も相対になり得ます。テストでは `TempDir` など絶対パスを渡してください。
+
+> **メモ**: 将来 #333 で `config.toml` パスが必要になっても、同じ構造体に `config_toml()` を足せば、直読みの散在を増やさずに済みます（C-6）。
+
+---
+
+## `CONCEPT` 5 つのレジストリ／キャッシュと統一入口
+
+「レジストリ」という言葉は、ここでは「ディスク上の状態を読み書きするコンポーネント」程度の意味で十分です。本変更の対象は次の 5 つです。
+
+| コンポーネント | 役割のイメージ | 使うアクセサ |
+|----------------|----------------|--------------|
+| `PackageCache` | プラグイン本体のキャッシュ | `plugins_cache_dir()` |
+| `MarketplaceRegistry` | マーケットプレイス用キャッシュ | `marketplaces_cache_dir()` |
+| `MarketplaceConfig` | マーケットプレイス一覧 JSON | `marketplaces_json()` |
+| `TargetRegistry` | ターゲット環境の登録 JSON | `targets_json()` |
+| `ImportRegistry` | インポート履歴 JSON | `imports_json()` |
+
+修正前は、上 2 つが `EnvVar` で `PLM_HOME`→`HOME` を見ていた一方、下 3 つが `std::env::var("HOME")` だけを見ていました。修正後は、いずれも `PlmPaths::new()` から入ります。
+
+```rust
+// MarketplaceConfig（エラー型は String のまま）
+pub fn load() -> Result<Self, String> {
+    let paths = crate::env::PlmPaths::new().map_err(|e| e.to_string())?;
+    Self::load_from(paths.marketplaces_json())
+}
+
+// TargetRegistry
+pub fn new() -> Result<Self> {
+    let paths = crate::env::PlmPaths::new()
+        .map_err(|e| PlmError::TargetRegistry(e.to_string()))?;
+    Ok(Self {
+        config_path: paths.targets_json(),
+        state: State::Idle,
+        config: None,
+    })
+}
+```
+
+> **注意**: `with_cache_dir` / `with_path` / `load_from` といった、すでにパスを外から注入できる API は壊しません（FR-8）。デフォルト構築経路だけを `PlmPaths` に寄せます。
+
+---
+
+## `CONCEPT` Personal 配置とスコープ外コード
+
+PLM は「プラグインをどこに置くか」と「PLM 自身のメタデータをどこに置くか」を分けて考えます。
+
+- **PLM 状態** — `{PLM_HOME ?? HOME}/.plm/...`（本 Issue の対象）
+- **Personal 配置** — 各 AI ツールの利用者ディレクトリ（例: `~/.codex`）。こちらは **常に本物の `HOME`** を見ます
+
+そのため `src/target/core/paths.rs` の `home_dir()` や、`src/plugin/cache/cleanup.rs` は変更しません（C-2）。回帰テストでは、`PLM_HOME ≠ HOME` でも `home_dir()` が `HOME` を返すことを確認します。
+
+```
+PLM_HOME=/tmp/plm-test
+HOME=/home/alice
+
+PLM 状態     → /tmp/plm-test/.plm/...     （差し替えられる）
+Personal     → /home/alice/.codex/...     （差し替えられない）
+```
+
+> **メモ**: 「全部を `PLM_HOME` 配下に寄せる」のではなく、「PLM が管理する状態だけを寄せる」のが仕様です。混同すると UC-3 を壊します。
+
+---
+
+## `LANGUAGE` 可視性 `pub(crate)` と Feature ベース配置
+
+Rust の `pub` はクレート外にも見える公開、`pub(crate)` は同じクレート内だけ、非公開はモジュール内だけ、という段階があります。PLM はバイナリクレートなので、内部ヘルパを `pub` にしすぎる必要はありません。`plm_root` と `PlmPaths` はどちらも `pub(crate)` です。
+
+配置場所は `src/env.rs` です（C-3）。環境変数と密接な Feature に置き、汎用パス拡張の `path_ext` には置きません。レイヤー（domain / infrastructure）ではなく、**Feature（関心ごと）単位でモジュールをまとめる** のがこのリポジトリの方針です。
+
+テストは本体と同ファイルに書かず、`src/env_test.rs` のように `*_test.rs` へ分離します（C-5）。
+
+---
+
+## `TOOL` TDD（Red → Green → Refactor）
+
+TDD は、実装の前に「望む振る舞いをテストで先に書く」進め方です。本機能は優先順位・フォールバック・バリデーションを含む純粋ロジックなので、TDD が特に向いています（NFR-2）。
+
+```
+  Red                         Green                        Refactor
+  ───                         ─────                        ────────
+  失敗するテストを書く         最小限の実装で通す            重複を削り命名を整える
+  （まだ plm_root が無い等）   （仮実装でもよい）            （テストは緑のまま）
+         │                         │                            │
+         └─────────────────────────┴────────────────────────────┘
+                         小さなステップで繰り返す
+```
+
+おすすめの順序は次のとおりです。
+
+1. `PlmPaths::with_root` のパス計算テストを先に書く（環境変数不要）
+2. `plm_root` の優先順位・エラー系テストを書く（必要なら `--test-threads=1`）
+3. 実装を足して緑にする
+4. 各レジストリの `new` / `load` を `PlmPaths` に差し替え、回帰テストで確認する
+
+> **メモ**: Red を確認せずに実装へ進むと、「テストがそもそも間違っている」ことに気づけません。一度失敗を目で見てから Green に進みます。
+
+---
+
+## `TOOL` ユニットテストと環境変数の並列競合
+
+`cargo test` はデフォルトで複数スレッドでテストを並列実行します。`std::env::set_var` / `remove_var` は **プロセス全体の環境** を書き換えるため、テスト A が `PLM_HOME` を付けている最中にテスト B が読むと、意図しない結果になります。
+
+対策は二段構えです。
+
+1. **パス計算は `with_root` で十分** — 環境を触らないので並列安全
+2. **`plm_root` の環境操作テストは最小限** — `cargo test plm_root -- --test-threads=1` で直列化（または `serial_test`）
+
+```bash
+# 並列でよい
+cargo test plm_paths
+
+# 環境を触るものだけ直列
+cargo test plm_root -- --test-threads=1
+```
+
+テスト用の一時ディレクトリには、既存依存の `tempfile::TempDir` を使います。新規クレート依存は追加しません（NFR-1）。
+
+> **注意**: 環境変数テストを増やしすぎると、CI でのフレーク（たまに落ちる）の温床になります。「優先順位・フォールバック・エラー」の代表ケースに絞ってください。
+
+---
+
+## `TOOL` `cargo test` / `clippy` と検証の位置づけ
+
+実装後の機械検証の中心は次です。
+
+```bash
+cargo test
+cargo clippy -- -D warnings
+```
+
+`-D warnings` は警告をエラー扱いにします。CI で有効なので、ローカルでも同じ厳しさで見ます。`PlmPaths` に `Default` が必要になった場合は、`new()` との関係を整理してから足します。
+
+手動検証では、実際に `PLM_HOME` を付けてコマンドを叩き、JSON が `/tmp/.../.plm/` に出ること、未設定時は `$HOME/.plm` に戻ること、Personal 配置が `$HOME` 側のままであることを確認します。
+
+---
+
+## `CONCEPT` 後方互換と破壊的変更の境界
+
+「後方互換」とは、今まで動いていた使い方が、アップデート後も同じ結果になることです。本機能では次が約束です。
+
+- `PLM_HOME` **未設定** → 実効パスは従来どおり `$HOME/.plm`（NFR-3）
+- `PLM_HOME` **設定済み** → 以前は一部だけ無視されていたものが、すべて新ルートに揃う（ここが修正＝意図した変化）
+
+つまり破壊的変更の影響範囲は、「すでに `PLM_HOME` を付けて使っていた人」に限定されます。その人たちにとって、以前は設定 JSON がホーム側に残っていた可能性があり、修正後はキャッシュと同じルートに集まります。
+
+```
+未設定ユーザー          PLM_HOME 設定ユーザー
+──────────────          ────────────────────
+パス不変（互換）         分裂が解消（意図した修正）
+$HOME/.plm/...          $PLM_HOME/.plm/... に統一
+```
+
+---
+
+## 用語集
+
+| 用語 | 意味 |
+|------|------|
+| `PLM` | 複数の AI 開発環境向けプラグインを管理する CLI ツール |
+| `PLM_HOME` | PLM 状態ルートを差し替える環境変数（案 A では HOME の代替） |
+| `HOME` | 利用者のホームディレクトリを示す環境変数。フォールバック先 |
+| 環境変数 | プロセスに渡される名前付きの設定文字列 |
+| `EnvVar` | 空文字を無効扱いする PLM の環境変数取得ラッパ |
+| `plm_root()` | `PLM_HOME`→`HOME` で状態ルートを解決する関数 |
+| `PlmPaths` | `{root}/.plm/...` 配下のパスを返す値オブジェクト |
+| 値オブジェクト | 識別子ではなく値の内容で意味を持つ小さな型 |
+| `PathBuf` | Rust 標準の所有パス型。`join` で部品を安全に結合する |
+| 絶対パス | `/` から始まるなど、位置が一意に決まるパス |
+| 相対パス | カレントディレクトリに依存するパス。本機能では拒否 |
+| `Result` / `Ok` / `Err` | 成功または失敗を表す戻り値の型 |
+| `PlmError` | PLM 共通のエラー列挙。共有リゾルバは `General` を使う |
+| `map_err` | `Err` の中身だけ別の型・文脈に変換する操作 |
+| `?` | `Err` なら早期 return、`Ok` なら中身を取り出す演算子 |
+| `Option` / `Some` / `None` | 値の有無を表す型 |
+| `filter` / `or_else` | `Option` を絞り込む・代替を足すメソッド |
+| `trim` | 文字列の前後空白を除く |
+| `pub(crate)` | 同じクレート内だけに見える可視性 |
+| レジストリ | ここでは状態 JSON / キャッシュを管理するコンポーネント |
+| `PackageCache` | プラグインキャッシュ（`cache/plugins`） |
+| `MarketplaceRegistry` | マーケットプレイスキャッシュ（`cache/marketplaces`） |
+| `MarketplaceConfig` | `marketplaces.json` の読み書き。エラー型は `String` |
+| `TargetRegistry` | `targets.json` の管理 |
+| `ImportRegistry` | `imports.json` の管理 |
+| Personal 配置 | Codex / Cursor 等の利用者ディレクトリ配置（HOME 固定） |
+| 案 A（HOME 代替） | `PLM_HOME` をホーム相当とし、その下に `.plm` を足す解釈 |
+| TDD | 失敗するテスト→最小実装→リファクタのサイクル |
+| フォールバック | 第一候補が無効なとき第二候補へ切り替えること |
+| 後方互換 | 既存のデフォルト利用が同じ結果のままであること |
+| `TempDir` | テスト用の一時ディレクトリ（絶対パス） |
+| Feature ベース | 関心ごと単位でモジュールをまとめる構成方針 |
+| `*_test.rs` | 本体と分離したテストファイルの命名慣例 |

--- a/docs/specs/001-plm-home-unification/test-cases.html
+++ b/docs/specs/001-plm-home-unification/test-cases.html
@@ -1,0 +1,1569 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>テストケース仕様 — PLM_HOME / HOME 解決の一元化</title>
+<style>
+:root {
+  --bg: oklch(0.985 0.003 255);
+  --surface: #ffffff;
+  --surface-2: oklch(0.978 0.004 255);
+  --surface-3: oklch(0.965 0.005 255);
+  --border: oklch(0.925 0.005 255);
+  --border-strong: oklch(0.875 0.007 255);
+  --text: oklch(0.28 0.012 262);
+  --text-2: oklch(0.52 0.012 262);
+  --text-3: oklch(0.65 0.011 262);
+  --accent: oklch(0.55 0.16 264);
+  --accent-2: oklch(0.5 0.16 264);
+  --accent-soft: oklch(0.955 0.025 264);
+  --accent-border: oklch(0.86 0.06 264);
+
+  --green: oklch(0.5 0.11 156);
+  --green-soft: oklch(0.955 0.04 156);
+  --green-border: oklch(0.85 0.07 156);
+  --rose: oklch(0.54 0.16 22);
+  --rose-soft: oklch(0.957 0.03 22);
+  --rose-border: oklch(0.87 0.06 22);
+  --amber: oklch(0.52 0.1 72);
+  --amber-soft: oklch(0.955 0.05 82);
+  --amber-border: oklch(0.85 0.08 82);
+
+  --r-sm: 6px;
+  --r-md: 9px;
+  --r-lg: 13px;
+  --shadow-sm: 0 1px 2px oklch(0.4 0.02 262 / 0.05);
+  --shadow-md: 0 4px 14px oklch(0.4 0.02 262 / 0.08), 0 1px 3px oklch(0.4 0.02 262 / 0.05);
+
+  --pad: 20px;
+  --gap: 16px;
+  --mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+html, body { height: 100%; }
+body {
+  font-family: "Noto Sans JP", system-ui, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  font-size: 14px;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+  letter-spacing: 0.01em;
+}
+
+#app {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  overflow: hidden;
+}
+
+/* ============ Header ============ */
+header.topbar {
+  display: flex;
+  align-items: center;
+  gap: 22px;
+  padding: 0 22px;
+  height: 60px;
+  flex: 0 0 auto;
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  z-index: 5;
+}
+.brand { display: flex; align-items: center; gap: 11px; flex: 0 0 auto; }
+.brand-mark {
+  width: 30px; height: 30px; border-radius: 8px;
+  background: linear-gradient(150deg, var(--accent), var(--accent-2));
+  display: grid; place-items: center; flex: 0 0 auto;
+  box-shadow: var(--shadow-sm);
+}
+.brand-mark::before {
+  content: ""; width: 12px; height: 12px;
+  border: 2px solid #fff; border-radius: 3px;
+  transform: rotate(45deg);
+}
+.brand-title { display: flex; flex-direction: column; line-height: 1.2; }
+.brand-title b { font-size: 16px; font-weight: 700; letter-spacing: 0.02em; white-space: nowrap; }
+.brand-title span {
+  font-size: 11.5px; color: var(--text-3); font-family: var(--mono);
+  display: flex; align-items: center; gap: 6px; white-space: nowrap;
+}
+.branch-chip {
+  font-family: var(--mono); font-size: 11px; color: var(--accent-2);
+  background: var(--accent-soft); border: 1px solid var(--accent-border);
+  padding: 1px 7px; border-radius: 20px; white-space: nowrap;
+}
+
+.stats { display: flex; align-items: stretch; gap: 0; margin-left: auto; }
+.stat {
+  display: flex; flex-direction: column; align-items: flex-start;
+  padding: 0 18px; border-left: 1px solid var(--border);
+}
+.stat:first-child { border-left: none; }
+.stat .num { font-size: 17px; font-weight: 700; font-family: var(--mono); letter-spacing: -0.01em; }
+.stat .lbl { font-size: 10.5px; color: var(--text-3); text-transform: uppercase; letter-spacing: 0.06em; white-space: nowrap; }
+.stat .num.warn { color: var(--amber); }
+.stat .num.accent { color: var(--accent); }
+
+.cov-meter { display: flex; flex-direction: column; gap: 5px; padding: 0 18px; border-left: 1px solid var(--border); justify-content: center; }
+.cov-meter .lbl { font-size: 10.5px; color: var(--text-3); text-transform: uppercase; letter-spacing: 0.06em; }
+.cov-meter .track { width: 96px; height: 6px; border-radius: 4px; background: var(--surface-3); overflow: hidden; }
+.cov-meter .fill { height: 100%; background: linear-gradient(90deg, var(--green), oklch(0.6 0.12 156)); border-radius: 4px; }
+.cov-meter .pct { font-size: 11px; font-family: var(--mono); font-weight: 700; color: var(--green); }
+
+.btn {
+  font-family: inherit; font-size: 13px; font-weight: 500;
+  border: 1px solid var(--border-strong); background: var(--surface);
+  color: var(--text); padding: 7px 13px; border-radius: var(--r-sm);
+  cursor: pointer; display: inline-flex; align-items: center; gap: 7px;
+  transition: background .12s, border-color .12s, box-shadow .12s;
+  white-space: nowrap;
+}
+.btn:hover { background: var(--surface-2); border-color: var(--text-3); }
+.btn.primary { background: var(--accent); border-color: var(--accent); color: #fff; box-shadow: var(--shadow-sm); }
+.btn.primary:hover { background: var(--accent-2); border-color: var(--accent-2); }
+.btn .kbd { font-family: var(--mono); font-size: 10.5px; opacity: 0.65; }
+
+/* ============ Body ============ */
+.body { flex: 1 1 auto; display: flex; min-height: 0; }
+
+/* ---- Master ---- */
+aside.master {
+  flex: 0 0 332px; width: 332px;
+  border-right: 1px solid var(--border);
+  background: var(--surface);
+  display: flex; flex-direction: column; min-height: 0;
+}
+.master-head {
+  padding: 14px 18px 10px;
+  display: flex; align-items: center; justify-content: space-between;
+  flex: 0 0 auto;
+}
+.master-head h2 { font-size: 12px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--text-3); font-weight: 700; }
+.master-head .count { font-size: 11px; color: var(--text-3); font-family: var(--mono); background: var(--surface-3); padding: 1px 8px; border-radius: 20px; }
+.file-list { overflow-y: auto; padding: 0 10px 14px; display: flex; flex-direction: column; gap: 3px; }
+
+.file-item {
+  position: relative; text-align: left; width: 100%;
+  background: transparent; border: 1px solid transparent; border-radius: var(--r-md);
+  padding: 11px 12px 11px 14px; cursor: pointer; font-family: inherit;
+  transition: background .1s, border-color .1s;
+  display: flex; flex-direction: column; gap: 7px;
+}
+.file-item:hover { background: var(--surface-2); }
+.file-item.active { background: var(--accent-soft); border-color: var(--accent-border); }
+.file-item.active::before {
+  content: ""; position: absolute; left: 0; top: 9px; bottom: 9px; width: 3px;
+  background: var(--accent); border-radius: 0 3px 3px 0;
+}
+.fi-top { display: flex; align-items: center; gap: 8px; }
+.fi-dot { width: 7px; height: 7px; border-radius: 50%; flex: 0 0 auto; }
+.fi-dot.pending { background: var(--amber); box-shadow: 0 0 0 3px var(--amber-soft); }
+.fi-dot.done { background: var(--green); box-shadow: 0 0 0 3px var(--green-soft); }
+.fi-name { font-family: var(--mono); font-size: 13px; font-weight: 700; color: var(--text); }
+.fi-cases { margin-left: auto; font-family: var(--mono); font-size: 11px; color: var(--text-3); }
+.fi-path { font-family: var(--mono); font-size: 11px; color: var(--text-3); padding-left: 15px; margin-top: -3px; word-break: break-all; }
+.fi-desc { font-size: 12px; color: var(--text-2); padding-left: 15px; line-height: 1.45; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; }
+.fi-bars { display: flex; gap: 3px; padding-left: 15px; align-items: center; }
+.seg { height: 4px; border-radius: 2px; }
+.seg.normal { background: var(--green); }
+.seg.error { background: var(--rose); }
+.seg.boundary { background: var(--amber); }
+.fi-warn { display: inline-flex; align-items: center; gap: 4px; font-size: 10.5px; color: var(--amber); font-weight: 500; margin-left: auto; }
+.fi-warn::before { content: "▲"; font-size: 8px; }
+
+/* ---- Detail ---- */
+main.detail { flex: 1 1 auto; overflow-y: auto; min-width: 0; background: var(--bg); }
+.detail-inner { max-width: 1080px; margin: 0 auto; padding: 26px 32px 80px; }
+
+.file-header {
+  background: var(--surface); border: 1px solid var(--border);
+  border-radius: var(--r-lg); padding: 22px 24px; box-shadow: var(--shadow-sm);
+  margin-bottom: 22px;
+}
+.fh-pathrow { display: flex; align-items: center; gap: 10px; margin-bottom: 12px; flex-wrap: wrap; }
+.fh-path {
+  font-family: var(--mono); font-size: 13.5px; font-weight: 700; color: var(--text);
+  background: var(--surface-3); border: 1px solid var(--border);
+  padding: 4px 10px; border-radius: var(--r-sm); display: inline-flex; align-items: center; gap: 8px;
+}
+.fh-path .dir { color: var(--text-3); font-weight: 400; }
+.lang-tag { font-family: var(--mono); font-size: 11px; color: var(--text-2); border: 1px solid var(--border-strong); padding: 2px 8px; border-radius: 20px; }
+.fh-desc-label { font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.07em; color: var(--text-3); font-weight: 700; margin-bottom: 5px; }
+.fh-desc { font-size: 14px; color: var(--text); line-height: 1.6; max-width: 760px; }
+
+.cov-grid { display: flex; gap: 28px; margin-top: 18px; padding-top: 18px; border-top: 1px dashed var(--border-strong); flex-wrap: wrap; align-items: flex-end; }
+.cov-block { display: flex; flex-direction: column; gap: 7px; min-width: 150px; }
+.cov-block .ctitle { font-size: 11px; color: var(--text-3); font-weight: 500; display: flex; justify-content: space-between; }
+.cov-block .ctitle b { font-family: var(--mono); color: var(--text); }
+.cov-block .ctrack { height: 7px; border-radius: 4px; background: var(--surface-3); overflow: hidden; }
+.cov-block .cfill { height: 100%; border-radius: 4px; }
+.cov-fns .cfill { background: linear-gradient(90deg, var(--accent), oklch(0.62 0.14 264)); }
+.cov-br .cfill { background: linear-gradient(90deg, var(--green), oklch(0.6 0.12 156)); }
+.cov-gap {
+  margin-left: auto; align-self: stretch; display: flex; flex-direction: column; gap: 5px;
+  background: var(--amber-soft); border: 1px solid var(--amber-border);
+  border-radius: var(--r-md); padding: 9px 13px; min-width: 210px;
+}
+.cov-gap .gtitle { font-size: 11px; font-weight: 700; color: var(--amber); display: flex; align-items: center; gap: 6px; }
+.cov-gap .gtitle::before { content: "▲"; font-size: 9px; }
+.cov-gap .gitems { font-size: 12px; color: var(--text-2); line-height: 1.5; }
+.cov-gap code { font-family: var(--mono); font-size: 11.5px; color: var(--text); background: oklch(1 0 0 / 0.6); padding: 1px 5px; border-radius: 4px; }
+
+/* ---- Toolbar above cases ---- */
+.cases-bar { display: flex; align-items: center; gap: 12px; margin-bottom: 16px; flex-wrap: wrap; }
+.cases-bar h3 { font-size: 15px; font-weight: 700; letter-spacing: 0.01em; }
+.cases-bar h3 .n { color: var(--text-3); font-weight: 500; font-family: var(--mono); }
+.filters { display: flex; gap: 6px; }
+.chip {
+  font-family: inherit; font-size: 12px; cursor: pointer;
+  border: 1px solid var(--border-strong); background: var(--surface);
+  color: var(--text-2); padding: 4px 11px; border-radius: 20px; white-space: nowrap;
+  display: inline-flex; align-items: center; gap: 6px; transition: all .1s;
+}
+.chip:hover { border-color: var(--text-3); color: var(--text); }
+.chip.active { background: var(--text); border-color: var(--text); color: #fff; }
+.chip .dot { width: 7px; height: 7px; border-radius: 50%; }
+.chip .dot.normal { background: var(--green); }
+.chip .dot.error { background: var(--rose); }
+.chip .dot.boundary { background: var(--amber); }
+.cases-bar .right { margin-left: auto; display: flex; gap: 8px; }
+
+/* ---- Case list / cards ---- */
+.cases { display: flex; flex-direction: column; gap: 14px; }
+
+.case {
+  background: var(--surface); border: 1px solid var(--border);
+  border-radius: var(--r-lg); box-shadow: var(--shadow-sm);
+  overflow: hidden; transition: box-shadow .14s, border-color .14s;
+}
+.case:hover { box-shadow: var(--shadow-md); border-color: var(--border-strong); }
+
+.case-head { display: flex; align-items: center; gap: 11px; padding: 15px 18px; flex-wrap: wrap; }
+.case-id { font-family: var(--mono); font-size: 12px; font-weight: 700; color: var(--text-3); }
+.case-title { font-size: 14.5px; font-weight: 700; color: var(--text); flex: 1 1 auto; min-width: 160px; }
+.badge {
+  font-size: 11px; font-weight: 700; padding: 2px 9px; border-radius: 20px;
+  display: inline-flex; align-items: center; gap: 5px; white-space: nowrap;
+  border: 1px solid transparent;
+}
+.badge.normal { color: var(--green); background: var(--green-soft); border-color: var(--green-border); }
+.badge.error { color: var(--rose); background: var(--rose-soft); border-color: var(--rose-border); }
+.badge.boundary { color: var(--amber); background: var(--amber-soft); border-color: var(--amber-border); }
+.prio { font-size: 10.5px; font-weight: 700; padding: 2px 8px; border-radius: 5px; display: inline-flex; align-items: center; gap: 4px; }
+.prio::before { content: ""; width: 6px; height: 6px; border-radius: 50%; }
+.prio.high { color: var(--rose); background: var(--rose-soft); }
+.prio.high::before { background: var(--rose); }
+.prio.med { color: var(--amber); background: var(--amber-soft); }
+.prio.med::before { background: var(--amber); }
+.prio.low { color: var(--text-2); background: var(--surface-3); }
+.prio.low::before { background: var(--text-3); }
+.case-status { font-size: 11px; color: var(--text-3); display: inline-flex; align-items: center; gap: 5px; font-family: var(--mono); }
+.case-status::before { content: ""; width: 7px; height: 7px; border-radius: 50%; background: var(--amber); box-shadow: 0 0 0 3px var(--amber-soft); }
+
+.case-body { padding: 0 18px 16px; display: grid; grid-template-columns: 1fr 1fr; gap: 18px; }
+.field { display: flex; flex-direction: column; gap: 7px; min-width: 0; }
+.field.full { grid-column: 1 / -1; }
+.field-label { font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.07em; color: var(--text-3); font-weight: 700; display: flex; align-items: center; gap: 6px; }
+.field-label::before { content: ""; width: 3px; height: 11px; border-radius: 2px; background: var(--border-strong); }
+
+ol.steps { list-style: none; display: flex; flex-direction: column; gap: 6px; counter-reset: s; }
+ol.steps li { font-size: 13px; color: var(--text); padding-left: 26px; position: relative; line-height: 1.5; }
+ol.steps li::before {
+  counter-increment: s; content: counter(s);
+  position: absolute; left: 0; top: 1px;
+  width: 18px; height: 18px; border-radius: 50%;
+  background: var(--surface-3); border: 1px solid var(--border);
+  font-family: var(--mono); font-size: 10.5px; font-weight: 700; color: var(--text-2);
+  display: grid; place-items: center;
+}
+.precond { font-size: 12.5px; color: var(--text-2); background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--r-sm); padding: 8px 11px; line-height: 1.5; }
+.precond b { color: var(--text); font-weight: 500; }
+
+.io { display: flex; flex-direction: column; gap: 8px; }
+.io-block { background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--r-sm); overflow: hidden; }
+.io-block .io-tag { font-size: 10px; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase; padding: 5px 11px; border-bottom: 1px solid var(--border); display: flex; align-items: center; gap: 6px; }
+.io-block.in .io-tag { color: var(--accent-2); background: var(--accent-soft); }
+.io-block.out .io-tag { color: var(--green); background: var(--green-soft); }
+.io-block pre { font-family: var(--mono); font-size: 12px; color: var(--text); padding: 9px 11px; white-space: pre-wrap; word-break: break-word; line-height: 1.55; }
+.io-block.out.throws pre { color: var(--rose); }
+.io-arrow { align-self: center; color: var(--text-3); font-size: 13px; font-family: var(--mono); }
+
+.cov-chips { display: flex; flex-wrap: wrap; gap: 6px; }
+.cov-chip { font-family: var(--mono); font-size: 11.5px; padding: 3px 9px; border-radius: 5px; border: 1px solid var(--border); background: var(--surface-2); color: var(--text); display: inline-flex; align-items: center; gap: 6px; white-space: nowrap; }
+.cov-chip .ck { font-size: 9.5px; color: var(--text-3); font-family: "Noto Sans JP"; white-space: nowrap; }
+.cov-chip.branch { background: var(--accent-soft); border-color: var(--accent-border); color: var(--accent-2); }
+
+.ai {
+  grid-column: 1 / -1; display: flex; gap: 12px;
+  background: linear-gradient(180deg, var(--accent-soft), oklch(0.975 0.012 264));
+  border: 1px solid var(--accent-border); border-radius: var(--r-md);
+  padding: 12px 15px;
+}
+.ai-mark { flex: 0 0 auto; width: 24px; height: 24px; border-radius: 7px; background: linear-gradient(150deg, var(--accent), var(--accent-2)); display: grid; place-items: center; box-shadow: var(--shadow-sm); }
+.ai-mark::before { content: ""; width: 9px; height: 9px; background: #fff; clip-path: polygon(50% 0, 61% 39%, 100% 50%, 61% 61%, 50% 100%, 39% 61%, 0 50%, 39% 39%); }
+.ai-body { min-width: 0; }
+.ai-body .ai-label { font-size: 10.5px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em; color: var(--accent-2); margin-bottom: 3px; }
+.ai-body p { font-size: 13px; color: var(--text); line-height: 1.55; }
+
+.case-foot {
+  display: flex; align-items: center; gap: 8px;
+  padding: 11px 18px; border-top: 1px solid var(--border); background: var(--surface-2);
+}
+.case-foot .hint { font-size: 11.5px; color: var(--text-3); }
+.case-foot .actions { margin-left: auto; display: flex; gap: 8px; }
+.btn.sm { padding: 5px 11px; font-size: 12px; }
+.btn.ok { color: var(--green); border-color: var(--green-border); }
+.btn.ok:hover { background: var(--green-soft); }
+.btn.warn { color: var(--amber); border-color: var(--amber-border); }
+.btn.warn:hover { background: var(--amber-soft); }
+
+/* ============ LIST layout tweak ============ */
+#app[data-layout="list"] .cases { gap: 0; border: 1px solid var(--border); border-radius: var(--r-lg); overflow: hidden; box-shadow: var(--shadow-sm); }
+#app[data-layout="list"] .case { border-radius: 0; border: none; border-bottom: 1px solid var(--border); box-shadow: none; }
+#app[data-layout="list"] .case:last-child { border-bottom: none; }
+#app[data-layout="list"] .case:hover { box-shadow: none; background: var(--surface-2); }
+#app[data-layout="list"] .case-head { padding: 12px 16px; }
+#app[data-layout="list"] .case-body { grid-template-columns: 1.1fr 1fr; gap: 14px 22px; padding: 0 16px 14px; }
+#app[data-layout="list"] .field.steps-field { display: none; }
+#app[data-layout="list"] .precond { background: transparent; border: none; padding: 0; }
+#app[data-layout="list"] .ai { background: transparent; border: none; border-top: 1px dashed var(--accent-border); border-radius: 0; padding: 10px 0 0; }
+#app[data-layout="list"] .ai-mark { width: 20px; height: 20px; }
+#app[data-layout="list"] .case-foot { padding: 9px 16px; }
+
+/* ============ DENSITY tweak ============ */
+#app[data-density="compact"] { font-size: 13px; }
+#app[data-density="compact"] .detail-inner { padding: 18px 24px 60px; }
+#app[data-density="compact"] .file-header { padding: 16px 18px; margin-bottom: 16px; }
+#app[data-density="compact"] .case-head { padding: 11px 14px; }
+#app[data-density="compact"] .case-body { padding: 0 14px 12px; gap: 13px; }
+#app[data-density="compact"] .cases { gap: 10px; }
+#app[data-density="compact"] .ai { padding: 9px 12px; }
+
+/* ============ Header legend ============ */
+.legend { display: flex; gap: 14px; align-items: center; padding-left: 4px; }
+.legend .lg { display: inline-flex; align-items: center; gap: 6px; font-size: 12px; color: var(--text-2); white-space: nowrap; }
+.legend .dot { width: 8px; height: 8px; border-radius: 50%; }
+.legend .dot.normal { background: var(--green); }
+.legend .dot.error { background: var(--rose); }
+.legend .dot.boundary { background: var(--amber); }
+
+/* ============ Master nav groups ============ */
+.master-scroll { overflow-y: auto; padding: 12px 10px 20px; display: flex; flex-direction: column; }
+.nav-group + .nav-group { margin-top: 8px; }
+.nav-grouphead { display: flex; align-items: center; justify-content: space-between; padding: 8px 8px 7px; }
+.nav-grouphead h2 { font-size: 11px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--text-3); font-weight: 700; }
+.nav-grouphead .count { font-size: 11px; color: var(--text-3); font-family: var(--mono); background: var(--surface-3); padding: 1px 8px; border-radius: 20px; }
+.nav-items { display: flex; flex-direction: column; gap: 2px; }
+
+.nav-item {
+  position: relative; text-align: left; width: 100%;
+  background: transparent; border: 1px solid transparent; border-radius: var(--r-md);
+  padding: 9px 11px; cursor: pointer; font-family: inherit; color: var(--text);
+  transition: background .1s, border-color .1s; display: flex; align-items: center; gap: 10px;
+}
+.nav-item:hover { background: var(--surface-2); }
+.nav-item.active { background: var(--accent-soft); border-color: var(--accent-border); }
+.nav-item.active::before { content: ""; position: absolute; left: 0; top: 8px; bottom: 8px; width: 3px; background: var(--accent); border-radius: 0 3px 3px 0; }
+.nav-ico { flex: 0 0 auto; width: 26px; height: 26px; border-radius: 7px; background: var(--surface-3); border: 1px solid var(--border); display: grid; place-items: center; color: var(--text-2); }
+.nav-item.active .nav-ico { background: #fff; border-color: var(--accent-border); color: var(--accent); }
+.nav-ico svg { width: 15px; height: 15px; }
+.nav-label { font-size: 13.5px; font-weight: 500; line-height: 1.25; }
+.nav-item .nav-tag { margin-left: auto; font-size: 10px; font-family: var(--mono); color: var(--amber); background: var(--amber-soft); border: 1px solid var(--amber-border); padding: 1px 6px; border-radius: 20px; }
+
+/* ============ Detail: section heading ============ */
+.view-head { margin-bottom: 20px; }
+.view-kicker { font-size: 11px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--accent-2); font-weight: 700; margin-bottom: 6px; }
+.view-title { font-size: 22px; font-weight: 700; letter-spacing: 0.01em; }
+.view-lead { font-size: 13.5px; color: var(--text-2); margin-top: 8px; max-width: 720px; line-height: 1.65; }
+
+.panel { background: var(--surface); border: 1px solid var(--border); border-radius: var(--r-lg); box-shadow: var(--shadow-sm); padding: 20px 22px; margin-bottom: 16px; }
+.panel-title { font-size: 13px; font-weight: 700; margin-bottom: 14px; display: flex; align-items: center; gap: 9px; flex-wrap: wrap; }
+.panel-title .pn { font-family: var(--mono); font-size: 11px; color: #fff; background: var(--accent); width: 22px; height: 22px; border-radius: 6px; display: grid; place-items: center; flex: 0 0 auto; }
+.panel-title .pn svg { width: 13px; height: 13px; }
+.panel-title .ptsub { font-size: 11.5px; font-weight: 400; color: var(--text-3); display: inline-flex; align-items: center; gap: 5px; }
+.panel-title .ptsub .mx-empty { display: inline-block; }
+.approach { font-size: 13.5px; color: var(--text); line-height: 1.7; max-width: 760px; }
+.bullets { list-style: none; display: flex; flex-direction: column; gap: 7px; }
+.bullets li { position: relative; padding-left: 17px; font-size: 13.5px; color: var(--text); line-height: 1.6; }
+.bullets li::before { content: ""; position: absolute; left: 2px; top: 9px; width: 5px; height: 5px; border-radius: 50%; background: var(--accent); }
+.muted-note { font-size: 12.5px; color: var(--text-3); padding: 4px 0; }
+
+/* doc: label + content rows */
+.doc-row { display: grid; grid-template-columns: 150px 1fr; gap: 18px; padding: 13px 0; border-top: 1px solid var(--border); }
+.doc-row:first-child { border-top: none; padding-top: 0; }
+.doc-row .dl { font-size: 12px; font-weight: 700; color: var(--text-3); padding-top: 2px; }
+.doc-row .dc { font-size: 13.5px; color: var(--text); line-height: 1.65; }
+.doc-row .dc ul { list-style: none; display: flex; flex-direction: column; gap: 6px; }
+.doc-row .dc ul li { position: relative; padding-left: 16px; }
+.doc-row .dc ul li::before { content: ""; position: absolute; left: 2px; top: 9px; width: 5px; height: 5px; border-radius: 50%; background: var(--accent); }
+.scope-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+.scope-box { border: 1px solid var(--border); border-radius: var(--r-md); padding: 11px 13px; }
+.scope-box .sb-h { font-size: 11px; font-weight: 700; margin-bottom: 7px; display: flex; align-items: center; gap: 6px; }
+.scope-box.in .sb-h { color: var(--green); }
+.scope-box.out .sb-h { color: var(--text-3); }
+.scope-box code { font-family: var(--mono); font-size: 11.5px; }
+.scope-box ul { list-style: none; display: flex; flex-direction: column; gap: 5px; font-size: 12.5px; color: var(--text-2); }
+
+.levelbars { display: flex; flex-direction: column; gap: 9px; max-width: 420px; }
+.levelbar { display: grid; grid-template-columns: 70px 1fr 48px; gap: 10px; align-items: center; font-size: 12.5px; }
+.levelbar .lv-track { height: 8px; border-radius: 4px; background: var(--surface-3); overflow: hidden; }
+.levelbar .lv-fill { height: 100%; border-radius: 4px; background: linear-gradient(90deg, var(--accent), oklch(0.62 0.14 264)); }
+.levelbar .lv-val { font-family: var(--mono); font-size: 12px; color: var(--text-2); text-align: right; }
+.levelbar .lv-note { font-size: 11px; color: var(--text-3); }
+
+/* generic data table */
+table.dtable { width: 100%; border-collapse: collapse; font-size: 13px; }
+table.dtable th { text-align: left; font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.06em; color: var(--text-3); font-weight: 700; padding: 0 12px 9px; border-bottom: 1px solid var(--border-strong); }
+table.dtable td { padding: 11px 12px; border-bottom: 1px solid var(--border); vertical-align: top; line-height: 1.55; }
+table.dtable tr:last-child td { border-bottom: none; }
+table.dtable tr:hover td { background: var(--surface-2); }
+table.dtable code, .mono { font-family: var(--mono); font-size: 12px; }
+.reqid { font-family: var(--mono); font-size: 12px; font-weight: 700; color: var(--accent-2); }
+.tc-ref { font-family: var(--mono); font-size: 11px; color: var(--text-2); background: var(--surface-3); border: 1px solid var(--border); padding: 1px 7px; border-radius: 5px; display: inline-block; margin: 2px 4px 2px 0; }
+.pill { font-size: 11px; font-weight: 700; padding: 2px 9px; border-radius: 20px; border: 1px solid transparent; display: inline-flex; align-items: center; gap: 5px; white-space: nowrap; }
+.pill.ok { color: var(--green); background: var(--green-soft); border-color: var(--green-border); }
+.pill.gap { color: var(--amber); background: var(--amber-soft); border-color: var(--amber-border); }
+.pill.real { color: var(--green); background: var(--green-soft); border-color: var(--green-border); }
+.pill.fake { color: var(--accent-2); background: var(--accent-soft); border-color: var(--accent-border); }
+.pill.stub { color: var(--amber); background: var(--amber-soft); border-color: var(--amber-border); }
+.pill.mock { color: var(--rose); background: var(--rose-soft); border-color: var(--rose-border); }
+
+/* matrix */
+table.matrix td.cell { text-align: center; min-width: 110px; }
+table.matrix th.coltype { text-align: center; }
+table.matrix .grouprow td { background: var(--surface-3); font-family: var(--mono); font-size: 11.5px; font-weight: 700; color: var(--text-2); padding: 7px 12px; }
+table.matrix .fn { font-family: var(--mono); font-size: 12.5px; font-weight: 500; }
+.mx-empty { display: inline-block; width: 22px; height: 3px; border-radius: 2px; background: var(--border-strong); opacity: 0.7; }
+.mx-cell-ids { display: inline-flex; flex-direction: column; gap: 3px; align-items: center; }
+.mx-id { font-family: var(--mono); font-size: 10.5px; font-weight: 700; padding: 1px 7px; border-radius: 5px; white-space: nowrap; }
+.mx-id.normal { color: var(--green); background: var(--green-soft); }
+.mx-id.error { color: var(--rose); background: var(--rose-soft); }
+.mx-id.boundary { color: var(--amber); background: var(--amber-soft); }
+
+/* test data cards */
+.data-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 12px; }
+.data-card { border: 1px solid var(--border); border-radius: var(--r-md); padding: 13px 15px; background: var(--surface); }
+.data-card .dh { display: flex; align-items: baseline; gap: 9px; margin-bottom: 7px; flex-wrap: wrap; }
+.data-card .dh .dname { font-size: 13.5px; font-weight: 700; }
+.data-card .dh .did { font-family: var(--mono); font-size: 11px; color: var(--text-3); }
+.data-card .ddesc { font-size: 12.5px; color: var(--text-2); line-height: 1.55; margin-bottom: 9px; }
+.data-card pre.code { font-family: var(--mono); font-size: 11.5px; background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--r-sm); padding: 8px 10px; white-space: pre-wrap; word-break: break-word; color: var(--text); margin-bottom: 9px; line-height: 1.5; }
+.data-card .usedby { display: flex; flex-wrap: wrap; gap: 4px; align-items: center; }
+.data-card .usedby .ub-lb { font-size: 10px; color: var(--text-3); margin-right: 2px; }
+
+.callout { display: flex; gap: 12px; background: linear-gradient(180deg, var(--accent-soft), oklch(0.975 0.012 264)); border: 1px solid var(--accent-border); border-radius: var(--r-md); padding: 14px 16px; margin-bottom: 16px; }
+.callout .ci { flex: 0 0 auto; width: 24px; height: 24px; border-radius: 7px; background: linear-gradient(150deg, var(--accent), var(--accent-2)); display: grid; place-items: center; }
+.callout .ci::before { content: ""; width: 9px; height: 9px; background: #fff; clip-path: polygon(50% 0, 61% 39%, 100% 50%, 61% 61%, 50% 100%, 39% 61%, 0 50%, 39% 39%); }
+.callout .ct { font-size: 13px; color: var(--text); line-height: 1.6; }
+.callout .ct b { font-weight: 700; }
+
+@media (max-width: 1000px) {
+  .data-grid, .scope-grid { grid-template-columns: 1fr; }
+  .doc-row { grid-template-columns: 1fr; gap: 6px; }
+}
+
+/* scrollbars */
+.master-scroll::-webkit-scrollbar, main.detail::-webkit-scrollbar { width: 11px; }
+.master-scroll::-webkit-scrollbar-thumb, main.detail::-webkit-scrollbar-thumb { background: var(--border-strong); border-radius: 20px; border: 3px solid var(--surface); }
+main.detail::-webkit-scrollbar-thumb { border-color: var(--bg); }
+
+@media (max-width: 900px) {
+  .case-body, #app[data-layout="list"] .case-body { grid-template-columns: 1fr; }
+  .stats .stat:nth-child(n+3) { display: none; }
+}
+
+/* ===== 4th category: edge (エッジケース) ===== */
+:root {
+  --purple: oklch(0.5 0.16 300);
+  --purple-soft: oklch(0.955 0.04 300);
+  --purple-border: oklch(0.85 0.07 300);
+}
+.legend .dot.edge { background: var(--purple); }
+.chip .dot.edge { background: var(--purple); }
+.seg.edge { background: var(--purple); }
+.badge.edge { color: var(--purple); background: var(--purple-soft); border-color: var(--purple-border); }
+.mx-id.edge { color: var(--purple); background: var(--purple-soft); }
+
+</style>
+</head>
+<body>
+
+<div id="app" data-layout="card" data-density="regular">
+  <header class="topbar">
+    <div class="brand">
+      <div class="brand-mark"></div>
+      <div class="brand-title">
+        <b>テストケース仕様</b>
+      </div>
+    </div>
+    <div class="stats">
+      <div class="stat"><span class="num" id="stat-files">0</span><span class="lbl">ファイル</span></div>
+      <div class="stat"><span class="num" id="stat-cases">0</span><span class="lbl">ケース</span></div>
+      <div class="stat"><span class="num warn" id="stat-pending">0</span><span class="lbl">要確認</span></div>
+      <div class="cov-meter">
+        <span class="lbl">想定カバレッジ</span>
+        <div style="display:flex;align-items:center;gap:8px;">
+          <div class="track"><div class="fill" id="cov-fill" style="width:0%"></div></div>
+          <span class="pct" id="cov-pct">0%</span>
+        </div>
+      </div>
+    </div>
+    <div class="legend">
+      <span class="lg"><span class="dot normal"></span>正常系</span>
+      <span class="lg"><span class="dot boundary"></span>境界値</span>
+      <span class="lg"><span class="dot error"></span>異常系</span>
+      <span class="lg"><span class="dot edge"></span>エッジケース</span>
+    </div>
+  </header>
+
+  <div class="body">
+    <aside class="master">
+      <div class="master-scroll" id="master-scroll"></div>
+    </aside>
+    <main class="detail" id="detail"></main>
+  </div>
+</div>
+
+<!-- ============================================================
+     DATA — このスクリプトだけをエージェントが実データで置き換える
+     ============================================================ -->
+<script>
+/*
+ * ============================================================================
+ *  test-case-designer エージェントへ:
+ *  この FILES と PLAN を、実際のテスト計画データで丸ごと置き換えること。
+ *  下記はデータ構造（スキーマ）の例。HTMLは書かない — データだけ書けばよい。
+ * ----------------------------------------------------------------------------
+ *  FILES[]: テスト対象ファイルごとのオブジェクト
+ *    name      : ファイル名（例 "price.ts"）
+ *    dir       : ディレクトリ（例 "src/utils/"）
+ *    lang      : 言語タグ（例 "TypeScript"）
+ *    purpose   : このファイルの役割（1〜2文）
+ *    approach  : テスト方針（どう検証するか）
+ *    viewpoints: string[]  重点的に確認する観点
+ *    coverage  : { fns:[到達,全体], branches:[到達,全体] }  ← 数値
+ *    gaps      : string[]  未カバーの疑い（空配列なら「カバー済」表示）。<code> 可
+ *    cases[]   : テストケース
+ *      id       : "TC-01" など
+ *      title    : ケース名
+ *      cat      : "normal" | "boundary" | "error" | "edge"   （正常/境界/異常/エッジ）
+ *      prio     : "high" | "med" | "low"
+ *      precond  : 前提条件
+ *      steps    : string[]  実行手順
+ *      input    : 入力値（複数行可、\n 区切り）
+ *      expected : 期待結果（throws:true のときは期待される例外）
+ *      throws   : boolean   例外を期待するか
+ *      coverage : [{ k:"関数"|"分岐", v:"名前", branch?:true }]  ← k:"関数" がマトリクスの行になる
+ *      ai       : このケースをなぜ提案したか（レビュー補助の一文）
+ *
+ *  PLAN: 計画全体
+ *    strategy : { purpose, scopeIn:[], scopeOut:[], levels:[{label,pct,note}],
+ *                 viewpoints:[], priority, exit:[] }
+ *    trace    : [{ id:"REQ-1", req, tcs:["price/TC-01", ...], status:"ok"|"gap" }]
+ *    testData : [{ id, name, desc, code, usedBy:["<file-base>/TC-xx", ...] }]
+ *               usedBy の <file-base> は name から拡張子を除いたもの（price.ts → price）
+ * ============================================================================
+ */
+const FILES = [
+  {
+    name: "env_test.rs",
+    dir: "src/",
+    lang: "Rust",
+    purpose: "plm_root() の環境変数解決ロジック（PLM_HOME→HOME の優先順位・フォールバック・相対パス拒否）と PlmPaths のパス計算、および 5 経路が同一 root 配下に揃う横断整合性を検証する中核テスト。",
+    approach: "環境変数に依存しない PlmPaths::with_root() 経由のパス計算テストを主軸にし（並列安全）、plm_root() の環境変数制御テストは cargo test plm_root -- --test-threads=1 で並列競合を回避して実施する。相対パス拒否・両方未設定は Err を assert する。",
+    viewpoints: [
+      "PLM_HOME 有効時に PLM_HOME が優先されること（案 A: HOME 代替）",
+      "空文字・空白のみの PLM_HOME は無効扱いで HOME にフォールバックすること",
+      "相対パス / 両方無効時に明確なエラーを返すこと",
+      "5 アクセサがすべて {root}/.plm 配下に揃うこと（UC-1 整合性）",
+      "PLM_HOME 設定下でも Personal 配置用 home_dir() は HOME を返す回帰",
+    ],
+    status: "pending",
+    coverage: { fns: [8, 9], branches: [7, 8] },
+    gaps: [
+      "<code>PlmPaths::new()</code> の直接テストは環境変数依存のため <code>plm_root()</code> 経由で間接検証（パス計算は <code>with_root()</code> で直接カバー）",
+      "非 UTF-8 の <code>PLM_HOME</code>（OsString）は <code>EnvVar::get</code> が String 前提のためテスト対象外",
+    ],
+    cases: [
+      {
+        id: "TC-01",
+        title: "PLM_HOME 有効時に plm_root() が PLM_HOME を返す",
+        cat: "normal",
+        prio: "high",
+        precond: "PLM_HOME に絶対パス、HOME に別の絶対パスが設定されている",
+        steps: ["PLM_HOME と HOME を set_var で設定", "plm_root() を呼ぶ", "戻り値の PathBuf を検証"],
+        input: "PLM_HOME=\"/tmp/plm-a\"\nHOME=\"/home/user\"",
+        expected: "Ok(PathBuf::from(\"/tmp/plm-a\"))",
+        throws: false,
+        coverage: [{ k: "関数", v: "plm_root" }, { k: "分岐", v: "PLM_HOME=Some(有効)", branch: true }],
+        ai: "FR-1 の主要正常系。PLM_HOME 有効時にそれが採用される最重要パスを最初に固定する。",
+      },
+      {
+        id: "TC-02",
+        title: "PLM_HOME 未設定時に HOME へフォールバック",
+        cat: "normal",
+        prio: "high",
+        precond: "PLM_HOME は unset、HOME に絶対パスが設定されている",
+        steps: ["PLM_HOME を remove_var", "HOME を set_var", "plm_root() を呼ぶ"],
+        input: "PLM_HOME=(unset)\nHOME=\"/home/user\"",
+        expected: "Ok(PathBuf::from(\"/home/user\"))",
+        throws: false,
+        coverage: [{ k: "関数", v: "plm_root" }, { k: "分岐", v: "PLM_HOME=None→HOME", branch: true }],
+        ai: "FR-4 / NFR-3（後方互換）。PLM_HOME 未設定時に従来の HOME 解決が保たれることを保証。",
+      },
+      {
+        id: "TC-03",
+        title: "PLM_HOME と HOME 両方設定時は PLM_HOME 優先",
+        cat: "normal",
+        prio: "high",
+        precond: "PLM_HOME・HOME ともに異なる有効な絶対パス",
+        steps: ["両方を set_var で設定", "plm_root() を呼ぶ", "PLM_HOME 側が返ることを確認"],
+        input: "PLM_HOME=\"/tmp/plm-a\"\nHOME=\"/home/user\"",
+        expected: "Ok(PathBuf::from(\"/tmp/plm-a\"))（HOME は無視）",
+        throws: false,
+        coverage: [{ k: "関数", v: "plm_root" }, { k: "分岐", v: "優先順位 PLM_HOME>HOME", branch: true }],
+        ai: "優先順位の明示検証。案 A の中核セマンティクスを回帰から守る。",
+      },
+      {
+        id: "TC-04",
+        title: "PlmPaths::plm_dir() のパス計算",
+        cat: "normal",
+        prio: "med",
+        precond: "with_root で任意のルートを注入（環境変数不使用・並列安全）",
+        steps: ["PlmPaths::with_root(\"/tmp/foo\") を構築", "plm_dir() を呼ぶ"],
+        input: "root = \"/tmp/foo\"",
+        expected: "PathBuf::from(\"/tmp/foo/.plm\")",
+        throws: false,
+        coverage: [{ k: "関数", v: "plm_dir" }],
+        ai: "FR-2。全パスの基点となる plm_dir を with_root で並列安全に固定。",
+      },
+      {
+        id: "TC-05",
+        title: "PlmPaths::targets_json() のパス計算",
+        cat: "normal",
+        prio: "med",
+        precond: "with_root でルートを注入",
+        steps: ["with_root(\"/tmp/foo\") を構築", "targets_json() を呼ぶ"],
+        input: "root = \"/tmp/foo\"",
+        expected: "PathBuf::from(\"/tmp/foo/.plm/targets.json\")",
+        throws: false,
+        coverage: [{ k: "関数", v: "targets_json" }],
+        ai: "FR-3。TargetRegistry が使うパスの計算結果を単体で確定。",
+      },
+      {
+        id: "TC-06",
+        title: "PlmPaths::marketplaces_json() のパス計算",
+        cat: "normal",
+        prio: "med",
+        precond: "with_root でルートを注入",
+        steps: ["with_root(\"/tmp/foo\") を構築", "marketplaces_json() を呼ぶ"],
+        input: "root = \"/tmp/foo\"",
+        expected: "PathBuf::from(\"/tmp/foo/.plm/marketplaces.json\")",
+        throws: false,
+        coverage: [{ k: "関数", v: "marketplaces_json" }],
+        ai: "FR-3。MarketplaceConfig が使うパスの計算結果を単体で確定。",
+      },
+      {
+        id: "TC-07",
+        title: "PlmPaths::imports_json() のパス計算",
+        cat: "normal",
+        prio: "med",
+        precond: "with_root でルートを注入",
+        steps: ["with_root(\"/tmp/foo\") を構築", "imports_json() を呼ぶ"],
+        input: "root = \"/tmp/foo\"",
+        expected: "PathBuf::from(\"/tmp/foo/.plm/imports.json\")",
+        throws: false,
+        coverage: [{ k: "関数", v: "imports_json" }],
+        ai: "FR-3。ImportRegistry が使うパスの計算結果を単体で確定。",
+      },
+      {
+        id: "TC-08",
+        title: "PlmPaths::plugins_cache_dir() のパス計算",
+        cat: "normal",
+        prio: "med",
+        precond: "with_root でルートを注入",
+        steps: ["with_root(\"/tmp/foo\") を構築", "plugins_cache_dir() を呼ぶ"],
+        input: "root = \"/tmp/foo\"",
+        expected: "PathBuf::from(\"/tmp/foo/.plm/cache/plugins\")",
+        throws: false,
+        coverage: [{ k: "関数", v: "plugins_cache_dir" }],
+        ai: "FR-3。PackageCache が使うキャッシュパスの計算結果を単体で確定。",
+      },
+      {
+        id: "TC-09",
+        title: "PlmPaths::marketplaces_cache_dir() のパス計算",
+        cat: "normal",
+        prio: "med",
+        precond: "with_root でルートを注入",
+        steps: ["with_root(\"/tmp/foo\") を構築", "marketplaces_cache_dir() を呼ぶ"],
+        input: "root = \"/tmp/foo\"",
+        expected: "PathBuf::from(\"/tmp/foo/.plm/cache/marketplaces\")",
+        throws: false,
+        coverage: [{ k: "関数", v: "marketplaces_cache_dir" }],
+        ai: "FR-3。MarketplaceRegistry が使うキャッシュパスの計算結果を単体で確定。",
+      },
+      {
+        id: "TC-10",
+        title: "PLM_HOME が空文字なら HOME フォールバック",
+        cat: "boundary",
+        prio: "high",
+        precond: "PLM_HOME=\"\"（空文字）、HOME に有効な絶対パス",
+        steps: ["PLM_HOME=\"\" を set_var", "HOME を set_var", "plm_root() を呼ぶ"],
+        input: "PLM_HOME=\"\"\nHOME=\"/home/user\"",
+        expected: "Ok(PathBuf::from(\"/home/user\"))",
+        throws: false,
+        coverage: [{ k: "関数", v: "plm_root" }, { k: "分岐", v: "空文字フィルタ→None", branch: true }],
+        ai: "FR-4 境界。EnvVar::get 互換で空文字を無効扱いする分岐をカバー。",
+      },
+      {
+        id: "TC-11",
+        title: "PLM_HOME が空白のみなら HOME フォールバック",
+        cat: "boundary",
+        prio: "med",
+        precond: "PLM_HOME=\"   \"（空白のみ）、HOME に有効な絶対パス",
+        steps: ["PLM_HOME=\"   \" を set_var", "HOME を set_var", "plm_root() を呼ぶ"],
+        input: "PLM_HOME=\"   \"\nHOME=\"/home/user\"",
+        expected: "Ok(PathBuf::from(\"/home/user\"))",
+        throws: false,
+        coverage: [{ k: "関数", v: "plm_root" }, { k: "分岐", v: "trim後空チェック→None", branch: true }],
+        ai: "FR-4 境界。EnvVar::get に加えた trim 拡張の空白除去分岐を明示的にカバー。",
+      },
+      {
+        id: "TC-12",
+        title: "相対パスの PLM_HOME を拒否してエラー",
+        cat: "error",
+        prio: "high",
+        precond: "PLM_HOME に相対パスを設定",
+        steps: ["PLM_HOME=\"relative/path\" を set_var", "plm_root() を呼ぶ", "Err と相対パス拒否メッセージを確認"],
+        input: "PLM_HOME=\"relative/path\"",
+        expected: "Err(PlmError::General(\"PLM_HOME/HOME must be an absolute path, got: relative/path\"))",
+        throws: true,
+        coverage: [{ k: "関数", v: "plm_root" }, { k: "分岐", v: "is_absolute()=false", branch: true }],
+        ai: "FR-5。相対パス混入時の誤ルート生成をエラーで防ぐセキュリティ観点の重要ケース。",
+      },
+      {
+        id: "TC-13",
+        title: "HOME が相対パス（PLM_HOME 未設定）を拒否",
+        cat: "error",
+        prio: "high",
+        precond: "PLM_HOME は unset、HOME に相対パス",
+        steps: ["PLM_HOME を remove_var", "HOME=\"relative\" を set_var", "plm_root() を呼ぶ"],
+        input: "PLM_HOME=(unset)\nHOME=\"relative\"",
+        expected: "Err(PlmError::General(相対パス拒否))",
+        throws: true,
+        coverage: [{ k: "関数", v: "plm_root" }, { k: "分岐", v: "HOME採用後 is_absolute()=false", branch: true }],
+        ai: "FR-5。フォールバック先 HOME にも絶対パス検証が効くことを確認。",
+      },
+      {
+        id: "TC-14",
+        title: "PLM_HOME・HOME 両方未設定でエラー",
+        cat: "error",
+        prio: "high",
+        precond: "PLM_HOME・HOME ともに unset",
+        steps: ["両方を remove_var", "plm_root() を呼ぶ", "Err を確認"],
+        input: "PLM_HOME=(unset)\nHOME=(unset)",
+        expected: "Err(PlmError::General(\"PLM_HOME and HOME environment variables are not set or empty\"))",
+        throws: true,
+        coverage: [{ k: "関数", v: "plm_root" }, { k: "分岐", v: "両方None→ok_or_else", branch: true }],
+        ai: "FR-6。両方無効時に明確なエラーを返すことを保証（既存キャッシュと同系メッセージ）。",
+      },
+      {
+        id: "TC-15",
+        title: "PLM_HOME・HOME 両方が空白のみでエラー",
+        cat: "error",
+        prio: "med",
+        precond: "PLM_HOME・HOME ともに空白のみ",
+        steps: ["両方を \"   \" で set_var", "plm_root() を呼ぶ"],
+        input: "PLM_HOME=\"   \"\nHOME=\"   \"",
+        expected: "Err(PlmError::General(両方未設定エラー))",
+        throws: true,
+        coverage: [{ k: "関数", v: "plm_root" }, { k: "分岐", v: "両方 trim空→None", branch: true }],
+        ai: "FR-6 境界。空白のみが両方無効と等価に扱われる複合分岐をカバー。",
+      },
+      {
+        id: "TC-16",
+        title: "5 パスが同一 root 配下に揃う（UC-1 整合性）",
+        cat: "edge",
+        prio: "high",
+        precond: "with_root(root) で 5 アクセサを取得",
+        steps: ["with_root(root) を構築", "targets/marketplaces/imports_json と 2 つの cache_dir を取得", "全てが {root}/.plm でプレフィックス一致することを assert"],
+        input: "root = TempDir パス",
+        expected: "5 パスすべてが {root}/.plm/ で始まる（分裂なし）",
+        throws: false,
+        coverage: [{ k: "関数", v: "with_root" }, { k: "分岐", v: "全アクセサ整合", branch: true }],
+        ai: "hearing-notes の統合検証要件。バグの本質（ルート分裂）を 1 テストで直接検出する。",
+      },
+      {
+        id: "TC-17",
+        title: "plm_root() のべき等性",
+        cat: "edge",
+        prio: "low",
+        precond: "環境変数を固定して連続呼び出し",
+        steps: ["環境を固定", "plm_root() を 2 回呼ぶ", "戻り値が一致することを確認"],
+        input: "PLM_HOME=\"/tmp/plm-a\"（固定）",
+        expected: "1 回目 == 2 回目（同一 PathBuf）",
+        throws: false,
+        coverage: [{ k: "関数", v: "plm_root" }],
+        ai: "副作用がなく解決が決定的であることを保証（Pure Logic のべき等性観点）。",
+      },
+      {
+        id: "TC-18",
+        title: "PLM_HOME 設定下でも home_dir() は HOME を返す（回帰）",
+        cat: "edge",
+        prio: "med",
+        precond: "PLM_HOME ≠ HOME の状態（スコープ外 paths.rs の回帰確認）",
+        steps: ["PLM_HOME と HOME を別値で set_var", "target::core::paths::home_dir() を呼ぶ", "HOME 値が返ることを確認"],
+        input: "PLM_HOME=\"/tmp/plm-a\"\nHOME=\"/home/user\"",
+        expected: "PathBuf::from(\"/home/user\")（$PLM_HOME に引きずられない）",
+        throws: false,
+        coverage: [{ k: "関数", v: "home_dir(回帰)" }],
+        ai: "UC-3 / C-2。Personal 配置が PLM_HOME に汚染されないことを守る回帰テスト。",
+      },
+    ],
+  },
+  {
+    name: "target-registry.rs",
+    dir: "src/target/core/",
+    lang: "Rust",
+    purpose: "TargetRegistry::new() が PlmPaths 経由で targets.json のパスを構築するようになったこと（HOME 直読み除去のバグ修正）を検証する。",
+    approach: "assert_cmd / 直接呼び出しで PLM_HOME・HOME を差し替え（--test-threads=1）、new() が返す config_path を確認する。既存の with_path() テストは維持。",
+    viewpoints: ["PLM_HOME 設定時に targets.json が PLM_HOME 配下になること", "HOME フォールバックの後方互換", "両方未設定時のドメインエラー型"],
+    status: "pending",
+    coverage: { fns: [1, 2], branches: [3, 3] },
+    gaps: ["<code>with_path()</code> 維持の明示テストは新規作成せず、既存テスト＋env の <code>with_root</code> で代替確認（FR-8）"],
+    cases: [
+      {
+        id: "TC-01",
+        title: "HOME のみで new() がデフォルトパスを構築",
+        cat: "normal",
+        prio: "high",
+        precond: "PLM_HOME unset、HOME を TempDir に向ける",
+        steps: ["PLM_HOME を remove_var", "HOME=TempDir を set_var", "TargetRegistry::new() を呼ぶ"],
+        input: "PLM_HOME=(unset)\nHOME=<TempDir>",
+        expected: "config_path == <TempDir>/.plm/targets.json",
+        throws: false,
+        coverage: [{ k: "関数", v: "new" }, { k: "分岐", v: "Ok パス", branch: true }],
+        ai: "FR-3 / NFR-3。後方互換（HOME 配下）を保証。",
+      },
+      {
+        id: "TC-02",
+        title: "PLM_HOME 設定下で new() が PLM_HOME 配下を使う",
+        cat: "normal",
+        prio: "high",
+        precond: "PLM_HOME=TempDir、HOME を別パスに設定",
+        steps: ["PLM_HOME=TempDir を set_var", "HOME=別 を set_var", "new() を呼ぶ"],
+        input: "PLM_HOME=<TempDirA>\nHOME=<TempDirB>",
+        expected: "config_path == <TempDirA>/.plm/targets.json（バグ修正の核心）",
+        throws: false,
+        coverage: [{ k: "関数", v: "new" }, { k: "分岐", v: "PLM_HOME 優先", branch: true }],
+        ai: "本 Issue の直接修正対象。旧実装では HOME 配下になっていた不整合を検出。",
+      },
+      {
+        id: "TC-03",
+        title: "両方未設定で new() がドメインエラーを返す",
+        cat: "error",
+        prio: "high",
+        precond: "PLM_HOME・HOME ともに unset",
+        steps: ["両方を remove_var", "new() を呼ぶ"],
+        input: "PLM_HOME=(unset)\nHOME=(unset)",
+        expected: "Err(PlmError::TargetRegistry(...))（General→map_err 変換）",
+        throws: true,
+        coverage: [{ k: "関数", v: "new" }, { k: "分岐", v: "Err map_err", branch: true }],
+        ai: "General から TargetRegistry へのマップでドメイン文脈が保持されることを確認。",
+      },
+    ],
+  },
+  {
+    name: "import-registry.rs",
+    dir: "src/import/",
+    lang: "Rust",
+    purpose: "ImportRegistry::new() が PlmPaths 経由で imports.json のパスを構築するようになったこと（HOME 直読み除去のバグ修正）を検証する。",
+    approach: "PLM_HOME・HOME を差し替え（--test-threads=1）、new() の config_path を確認する。既存 with_path() テストは維持。",
+    viewpoints: ["PLM_HOME 設定時に imports.json が PLM_HOME 配下になること", "HOME フォールバック", "両方未設定時の ImportRegistry エラー型"],
+    status: "pending",
+    coverage: { fns: [1, 2], branches: [3, 3] },
+    gaps: ["<code>with_path()</code> 維持の明示テストは新規作成せず既存で代替（FR-8）"],
+    cases: [
+      {
+        id: "TC-01",
+        title: "HOME のみで new() がデフォルトパスを構築",
+        cat: "normal",
+        prio: "high",
+        precond: "PLM_HOME unset、HOME を TempDir に向ける",
+        steps: ["PLM_HOME を remove_var", "HOME=TempDir を set_var", "ImportRegistry::new() を呼ぶ"],
+        input: "PLM_HOME=(unset)\nHOME=<TempDir>",
+        expected: "config_path == <TempDir>/.plm/imports.json",
+        throws: false,
+        coverage: [{ k: "関数", v: "new" }, { k: "分岐", v: "Ok パス", branch: true }],
+        ai: "FR-3 / NFR-3。後方互換を保証。",
+      },
+      {
+        id: "TC-02",
+        title: "PLM_HOME 設定下で new() が PLM_HOME 配下を使う",
+        cat: "normal",
+        prio: "high",
+        precond: "PLM_HOME=TempDir、HOME を別パスに設定",
+        steps: ["PLM_HOME=TempDir を set_var", "HOME=別 を set_var", "new() を呼ぶ"],
+        input: "PLM_HOME=<TempDirA>\nHOME=<TempDirB>",
+        expected: "config_path == <TempDirA>/.plm/imports.json",
+        throws: false,
+        coverage: [{ k: "関数", v: "new" }, { k: "分岐", v: "PLM_HOME 優先", branch: true }],
+        ai: "バグ修正の直接検証。旧実装での HOME 直読みを検出。",
+      },
+      {
+        id: "TC-03",
+        title: "両方未設定で new() がドメインエラーを返す",
+        cat: "error",
+        prio: "high",
+        precond: "PLM_HOME・HOME ともに unset",
+        steps: ["両方を remove_var", "new() を呼ぶ"],
+        input: "PLM_HOME=(unset)\nHOME=(unset)",
+        expected: "Err(PlmError::ImportRegistry(...))",
+        throws: true,
+        coverage: [{ k: "関数", v: "new" }, { k: "分岐", v: "Err map_err", branch: true }],
+        ai: "General→ImportRegistry マップでドメイン文脈が保たれることを確認。",
+      },
+    ],
+  },
+  {
+    name: "config.rs",
+    dir: "src/marketplace/",
+    lang: "Rust",
+    purpose: "MarketplaceConfig::load() が PlmPaths 経由で marketplaces.json を解決すること、および戻り値のエラー型 Result<_, String> が C-4 のとおり維持されることを検証する。",
+    approach: "PLM_HOME・HOME を差し替えて load() を呼び、読み込むパスを確認。map_err(|e| e.to_string()) 後も String エラー型であることを型で担保。既存 load_from() は維持。",
+    viewpoints: ["PLM_HOME 設定時に marketplaces.json が PLM_HOME 配下になること", "String エラー型の維持（C-4）", "load_from() の後方互換（FR-8）"],
+    status: "pending",
+    coverage: { fns: [2, 2], branches: [2, 2] },
+    gaps: ["壊れた JSON のパースエラーは本 Issue のスコープ外（既存 <code>load_from</code> の責務）"],
+    cases: [
+      {
+        id: "TC-01",
+        title: "PLM_HOME 設定下で load() が PLM_HOME 配下を読む",
+        cat: "normal",
+        prio: "high",
+        precond: "PLM_HOME=TempDir、HOME を別パスに設定。marketplaces.json は未作成",
+        steps: ["PLM_HOME=TempDir を set_var", "HOME=別 を set_var", "MarketplaceConfig::load() を呼ぶ"],
+        input: "PLM_HOME=<TempDirA>\nHOME=<TempDirB>",
+        expected: "<TempDirA>/.plm/marketplaces.json を読む（無ければ空 Config）",
+        throws: false,
+        coverage: [{ k: "関数", v: "load" }, { k: "分岐", v: "PLM_HOME 優先", branch: true }],
+        ai: "FR-3 バグ修正の直接検証。旧実装は HOME のみで PLM_HOME を無視していた。",
+      },
+      {
+        id: "TC-02",
+        title: "HOME のみで load() がデフォルトパスを読む",
+        cat: "normal",
+        prio: "high",
+        precond: "PLM_HOME unset、HOME=TempDir",
+        steps: ["PLM_HOME を remove_var", "HOME=TempDir を set_var", "load() を呼ぶ"],
+        input: "PLM_HOME=(unset)\nHOME=<TempDir>",
+        expected: "<TempDir>/.plm/marketplaces.json を読む",
+        throws: false,
+        coverage: [{ k: "関数", v: "load" }, { k: "分岐", v: "HOME フォールバック", branch: true }],
+        ai: "後方互換（NFR-3）。デフォルト動作が変わらないことを保証。",
+      },
+      {
+        id: "TC-03",
+        title: "両方未設定で load() が String エラーを返す",
+        cat: "error",
+        prio: "high",
+        precond: "PLM_HOME・HOME ともに unset",
+        steps: ["両方を remove_var", "load() を呼ぶ", "Err(String) であることを型と値で確認"],
+        input: "PLM_HOME=(unset)\nHOME=(unset)",
+        expected: "Err(String)（PlmError を map_err(|e| e.to_string()) で変換、C-4 維持）",
+        throws: true,
+        coverage: [{ k: "関数", v: "load" }, { k: "分岐", v: "Err→map_err(to_string)", branch: true }],
+        ai: "C-4 制約の核心。戻り値型 String を維持し呼び出し元 marketplace.rs を変更不要にする。",
+      },
+      {
+        id: "TC-04",
+        title: "load_from(path) が引き続き利用できる（FR-8）",
+        cat: "edge",
+        prio: "low",
+        precond: "任意の TempDir パスを直接注入",
+        steps: ["marketplaces.json を用意した TempDir パスを渡す", "load_from(path) を呼ぶ"],
+        input: "path = <TempDir>/.plm/marketplaces.json",
+        expected: "既存どおり Config を読み込める（API 破壊なし）",
+        throws: false,
+        coverage: [{ k: "関数", v: "load_from" }],
+        ai: "FR-8。テスト注入 API を壊していないことの回帰確認。",
+      },
+    ],
+  },
+  {
+    name: "cache.rs",
+    dir: "src/plugin/cache/",
+    lang: "Rust",
+    purpose: "PackageCache::new() が正解パターンから PlmPaths::new() 経由へ統一され、cache/plugins のパスを構築することを検証する（Cache エラー型維持）。",
+    approach: "PLM_HOME・HOME を差し替えて new() を呼び cache_dir を確認。create_dir_all が実行されるため TempDir を使用。既存 with_cache_dir() は維持。",
+    viewpoints: ["PLM_HOME 配下に cache/plugins が作られること", "HOME フォールバック", "両方未設定時の Cache エラー型", "with_cache_dir() の維持"],
+    status: "pending",
+    coverage: { fns: [2, 2], branches: [2, 2] },
+    gaps: ["create_dir_all の I/O 失敗（権限エラー等）はプラットフォーム依存のため自動テスト対象外（手動確認）"],
+    cases: [
+      {
+        id: "TC-01",
+        title: "PLM_HOME 設定下で new() が PLM_HOME 配下にキャッシュを作る",
+        cat: "normal",
+        prio: "high",
+        precond: "PLM_HOME=TempDir、HOME を別パスに設定",
+        steps: ["PLM_HOME=TempDir を set_var", "HOME=別 を set_var", "PackageCache::new() を呼ぶ"],
+        input: "PLM_HOME=<TempDirA>\nHOME=<TempDirB>",
+        expected: "cache_dir == <TempDirA>/.plm/cache/plugins（作成済み）",
+        throws: false,
+        coverage: [{ k: "関数", v: "new" }, { k: "分岐", v: "PLM_HOME 優先", branch: true }],
+        ai: "PlmPaths への統一確認。正解パターンが集約後も同一挙動であることを保証。",
+      },
+      {
+        id: "TC-02",
+        title: "両方未設定で new() が Cache エラーを返す",
+        cat: "error",
+        prio: "high",
+        precond: "PLM_HOME・HOME ともに unset",
+        steps: ["両方を remove_var", "new() を呼ぶ"],
+        input: "PLM_HOME=(unset)\nHOME=(unset)",
+        expected: "Err(PlmError::Cache(...))",
+        throws: true,
+        coverage: [{ k: "関数", v: "new" }, { k: "分岐", v: "Err map_err", branch: true }],
+        ai: "General→Cache マップでドメイン文脈が従来どおり保たれることを確認。",
+      },
+      {
+        id: "TC-03",
+        title: "with_cache_dir(path) が引き続き利用できる（FR-8）",
+        cat: "edge",
+        prio: "low",
+        precond: "任意の TempDir パスを直接注入",
+        steps: ["TempDir パスを with_cache_dir に渡す", "cache_dir を確認"],
+        input: "cache_dir = <TempDir>",
+        expected: "既存どおり構築でき API 破壊なし",
+        throws: false,
+        coverage: [{ k: "関数", v: "with_cache_dir" }],
+        ai: "FR-8。テスト注入 API の維持を回帰確認。",
+      },
+      {
+        id: "TC-04",
+        title: "HOME のみで new() が HOME 配下にキャッシュを作る",
+        cat: "normal",
+        prio: "med",
+        precond: "PLM_HOME unset、HOME=TempDir",
+        steps: ["PLM_HOME を remove_var", "HOME=TempDir を set_var", "new() を呼ぶ"],
+        input: "PLM_HOME=(unset)\nHOME=<TempDir>",
+        expected: "cache_dir == <TempDir>/.plm/cache/plugins",
+        throws: false,
+        coverage: [{ k: "関数", v: "new" }, { k: "分岐", v: "HOME フォールバック", branch: true }],
+        ai: "後方互換（NFR-3）。統一後も HOME デフォルトが不変であることを保証。",
+      },
+    ],
+  },
+  {
+    name: "marketplace-registry.rs",
+    dir: "src/marketplace/",
+    lang: "Rust",
+    purpose: "MarketplaceRegistry::new() が正解パターンから PlmPaths::new() 経由へ統一され、cache/marketplaces のパスを構築することを検証する。",
+    approach: "PLM_HOME・HOME を差し替えて new() を呼び cache_dir を確認。create_dir_all のため TempDir を使用。既存 with_cache_dir() は維持。",
+    viewpoints: ["PLM_HOME 配下に cache/marketplaces が作られること", "HOME フォールバック", "両方未設定時の Cache エラー型", "with_cache_dir() の維持"],
+    status: "pending",
+    coverage: { fns: [2, 2], branches: [2, 2] },
+    gaps: ["create_dir_all の I/O 失敗はプラットフォーム依存のため自動テスト対象外（手動確認）"],
+    cases: [
+      {
+        id: "TC-01",
+        title: "PLM_HOME 設定下で new() が PLM_HOME 配下にキャッシュを作る",
+        cat: "normal",
+        prio: "high",
+        precond: "PLM_HOME=TempDir、HOME を別パスに設定",
+        steps: ["PLM_HOME=TempDir を set_var", "HOME=別 を set_var", "MarketplaceRegistry::new() を呼ぶ"],
+        input: "PLM_HOME=<TempDirA>\nHOME=<TempDirB>",
+        expected: "cache_dir == <TempDirA>/.plm/cache/marketplaces（作成済み）",
+        throws: false,
+        coverage: [{ k: "関数", v: "new" }, { k: "分岐", v: "PLM_HOME 優先", branch: true }],
+        ai: "PlmPaths への統一確認。正解パターンが集約後も同一挙動であることを保証。",
+      },
+      {
+        id: "TC-02",
+        title: "両方未設定で new() が Cache エラーを返す",
+        cat: "error",
+        prio: "high",
+        precond: "PLM_HOME・HOME ともに unset",
+        steps: ["両方を remove_var", "new() を呼ぶ"],
+        input: "PLM_HOME=(unset)\nHOME=(unset)",
+        expected: "Err(PlmError::Cache(...))",
+        throws: true,
+        coverage: [{ k: "関数", v: "new" }, { k: "分岐", v: "Err map_err", branch: true }],
+        ai: "General→Cache マップでドメイン文脈が保たれることを確認。",
+      },
+      {
+        id: "TC-03",
+        title: "HOME のみで new() が HOME 配下にキャッシュを作る",
+        cat: "normal",
+        prio: "med",
+        precond: "PLM_HOME unset、HOME=TempDir",
+        steps: ["PLM_HOME を remove_var", "HOME=TempDir を set_var", "new() を呼ぶ"],
+        input: "PLM_HOME=(unset)\nHOME=<TempDir>",
+        expected: "cache_dir == <TempDir>/.plm/cache/marketplaces",
+        throws: false,
+        coverage: [{ k: "関数", v: "new" }, { k: "分岐", v: "HOME フォールバック", branch: true }],
+        ai: "後方互換（NFR-3）。統一後も HOME デフォルトが不変であることを保証。",
+      },
+      {
+        id: "TC-04",
+        title: "with_cache_dir(path) が引き続き利用できる（FR-8）",
+        cat: "edge",
+        prio: "low",
+        precond: "任意の TempDir パスを直接注入",
+        steps: ["TempDir パスを with_cache_dir に渡す", "cache_dir を確認"],
+        input: "cache_dir = <TempDir>",
+        expected: "既存どおり構築でき API 破壊なし",
+        throws: false,
+        coverage: [{ k: "関数", v: "with_cache_dir" }],
+        ai: "FR-8。テスト注入 API の維持を回帰確認。",
+      },
+    ],
+  },
+];
+
+const PLAN = {
+  strategy: {
+    purpose: "plm_root() / PlmPaths による PLM_HOME→HOME 解決の一元化と、全 5 レジストリ（PackageCache / MarketplaceRegistry / MarketplaceConfig / TargetRegistry / ImportRegistry）の統一を、パス解決ロジック中心の単体テストで保証する。PLM_HOME 設定時に全状態が {root}/.plm 配下に揃い分裂しないこと、未設定時は従来の $HOME/.plm と後方互換であることを検証範囲とする。",
+    scopeIn: [
+      "src/env.rs (plm_root / PlmPaths)",
+      "src/target/core/registry.rs (TargetRegistry::new)",
+      "src/import/registry.rs (ImportRegistry::new)",
+      "src/marketplace/config.rs (MarketplaceConfig::load)",
+      "src/plugin/cache/cache.rs (PackageCache::new)",
+      "src/marketplace/registry.rs (MarketplaceRegistry::new)",
+    ],
+    scopeOut: [
+      "src/target/core/paths.rs home_dir()（Personal 配置用・C-2 変更しない／回帰のみ）",
+      "src/plugin/cache/cleanup.rs resolve_home_dir()（同上）",
+      "config.toml 本体の実装（#333）",
+      "assert_cmd による E2E 統合テストは手動検証 4 項目で代替",
+    ],
+    levels: [
+      { label: "単体", pct: 90, note: "plm_root/PlmPaths と各 new()/load() のパス解決を単体で網羅（Pure Logic 中心）" },
+      { label: "結合", pct: 10, note: "env_test の 5 パス整合性テスト（with_root で横断確認）" },
+      { label: "E2E", pct: 0, note: "手動検証（PLM_HOME=/tmp/... plm target list 等）で代替" },
+    ],
+    viewpoints: [
+      "優先順位: PLM_HOME（有効時）> HOME（案 A）",
+      "フォールバック: 空文字・空白のみは無効扱い",
+      "相対パス拒否・両方無効時の明確なエラー",
+      "5 経路が同一 {root}/.plm 配下に揃う整合性（UC-1）",
+      "Personal 配置が PLM_HOME に引きずられない回帰（UC-3）",
+    ],
+    priority: "正常系の主要パス（PLM_HOME 優先・HOME フォールバック）と、相対パス拒否・両方未設定エラーは high。PlmPaths のパスアクセサ計算は med。既存 API 維持（with_root / with_cache_dir / load_from）と べき等性は low。",
+    exit: [
+      "cargo test が全テストグリーン（plm_root 系は --test-threads=1）",
+      "cargo clippy -- -D warnings が警告ゼロ",
+      "各要件 REQ に最低 1 ケースが紐づく（docs 更新の REQ-7 を除く）",
+      "手動検証 4 項目（PLM_HOME/HOME 切替・Personal 非引きずり）が完了",
+    ],
+  },
+  trace: [
+    { id: "REQ-1", req: "FR-1: plm_root() は PLM_HOME（有効時）→ HOME の順で解決", tcs: ["env/TC-01", "env/TC-02", "env/TC-03"], status: "ok" },
+    { id: "REQ-2", req: "FR-2: plm_dir() は {plm_root}/.plm を返す", tcs: ["env/TC-04"], status: "ok" },
+    { id: "REQ-3", req: "FR-3: 全 5 デフォルト構築が PlmPaths 経由になる", tcs: ["env/TC-05", "env/TC-06", "env/TC-07", "env/TC-08", "env/TC-09", "env/TC-16"], status: "ok" },
+    { id: "REQ-4", req: "FR-4: 空・空白の PLM_HOME は HOME へフォールバック", tcs: ["env/TC-10", "env/TC-11"], status: "ok" },
+    { id: "REQ-5", req: "FR-5: 相対パスの PLM_HOME / HOME を拒否してエラー", tcs: ["env/TC-12", "env/TC-13"], status: "ok" },
+    { id: "REQ-6", req: "FR-6: 両方無効なら明確なエラー", tcs: ["env/TC-14", "env/TC-15"], status: "ok" },
+    { id: "REQ-7", req: "FR-7: docs/reference/config.md・cache.md の PLM_HOME 説明を案 A に更新", tcs: [], status: "gap" },
+    { id: "REQ-8", req: "FR-8: with_cache_dir / with_path / load_from を維持", tcs: ["config/TC-04", "cache/TC-03", "marketplace-registry/TC-04"], status: "ok" },
+    { id: "REQ-9", req: "NFR-3 / UC-2: PLM_HOME 未設定時の実効パスは $HOME/.plm と同一（後方互換）", tcs: ["env/TC-02", "cache/TC-04"], status: "ok" },
+    { id: "REQ-10", req: "UC-3 / C-2: Personal 配置（home_dir）が PLM_HOME に引きずられない", tcs: ["env/TC-18"], status: "ok" },
+    { id: "REQ-11", req: "C-4: MarketplaceConfig の Result<_, String> エラー型を維持", tcs: ["config/TC-03"], status: "ok" },
+    { id: "REQ-12", req: "UC-1: 5 パスが同一 {root}/.plm 配下に揃う（分裂しない）", tcs: ["env/TC-16", "env/TC-17"], status: "ok" },
+    { id: "REQ-13", req: "FR-3: バグ 3 箇所（Target/Import/MarketplaceConfig）が PLM_HOME を尊重する", tcs: ["target-registry/TC-02", "import-registry/TC-02", "config/TC-01"], status: "ok" },
+  ],
+  testData: [
+    {
+      id: "FIX-1",
+      name: "TempDir 検証用ルート",
+      desc: "with_root() に渡す並列安全な検証ルート。環境変数を触らずパス計算を確定する。",
+      code: "let root = TempDir::new().unwrap();\nlet paths = PlmPaths::with_root(root.path().to_path_buf());",
+      usedBy: ["env/TC-04", "env/TC-05", "env/TC-06", "env/TC-07", "env/TC-08", "env/TC-09", "env/TC-16"],
+    },
+    {
+      id: "FIX-2",
+      name: "環境変数スワップ（PLM_HOME/HOME）",
+      desc: "PLM_HOME と HOME を別 TempDir に差し替える。並列競合回避のため --test-threads=1 で実行。",
+      code: "let plm_home = TempDir::new().unwrap();\nlet home = TempDir::new().unwrap();\nstd::env::set_var(\"PLM_HOME\", plm_home.path());\nstd::env::set_var(\"HOME\", home.path());",
+      usedBy: ["env/TC-01", "env/TC-03", "env/TC-18", "target-registry/TC-01", "target-registry/TC-02", "import-registry/TC-01", "import-registry/TC-02", "marketplace-registry/TC-01", "config/TC-01", "cache/TC-01"],
+    },
+    {
+      id: "FIX-3",
+      name: "両方 unset",
+      desc: "PLM_HOME・HOME を両方 remove し、エラー系のフィクスチャとする。",
+      code: "std::env::remove_var(\"PLM_HOME\");\nstd::env::remove_var(\"HOME\");",
+      usedBy: ["env/TC-14", "target-registry/TC-03", "import-registry/TC-03", "marketplace-registry/TC-02", "config/TC-03", "cache/TC-02"],
+    },
+  ],
+};
+
+</script>
+
+<!-- ===== 以下 2つのスクリプト（ヘルパー / レンダラ）は固定。編集しない ===== -->
+<script>
+(function () {
+  const CAT = { normal: "正常系", error: "異常系", boundary: "境界値", edge: "エッジケース" };
+  const PRIO = { high: "高", med: "中", low: "低" };
+
+  const esc = (s) =>
+    String(s).replace(/[&<>]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;" }[c]));
+
+  // 'price/TC-01' -> chip
+  const tcRef = (s) => `<span class="tc-ref">${esc(s)}</span>`;
+
+  // nav icons (simple line icons)
+  const ICON = {
+    strategy: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="8"/><circle cx="12" cy="12" r="3.2"/><path d="M12 1.5V4M12 20v2.5M1.5 12H4M20 12h2.5"/></svg>',
+    matrix: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><rect x="3.5" y="3.5" width="7" height="7" rx="1.5"/><rect x="13.5" y="3.5" width="7" height="7" rx="1.5"/><rect x="3.5" y="13.5" width="7" height="7" rx="1.5"/><rect x="13.5" y="13.5" width="7" height="7" rx="1.5"/></svg>',
+    data: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="12" cy="5.5" rx="7.5" ry="3"/><path d="M4.5 5.5v6c0 1.7 3.4 3 7.5 3s7.5-1.3 7.5-3v-6"/><path d="M4.5 11.5v6c0 1.7 3.4 3 7.5 3s7.5-1.3 7.5-3v-6"/></svg>',
+    mock: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><rect x="3.5" y="3.5" width="17" height="17" rx="3"/><path d="M5 19L19 5"/></svg>',
+    trace: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="6" cy="6" r="2.6"/><circle cx="18" cy="18" r="2.6"/><path d="M8.4 7.6l7.2 8.8"/><path d="M16 6h4v4"/></svg>',
+  };
+
+  let view = { type: "plan", key: "strategy" };
+
+  function catCounts(file) {
+    const c = { normal: 0, error: 0, boundary: 0, edge: 0 };
+    file.cases.forEach((x) => (c[x.cat] += 1));
+    return c;
+  }
+  const covPct = ([a, b]) => (b === 0 ? 0 : Math.round((a / b) * 100));
+
+  // ---------------- Master ----------------
+  const PLAN_NAV = [
+    { key: "strategy", label: "テスト戦略" },
+    { key: "trace", label: "要件トレーサビリティ" },
+  ];
+
+  function renderMaster() {
+    const root = document.getElementById("master-scroll");
+
+    const planItems = PLAN_NAV.map((n) => {
+      const active = view.type === "plan" && view.key === n.key ? "active" : "";
+      const tag = n.key === "trace" ? '<span class="nav-tag">1</span>' : "";
+      return `<button class="nav-item ${active}" data-type="plan" data-key="${n.key}">
+        <span class="nav-ico">${ICON[n.key]}</span>
+        <span class="nav-label">${n.label}</span>${tag}
+      </button>`;
+    }).join("");
+
+    const fileItems = FILES.map((f, i) => {
+      const c = catCounts(f);
+      const hasGap = f.gaps && f.gaps.length;
+      const bars = ["normal", "error", "boundary", "edge"]
+        .filter((k) => c[k] > 0)
+        .map((k) => `<div class="seg ${k}" style="flex:${c[k]}" title="${CAT[k]} ${c[k]}件"></div>`)
+        .join("");
+      const warn = hasGap ? `<span class="fi-warn">未カバー ${f.gaps.length}</span>` : "";
+      const active = view.type === "file" && view.index === i ? "active" : "";
+      return `<button class="file-item ${active}" data-type="file" data-index="${i}">
+        <div class="fi-top">
+          <span class="fi-dot ${hasGap ? "pending" : "done"}"></span>
+          <span class="fi-name">${esc(f.name)}</span>
+          <span class="fi-cases">${f.cases.length} cases</span>
+        </div>
+        <div class="fi-path">${esc(f.dir)}</div>
+        <div class="fi-desc">${esc(f.purpose)}</div>
+        <div class="fi-bars">${bars}${warn}</div>
+      </button>`;
+    }).join("");
+
+    root.innerHTML = `
+      <div class="nav-group">
+        <div class="nav-grouphead"><h2>計画全体</h2></div>
+        <div class="nav-items">${planItems}</div>
+      </div>
+      <div class="nav-group">
+        <div class="nav-grouphead"><h2>テスト対象ファイル</h2><span class="count">${FILES.length}</span></div>
+        <div class="nav-items">${fileItems}</div>
+      </div>`;
+
+    root.querySelectorAll("[data-type]").forEach((el) => {
+      el.addEventListener("click", () => {
+        view = el.dataset.type === "plan"
+          ? { type: "plan", key: el.dataset.key }
+          : { type: "file", index: +el.dataset.index };
+        renderMaster();
+        window.__renderDetail();
+        document.getElementById("detail").scrollTop = 0;
+      });
+    });
+  }
+
+  // expose pieces for the rest of the file
+  window.__rev = { CAT, PRIO, esc, tcRef, catCounts, covPct, getView: () => view, ICON };
+
+  window.__renderMaster = renderMaster;
+})();
+
+</script>
+<script>
+(function () {
+  const { CAT, PRIO, esc, tcRef, catCounts, covPct, getView, ICON } = window.__rev;
+
+  // ---------------- case card ----------------
+  function renderCase(c) {
+    const cov = c.coverage
+      .map((x) => `<span class="cov-chip ${x.branch ? "branch" : ""}"><span class="ck">${esc(x.k)}</span>${esc(x.v)}</span>`)
+      .join("");
+    const steps = c.steps.map((s) => `<li>${esc(s)}</li>`).join("");
+    return `
+      <article class="case" data-cat="${c.cat}">
+        <div class="case-head">
+          <span class="case-id">${esc(c.id)}</span>
+          <span class="case-title">${esc(c.title)}</span>
+          <span class="badge ${c.cat}">${CAT[c.cat]}</span>
+          <span class="prio ${c.prio}">優先度 ${PRIO[c.prio]}</span>
+        </div>
+        <div class="case-body">
+          <div class="field steps-field">
+            <div class="field-label">前提条件・手順</div>
+            <div class="precond"><b>前提:</b> ${esc(c.precond)}</div>
+            <ol class="steps">${steps}</ol>
+          </div>
+          <div class="field">
+            <div class="field-label">入力値 / 期待される結果</div>
+            <div class="io">
+              <div class="io-block in"><div class="io-tag">入力値</div><pre>${esc(c.input)}</pre></div>
+              <div class="io-arrow">↓</div>
+              <div class="io-block out ${c.throws ? "throws" : ""}"><div class="io-tag">${c.throws ? "期待される例外" : "期待される結果"}</div><pre>${esc(c.expected)}</pre></div>
+            </div>
+          </div>
+          <div class="field full">
+            <div class="field-label">カバレッジ — 検証する関数 / 分岐</div>
+            <div class="cov-chips">${cov}</div>
+          </div>
+          <div class="ai">
+            <div class="ai-mark"></div>
+            <div class="ai-body">
+              <div class="ai-label">AI がこのケースを提案した理由</div>
+              <p>${esc(c.ai)}</p>
+            </div>
+          </div>
+        </div>
+      </article>`;
+  }
+
+  // ---------------- per-file: 網羅性マトリクス ----------------
+  function fileMatrixPanel(f) {
+    const fns = [];
+    f.cases.forEach((c) => c.coverage.forEach((x) => { if (x.k === "関数" && !fns.includes(x.v)) fns.push(x.v); }));
+    let filled = 0, total = 0;
+    const rows = fns.map((fn) => {
+      const cells = ["normal", "error", "boundary", "edge"].map((cat) => {
+        const ids = f.cases.filter((c) => c.cat === cat && c.coverage.some((x) => x.k === "関数" && x.v === fn)).map((c) => c.id);
+        total += 1;
+        if (ids.length) { filled += 1; return `<td class="cell"><span class="mx-cell-ids">${ids.map((id) => `<span class="mx-id ${cat}">${esc(id)}</span>`).join("")}</span></td>`; }
+        return `<td class="cell"><span class="mx-empty"></span></td>`;
+      }).join("");
+      return `<tr><td class="fn">${esc(fn)}</td>${cells}</tr>`;
+    }).join("");
+    return `
+      <section class="panel">
+        <div class="panel-title"><span class="pn">${ICON.matrix}</span>網羅性マトリクス<span class="ptsub">関数 × 観点 — 空欄(<span class="mx-empty"></span>)はその観点のケースが無い箇所</span></div>
+        <table class="dtable matrix">
+          <thead><tr><th>関数</th><th class="coltype">正常系</th><th class="coltype">異常系</th><th class="coltype">境界値</th><th class="coltype">エッジケース</th></tr></thead>
+          <tbody>${rows}</tbody>
+        </table>
+      </section>`;
+  }
+
+  // ---------------- per-file: テストデータ ----------------
+  function fileDataPanel(f) {
+    const base = f.name.replace(/\.[^.]+$/, "");
+    const items = PLAN.testData.filter((d) => d.usedBy.some((u) => u.startsWith(base + "/")));
+    const body = items.length
+      ? `<div class="data-grid">${items.map((d) => `
+          <div class="data-card">
+            <div class="dh"><span class="dname">${esc(d.name)}</span><span class="did">${esc(d.id)}</span></div>
+            <div class="ddesc">${esc(d.desc)}</div>
+            <pre class="code">${esc(d.code)}</pre>
+            <div class="usedby"><span class="ub-lb">使用:</span>${d.usedBy.map(tcRef).join("")}</div>
+          </div>`).join("")}</div>`
+      : `<p class="muted-note">このファイル専用の共有テストデータはありません。</p>`;
+    return `
+      <section class="panel">
+        <div class="panel-title"><span class="pn">${ICON.data}</span>テストデータ<span class="ptsub">ケース間で共有する固定データ（フィクスチャ）</span></div>
+        ${body}
+      </section>`;
+  }
+
+  // ---------------- per-file: テスト方針 ----------------
+  function fileApproachPanel(f) {
+    const vps = (f.viewpoints || []).map((v) => `<li>${esc(v)}</li>`).join("");
+    return `
+      <section class="panel">
+        <div class="panel-title"><span class="pn">${ICON.strategy}</span>テスト方針</div>
+        <p class="approach">${esc(f.approach || "")}</p>
+        ${vps ? `<div class="field-label" style="margin:15px 0 9px">重点的に確認する観点</div><ul class="bullets">${vps}</ul>` : ""}
+      </section>`;
+  }
+
+  // ---------------- file view ----------------
+  let activeFilter = "all";
+  function renderFile(detail) {
+    const f = FILES[getView().index];
+    const gapBlock = f.gaps && f.gaps.length
+      ? `<div class="cov-gap">
+           <div class="gtitle">レビューで要確認 — 未カバーの疑い</div>
+           <div class="gitems">${f.gaps.map((g) => "・" + g).join("<br>")}</div>
+         </div>`
+      : `<div class="cov-gap" style="background:var(--green-soft);border-color:var(--green-border)">
+           <div class="gtitle" style="color:var(--green)">主要な関数・分岐をカバー</div>
+           <div class="gitems">明らかな未カバー箇所は検出されていません。</div>
+         </div>`;
+
+    const counts = catCounts(f);
+    const filters = ["all", "normal", "error", "boundary", "edge"].map((k) => {
+      const n = k === "all" ? f.cases.length : counts[k];
+      const label = k === "all" ? "すべて" : CAT[k];
+      const dot = k === "all" ? "" : `<span class="dot ${k}"></span>`;
+      return `<button class="chip ${k === activeFilter ? "active" : ""}" data-filter="${k}">${dot}${label} <span style="opacity:.6">${n}</span></button>`;
+    }).join("");
+    const visible = f.cases.filter((c) => activeFilter === "all" || c.cat === activeFilter);
+
+    detail.innerHTML = `
+      <div class="detail-inner">
+        <section class="file-header">
+          <div class="fh-pathrow">
+            <span class="fh-path"><span class="dir">${esc(f.dir)}</span>${esc(f.name)}</span>
+            <span class="lang-tag">${esc(f.lang)}</span>
+          </div>
+          <div class="fh-desc-label">このファイルの役割</div>
+          <p class="fh-desc">${esc(f.purpose)}</p>
+          <div class="cov-grid">
+            <div class="cov-block cov-fns">
+              <div class="ctitle"><span>関数カバレッジ</span><b>${f.coverage.fns[0]}/${f.coverage.fns[1]}</b></div>
+              <div class="ctrack"><div class="cfill" style="width:${covPct(f.coverage.fns)}%"></div></div>
+            </div>
+            <div class="cov-block cov-br">
+              <div class="ctitle"><span>分岐カバレッジ</span><b>${f.coverage.branches[0]}/${f.coverage.branches[1]}</b></div>
+              <div class="ctrack"><div class="cfill" style="width:${covPct(f.coverage.branches)}%"></div></div>
+            </div>
+            ${gapBlock}
+          </div>
+        </section>
+
+        ${fileApproachPanel(f)}
+        ${fileMatrixPanel(f)}
+        ${fileDataPanel(f)}
+
+        <div class="cases-bar">
+          <h3>テストケース <span class="n">${visible.length}/${f.cases.length}</span></h3>
+          <div class="filters">${filters}</div>
+        </div>
+        <div class="cases">${visible.map(renderCase).join("")}</div>
+      </div>`;
+
+    detail.querySelectorAll(".chip").forEach((el) => {
+      el.addEventListener("click", () => { activeFilter = el.dataset.filter; renderFile(detail); });
+    });
+  }
+
+  // ---------------- plan-level views ----------------
+  function viewHead(kicker, title, lead) {
+    return `<div class="view-head"><div class="view-kicker">${kicker}</div><div class="view-title">${title}</div>${lead ? `<p class="view-lead">${lead}</p>` : ""}</div>`;
+  }
+
+  function renderStrategy() {
+    const s = PLAN.strategy;
+    const levels = s.levels.map((l) => `
+      <div class="levelbar">
+        <span>${l.label}</span>
+        <div class="lv-track"><div class="lv-fill" style="width:${l.pct}%"></div></div>
+        <span class="lv-val">${l.pct}%</span>
+        <span class="lv-note" style="grid-column:2/4">${esc(l.note)}</span>
+      </div>`).join("");
+    return viewHead("計画全体", "テスト戦略", "この計画で「何を・どこまで・どう」検証するかの全体方針。ファイル個別の方針は各ファイルのページに記載。") + `
+      <div class="panel">
+        <div class="doc-row"><div class="dl">目的</div><div class="dc">${esc(s.purpose)}</div></div>
+        <div class="doc-row"><div class="dl">スコープ</div><div class="dc">
+          <div class="scope-grid">
+            <div class="scope-box in"><div class="sb-h">対象</div><ul>${s.scopeIn.map((x) => `<li><code>${esc(x)}</code></li>`).join("")}</ul></div>
+            <div class="scope-box out"><div class="sb-h">対象外</div><ul>${s.scopeOut.map((x) => `<li>${esc(x)}</li>`).join("")}</ul></div>
+          </div>
+        </div></div>
+        <div class="doc-row"><div class="dl">テストレベルと比重</div><div class="dc"><div class="levelbars">${levels}</div></div></div>
+        <div class="doc-row"><div class="dl">テスト観点（重点）</div><div class="dc"><ul>${s.viewpoints.map((v) => `<li>${esc(v)}</li>`).join("")}</ul></div></div>
+        <div class="doc-row"><div class="dl">優先度の方針</div><div class="dc">${esc(s.priority)}</div></div>
+        <div class="doc-row"><div class="dl">終了基準</div><div class="dc"><ul>${s.exit.map((v) => `<li>${esc(v)}</li>`).join("")}</ul></div></div>
+      </div>`;
+  }
+
+  function renderMock() {
+    const m = PLAN.mock;
+    const rows = m.rows.map((r) => `
+      <tr>
+        <td><b>${esc(r.dep)}</b></td>
+        <td><span class="pill ${r.kind}">${esc(r.policy)}</span></td>
+        <td style="color:var(--text-2)">${esc(r.why)}</td>
+      </tr>`).join("");
+    return viewHead("計画全体", "モック戦略", "依存ごとに「実物 / 偽物」のどちらで検証するかの方針。") + `
+      <div class="callout"><div class="ci"></div><div class="ct"><b>原則：</b> ${esc(m.principle)}</div></div>
+      <div class="panel" style="padding:14px 16px">
+        <table class="dtable">
+          <thead><tr><th>依存対象</th><th>方針</th><th>理由</th></tr></thead>
+          <tbody>${rows}</tbody>
+        </table>
+      </div>`;
+  }
+
+  function renderTrace() {
+    const rows = PLAN.trace.map((t) => `
+      <tr>
+        <td><span class="reqid">${esc(t.id)}</span></td>
+        <td>${esc(t.req)}</td>
+        <td>${t.tcs.length ? t.tcs.map(tcRef).join("") : '<span style="color:var(--text-3)">—</span>'}</td>
+        <td>${t.status === "ok" ? '<span class="pill ok">カバー</span>' : '<span class="pill gap">ギャップ</span>'}</td>
+      </tr>`).join("");
+    const gaps = PLAN.trace.filter((t) => t.status === "gap").length;
+    return viewHead("計画全体", "要件トレーサビリティ", "受け入れ条件（要件）と、それを満たすテストケースの対応表。どの要件が未検証かを一目で把握する。") + `
+      <div class="callout"><div class="ci"></div><div class="ct">${PLAN.trace.length} 件中 <b>${PLAN.trace.length - gaps}</b> 件をカバー、<b>${gaps}</b> 件にギャップ。<code>REQ-8</code>（二重課金防止／冪等性）は対応ケースが無く、追加検討が必要。</div></div>
+      <div class="panel" style="padding:14px 16px">
+        <table class="dtable">
+          <thead><tr><th style="width:80px">要件</th><th>受け入れ条件</th><th style="width:180px">対応テストケース</th><th style="width:110px">状況</th></tr></thead>
+          <tbody>${rows}</tbody>
+        </table>
+      </div>`;
+  }
+
+  const PLAN_RENDER = { strategy: renderStrategy, trace: renderTrace };
+
+  function renderDetail() {
+    const detail = document.getElementById("detail");
+    const v = getView();
+    if (v.type === "file") { renderFile(detail); return; }
+    detail.innerHTML = `<div class="detail-inner">${PLAN_RENDER[v.key]()}</div>`;
+  }
+
+  function renderStats() {
+    const totalCases = FILES.reduce((s, f) => s + f.cases.length, 0);
+    const gaps = FILES.reduce((s, f) => s + (f.gaps ? f.gaps.length : 0), 0);
+    document.getElementById("stat-files").textContent = FILES.length;
+    document.getElementById("stat-cases").textContent = totalCases;
+    document.getElementById("stat-pending").textContent = gaps;
+    const fa = FILES.reduce((s, f) => s + f.coverage.fns[0], 0);
+    const fb = FILES.reduce((s, f) => s + f.coverage.fns[1], 0);
+    const pct = fb === 0 ? 0 : Math.round((fa / fb) * 100);
+    const fill = document.getElementById("cov-fill");
+    const pctEl = document.getElementById("cov-pct");
+    if (fill) fill.style.width = pct + "%";
+    if (pctEl) pctEl.textContent = pct + "%";
+  }
+
+  window.__renderDetail = renderDetail;
+  renderStats();
+  window.__renderMaster();
+  renderDetail();
+})();
+
+</script>
+
+</body>
+</html>

--- a/docs/specs/001-plm-home-unification/understanding-quiz-plan.html
+++ b/docs/specs/001-plm-home-unification/understanding-quiz-plan.html
@@ -1,0 +1,590 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>実装前 理解度クイズ — PLM_HOME / HOME 解決の一元化</title>
+<style>
+:root {
+  --bg: oklch(0.985 0.003 255);
+  --surface: #ffffff;
+  --surface-2: oklch(0.978 0.004 255);
+  --surface-3: oklch(0.965 0.005 255);
+  --border: oklch(0.925 0.005 255);
+  --border-strong: oklch(0.875 0.007 255);
+  --text: oklch(0.28 0.012 262);
+  --text-2: oklch(0.52 0.012 262);
+  --text-3: oklch(0.65 0.011 262);
+  --accent: oklch(0.55 0.16 264);
+  --accent-2: oklch(0.5 0.16 264);
+  --accent-soft: oklch(0.955 0.025 264);
+  --accent-border: oklch(0.86 0.06 264);
+  --green: oklch(0.5 0.11 156);
+  --green-soft: oklch(0.955 0.04 156);
+  --green-border: oklch(0.85 0.07 156);
+  --rose: oklch(0.54 0.16 22);
+  --rose-soft: oklch(0.957 0.03 22);
+  --rose-border: oklch(0.87 0.06 22);
+  --amber: oklch(0.52 0.1 72);
+  --amber-soft: oklch(0.955 0.05 82);
+  --amber-border: oklch(0.85 0.08 82);
+  --r-sm: 6px; --r-md: 9px; --r-lg: 13px;
+  --shadow-sm: 0 1px 2px oklch(0.4 0.02 262 / 0.05);
+  --shadow-md: 0 4px 14px oklch(0.4 0.02 262 / 0.08), 0 1px 3px oklch(0.4 0.02 262 / 0.05);
+  --mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+* { box-sizing: border-box; margin: 0; padding: 0; }
+body {
+  font-family: "Noto Sans JP", system-ui, sans-serif;
+  background: var(--bg); color: var(--text);
+  font-size: 14.5px; line-height: 1.7; -webkit-font-smoothing: antialiased;
+}
+.wrap { max-width: 820px; margin: 0 auto; padding: 40px 24px 96px; }
+
+/* ---- Header ---- */
+.hero {
+  background: var(--surface); border: 1px solid var(--border);
+  border-radius: var(--r-lg); box-shadow: var(--shadow-sm);
+  padding: 26px 28px; margin-bottom: 22px;
+}
+.hero .kind {
+  display: inline-flex; align-items: center; gap: 7px;
+  font-family: var(--mono); font-size: 11px; font-weight: 700;
+  text-transform: uppercase; letter-spacing: 0.08em;
+  color: var(--accent-2); background: var(--accent-soft);
+  border: 1px solid var(--accent-border); padding: 3px 10px; border-radius: 20px;
+}
+.hero .kind::before { content: ""; width: 7px; height: 7px; border-radius: 50%; background: var(--accent); }
+.hero h1 { font-size: 25px; font-weight: 700; letter-spacing: -0.01em; margin: 13px 0 8px; line-height: 1.3; }
+.hero .intro { font-size: 14.5px; color: var(--text-2); line-height: 1.75; max-width: 680px; }
+.hero .sources { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 15px; }
+.hero .src { font-family: var(--mono); font-size: 11.5px; color: var(--text-2); background: var(--surface-3); border: 1px solid var(--border); padding: 2px 9px; border-radius: 5px; }
+.hero .advisory {
+  margin-top: 16px; display: flex; gap: 11px; align-items: flex-start;
+  background: var(--amber-soft); border: 1px solid var(--amber-border);
+  border-radius: var(--r-md); padding: 11px 14px; font-size: 12.5px; color: var(--text-2); line-height: 1.6;
+}
+.hero .advisory b { color: var(--text); }
+
+/* ---- Section (解説 + 設問) ---- */
+.section { margin-bottom: 26px; }
+.section-head { display: flex; align-items: baseline; gap: 10px; margin: 30px 0 10px; }
+.section-head .sn { font-family: var(--mono); font-size: 12px; font-weight: 700; color: var(--accent-2); }
+.section-head h2 { font-size: 18px; font-weight: 700; letter-spacing: -0.01em; }
+.brief {
+  background: var(--surface); border: 1px solid var(--border); border-left: 3px solid var(--accent);
+  border-radius: 0 var(--r-md) var(--r-md) 0; padding: 14px 18px; margin-bottom: 16px;
+  font-size: 13.5px; color: var(--text-2); line-height: 1.75;
+}
+.brief b { color: var(--text); }
+
+/* ---- Question card ---- */
+.q {
+  background: var(--surface); border: 1px solid var(--border);
+  border-radius: var(--r-lg); box-shadow: var(--shadow-sm);
+  padding: 20px 22px; margin-bottom: 14px; transition: border-color .14s, box-shadow .14s;
+}
+.q.correct { border-color: var(--green-border); box-shadow: 0 0 0 1px var(--green-border); }
+.q.wrong { border-color: var(--rose-border); box-shadow: 0 0 0 1px var(--rose-border); }
+.q-head { display: flex; align-items: center; gap: 9px; margin-bottom: 5px; flex-wrap: wrap; }
+.q-id { font-family: var(--mono); font-size: 11.5px; font-weight: 700; color: var(--text-3); }
+.q-type { font-size: 10.5px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.05em; padding: 2px 8px; border-radius: 20px; color: var(--accent-2); background: var(--accent-soft); border: 1px solid var(--accent-border); }
+.q-prompt { font-size: 15px; font-weight: 600; color: var(--text); line-height: 1.6; margin: 8px 0 6px; }
+.q-intent { font-size: 12px; color: var(--text-3); margin-bottom: 13px; }
+.q-intent::before { content: "◎ 意図: "; color: var(--accent-2); font-weight: 700; }
+
+/* choices */
+.opts { display: flex; flex-direction: column; gap: 8px; }
+.opt {
+  display: flex; align-items: flex-start; gap: 11px;
+  border: 1px solid var(--border-strong); border-radius: var(--r-md);
+  padding: 11px 14px; cursor: pointer; transition: background .1s, border-color .1s;
+  font-size: 14px; line-height: 1.5;
+}
+.q:not(.done) .opt:hover { background: var(--surface-2); }
+.opt input { margin-top: 3px; accent-color: var(--accent); flex: 0 0 auto; width: 16px; height: 16px; }
+.opt .ok-mark, .opt .no-mark { margin-left: auto; font-weight: 700; font-size: 12px; display: none; flex: 0 0 auto; }
+.opt.is-answer { border-color: var(--green-border); background: var(--green-soft); }
+.opt.is-answer .ok-mark { display: inline; color: var(--green); }
+.opt.is-picked-wrong { border-color: var(--rose-border); background: var(--rose-soft); }
+.opt.is-picked-wrong .no-mark { display: inline; color: var(--rose); }
+
+/* boolean */
+.bool { display: flex; gap: 10px; }
+.bool label {
+  flex: 1; text-align: center; border: 1px solid var(--border-strong); border-radius: var(--r-md);
+  padding: 12px; cursor: pointer; font-weight: 700; font-size: 14px; transition: background .1s, border-color .1s;
+}
+.q:not(.done) .bool label:hover { background: var(--surface-2); }
+.bool input { display: none; }
+.bool input:checked + span { color: var(--accent-2); }
+.bool label:has(input:checked) { border-color: var(--accent); background: var(--accent-soft); }
+.bool label.is-answer { border-color: var(--green-border); background: var(--green-soft); }
+.bool label.is-picked-wrong { border-color: var(--rose-border); background: var(--rose-soft); }
+
+/* 回答済み（ロック済み）の設問 */
+.q.done .opt, .q.done .bool label { cursor: default; }
+.q.done .opt:not(.is-answer):not(.is-picked-wrong),
+.q.done .bool label:not(.is-answer):not(.is-picked-wrong) { opacity: 0.55; }
+.q.done .bool label.is-answer { border-color: var(--green-border); background: var(--green-soft); }
+.q.done .bool label.is-answer span { color: var(--green); }
+.q.done .bool label.is-picked-wrong { border-color: var(--rose-border); background: var(--rose-soft); }
+.q.done .bool label.is-picked-wrong span { color: var(--rose); }
+
+/* order */
+.order-list { display: flex; flex-direction: column; gap: 7px; }
+.order-item {
+  display: flex; align-items: center; gap: 11px;
+  border: 1px solid var(--border-strong); border-radius: var(--r-md); padding: 10px 12px; background: var(--surface);
+  font-size: 14px;
+}
+.order-item .oi-idx { font-family: var(--mono); font-size: 12px; font-weight: 700; color: var(--text-3); width: 20px; flex: 0 0 auto; }
+.order-item .oi-text { flex: 1; line-height: 1.5; }
+.order-item .oi-move { display: flex; gap: 4px; flex: 0 0 auto; }
+.order-item.correct-pos { border-color: var(--green-border); background: var(--green-soft); }
+.order-item.wrong-pos { border-color: var(--rose-border); background: var(--rose-soft); }
+.mv {
+  font-family: inherit; border: 1px solid var(--border-strong); background: var(--surface);
+  color: var(--text-2); width: 26px; height: 26px; border-radius: var(--r-sm); cursor: pointer; font-size: 13px;
+}
+.mv:hover { background: var(--surface-2); border-color: var(--text-3); }
+.mv:disabled { opacity: 0.3; cursor: default; }
+.order-confirm-row { margin-top: 10px; display: flex; justify-content: flex-end; }
+.order-ref { margin-top: 10px; background: var(--green-soft); border: 1px solid var(--green-border); border-radius: var(--r-md); padding: 10px 14px; }
+.order-ref .or-head { font-size: 10.5px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em; color: var(--green); margin-bottom: 5px; }
+.order-ref .or-item { display: flex; gap: 10px; padding: 3px 0; font-size: 13.5px; }
+.order-ref .or-item .oi-idx { font-family: var(--mono); font-size: 12px; font-weight: 700; color: var(--green); width: 20px; flex: 0 0 auto; }
+
+/* explain */
+.explain { display: none; margin-top: 13px; border-top: 1px dashed var(--border-strong); padding-top: 12px; font-size: 13px; color: var(--text-2); line-height: 1.7; }
+.explain.show { display: block; }
+.explain .el { font-size: 10.5px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em; color: var(--accent-2); margin-bottom: 4px; }
+
+/* ---- Footer / score ---- */
+.actions { position: sticky; bottom: 0; margin-top: 30px; display: flex; align-items: center; gap: 14px; background: var(--surface); border: 1px solid var(--border); border-radius: var(--r-lg); box-shadow: var(--shadow-md); padding: 15px 20px; }
+.progress-lbl { font-size: 13px; color: var(--text-2); }
+.btn {
+  font-family: inherit; font-size: 14px; font-weight: 600; border: 1px solid var(--border-strong);
+  background: var(--surface); color: var(--text); padding: 10px 18px; border-radius: var(--r-sm);
+  cursor: pointer; transition: background .12s, border-color .12s;
+}
+.btn:hover { background: var(--surface-2); }
+.btn.primary { background: var(--accent); border-color: var(--accent); color: #fff; box-shadow: var(--shadow-sm); }
+.btn.primary:hover { background: var(--accent-2); }
+.score { margin-left: auto; text-align: right; }
+.score .num { font-family: var(--mono); font-size: 22px; font-weight: 700; letter-spacing: -0.01em; }
+.score .num.pass { color: var(--green); }
+.score .num.fail { color: var(--rose); }
+.score .lbl { font-size: 11px; color: var(--text-3); text-transform: uppercase; letter-spacing: 0.06em; }
+.verdict { margin-top: 16px; border-radius: var(--r-md); padding: 15px 18px; font-size: 14px; line-height: 1.7; display: none; }
+.verdict.show { display: block; }
+.verdict.pass { background: var(--green-soft); border: 1px solid var(--green-border); }
+.verdict.fail { background: var(--rose-soft); border: 1px solid var(--rose-border); }
+.verdict b { font-weight: 700; }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <header class="hero" id="hero"></header>
+  <div id="sections"></div>
+  <div class="verdict" id="verdict"></div>
+  <div class="actions">
+    <div class="progress-lbl" id="progress-lbl">未回答</div>
+    <button class="btn" id="reset">リセット</button>
+    <div class="score"><div class="num" id="score-num">—</div><div class="lbl">スコア</div></div>
+  </div>
+</div>
+
+<!-- ============================================================
+     DATA — このスクリプトだけをエージェントが実データで置き換える
+     ============================================================ -->
+<script>
+/*
+ * ============================================================================
+ *  spec-driven-dev のクイズ生成へ:
+ *  この QUIZ を、requirements.md / implementation-plan / hearing-notes を材料に
+ *  「設計の意図・理由」を問う実装前クイズの実データで丸ごと置き換えること。
+ *  HTMLは書かない — データだけ書けばよい。
+ * ----------------------------------------------------------------------------
+ *  QUIZ.meta:
+ *    title    : 機能名
+ *    intro    : このクイズが何を確認するか（1〜2文）。設計意図の自己確認である旨。
+ *    sources  : string[]  出題の材料（例: ["requirements.md","implementation-plan.md","hearing-notes.md"]）
+ *    passLine : 合格ライン（0〜1。既定 0.8）
+ *  QUIZ.sections[]: 出題ブロック
+ *    title    : ブロック名（例 "設計判断", "データモデル", "制約"）
+ *    brief    : 解説文（この設計判断の背景・前提。散文でHTML可: <b> のみ）
+ *    questions[]:
+ *      id      : "Q1" など
+ *      type    : "choice"(4択) | "boolean"(YES/NO) | "order"(並べ替え)
+ *      prompt  : 設問文
+ *      intent  : この設問が炙り出したい設計意図・unknown（1文）
+ *      explain : 正解の理由・誤答がなぜ違うか（散文）
+ *      -- type:"choice" の場合 --
+ *      options : string[]  4択（3〜5個）
+ *      answer  : number   正解の options インデックス（0始まり）
+ *      -- type:"boolean" の場合 --
+ *      answer  : boolean  正解（true=YES / false=NO）
+ *      -- type:"order" の場合 --
+ *      items   : string[]  「正しい順序」で列挙する（表示時は自動でシャッフルされる）
+ *
+ *  出題方針（quiz-design.md 準拠）:
+ *    - 「なぜこの設計にしたか」「このデータモデル/型にした理由」
+ *      「この制約が満たされないと何が壊れるか」「変わりやすい箇所の意図」を問う
+ *    - 誤答(distractor)は "もっともらしいが違う" 別設計・別解釈にする
+ *    - 各セクションの brief に、その設計判断の背景を先に解説してから問う
+ *    - 設問文・選択肢は挙動・役割の言葉で書く（関数名・変数名前提の設問にしない。
+ *      識別子は必要なときに括弧書きの補助として添えるに留める）
+ *    - 出題前に quiz-design.md の「設問セルフレビュー」で検査し、該当設問は修正または破棄する
+ * ============================================================================
+ */
+const QUIZ = {
+  meta: {
+    title: "PLM_HOME / HOME 解決の一元化",
+    intro: "状態ルート分裂を直す計画の設計意図を、実装に渡す前に自分の言葉で説明できるか確認するクイズです。落ちた設問は、まだ固まっていない論点の候補です。",
+    sources: ["requirements.md", "implementation-plan.md", "hearing-notes.md"],
+    passLine: 0.8,
+  },
+  sections: [
+    {
+      title: "セマンティクスと境界",
+      brief: "本計画では <b>PLM_HOME は HOME の代替</b>（案 A）です。実効パスは常に <b>{root}/.plm</b>。Personal 配置用のユーザー HOME 解決は別物で、本 Issue の対象外です。",
+      questions: [
+        {
+          id: "Q1",
+          type: "choice",
+          prompt: "PLM_HOME=/tmp/alt のとき、PLM の状態ディレクトリ（targets.json などが置かれる場所）はどれか？",
+          intent: "案 A（HOME 代替）と案 B（CARGO_HOME 型）の違いを理解しているか",
+          options: [
+            "/tmp/alt/.plm",
+            "/tmp/alt",
+            "$HOME/.plm（PLM_HOME は無視）",
+            "/tmp/alt/.plm/.plm"
+          ],
+          answer: 0,
+          explain: "案 A では PLM_HOME が HOME の代わりになり、その下に .plm を付ける。案 B なら /tmp/alt 自体が .plm 相当になるが、本計画は採用しない。"
+        },
+        {
+          id: "Q2",
+          type: "boolean",
+          prompt: "PLM_HOME を設定したとき、Personal スコープの Codex Skills 配置先も PLM_HOME 配下へ移すべきか？",
+          intent: "ユーザー HOME と PLM 状態ルートの境界を混同していないか",
+          answer: false,
+          explain: "NO。Personal 配置はユーザー HOME（paths.rs の home_dir）側。PLM_HOME に寄せると実際の Codex が見る ~/.codex と乖離する。本 Issue では変更しない。"
+        },
+        {
+          id: "Q3",
+          type: "choice",
+          prompt: "ドキュメントに「デフォルト: ~/.plm」とだけ書いてある場合、利用者が export PLM_HOME=~/.plm すると現行実装互換（案 A）では何が起きるか？",
+          intent: "docs と実装の意味論食い違いリスクを理解しているか",
+          options: [
+            "~/.plm/.plm 配下に状態が作られる",
+            "~/.plm 配下に正しく収まる",
+            "エラーになる",
+            "HOME が優先され影響なし"
+          ],
+          answer: 0,
+          explain: "案 A は PLM_HOME の下にさらに .plm を付ける。docs を信じた設定は二重 .plm になるため、本計画では docs を案 A 表現に直す。"
+        }
+      ]
+    },
+    {
+      title: "データモデルとエラー",
+      brief: "共有リゾルバは <b>General</b> を返し、呼び出し側がドメイン別バリアントへ map_err する。MarketplaceConfig だけは従来どおり String エラーを維持する。",
+      questions: [
+        {
+          id: "Q4",
+          type: "choice",
+          prompt: "共有のルート解決関数が返すエラー型として、計画が選んだものはどれか？",
+          intent: "実在しない Config バリアントを使わない理由と General 選択を理解しているか",
+          options: [
+            "PlmError::General（呼び出し側で Cache / TargetRegistry 等へマップ）",
+            "PlmError::Config（新規バリアントを追加）",
+            "常に PlmError::Cache のみ",
+            "anyhow::Error"
+          ],
+          answer: 0,
+          explain: "PlmError::Config は存在しない。共有リゾルバは General を返し、各レジストリが map_err で文脈を付ける。"
+        },
+        {
+          id: "Q5",
+          type: "boolean",
+          prompt: "本 Issue で MarketplaceConfig::load の戻り値型を Result<_, PlmError> に変更する必要があるか？",
+          intent: "C-4 制約（String 維持）を覚えているか",
+          answer: false,
+          explain: "NO。C-4 で String を維持。内部で PlmPaths::new を呼び map_err(|e| e.to_string()) するだけ。"
+        },
+        {
+          id: "Q6",
+          type: "order",
+          prompt: "デフォルト構築時にパスが解決される順序を並べ替えよ（正しい順）",
+          intent: "データフローの理解",
+          items: [
+            "Registry / Config の new() または load()",
+            "PlmPaths::new()",
+            "plm_root() が PLM_HOME → HOME を解決",
+            "アクセサで .plm 配下の具体パスを返す"
+          ],
+          explain: "入口は各レジストリ。共有は PlmPaths::new → plm_root。最後に targets_json 等のアクセサ。"
+        }
+      ]
+    },
+    {
+      title: "制約と壊れ方",
+      brief: "相対パス拒否・両方未設定エラー・後方互換（未設定時は $HOME/.plm）が守るべき契約です。",
+      questions: [
+        {
+          id: "Q7",
+          type: "choice",
+          prompt: "PLM_HOME=relative/path のとき、計画上の正しい挙動は？",
+          intent: "FR-5 相対パス拒否を理解しているか",
+          options: [
+            "エラーを返す（絶対パス必須）",
+            "カレントディレクトリからの相対として受理する",
+            "HOME にフォールバックする",
+            "literal \"~\" に置き換える"
+          ],
+          answer: 0,
+          explain: "相対パスは CWD 依存の状態分裂を招くため拒否。cleanup 側の絶対パス必須方針とも整合。"
+        },
+        {
+          id: "Q8",
+          type: "boolean",
+          prompt: "PLM_HOME 未設定の利用者にとって、本修正後の実効パス（$HOME/.plm）は現状から変わるか？",
+          intent: "後方互換（NFR-3）の理解",
+          answer: false,
+          explain: "NO。未設定時は従来どおり HOME 配下の .plm。破壊的変更は PLM_HOME 設定時のみ（レジストリが追従するようになる）。"
+        }
+      ]
+    }
+  ]
+};
+</script>
+
+<!-- ===== 以下 レンダラ / 採点ロジックは固定。編集しない ===== -->
+<script>
+(function () {
+  const esc = (s) => String(s == null ? "" : s).replace(/[&<>]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;" }[c]));
+  const rich = (s) => esc(s).replace(/&lt;b&gt;/g, "<b>").replace(/&lt;\/b&gt;/g, "</b>");
+  const TYPE_LABEL = { choice: "4択", boolean: "YES / NO", order: "並べ替え" };
+
+  // order 設問のシャッフル: Fisher-Yates。固定パターンだと並びを機械的に復元できてしまうため
+  // 毎回ランダムにし、恒等順列（正解順のままの表示）は引き直す
+  function displayOrder(n) {
+    const arr = Array.from({ length: n }, (_, i) => i);
+    if (n < 2) return arr;
+    do {
+      for (let i = arr.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [arr[i], arr[j]] = [arr[j], arr[i]];
+      }
+    } while (arr.every((v, i) => v === i));
+    return arr;
+  }
+
+  // question runtime state
+  const Q = [];
+  QUIZ.sections.forEach((sec) => sec.questions.forEach((q) => Q.push(q)));
+
+  // qid -> 初回回答の正誤。回答済みの設問はロックされ、答えの変更・再回答はできない
+  let results = {};
+
+  // ---- render hero ----
+  function renderHero() {
+    const m = QUIZ.meta;
+    const src = (m.sources || []).map((s) => `<span class="src">${esc(s)}</span>`).join("");
+    document.getElementById("hero").innerHTML = `
+      <span class="kind">実装前クイズ · Plan → Impl ゲート</span>
+      <h1>${esc(m.title)}</h1>
+      <p class="intro">${rich(m.intro)}</p>
+      <div class="sources">${src}</div>
+      <div class="advisory">
+        <div><b>これは advisory ゲートです。</b>合否は自己申告で、機械的なブロックはしません。
+        各設問は<b>回答した時点で正誤と解説が表示され、答えは変更できません</b>。
+        合否は初回の通し回答で判断してください（リセットは解説を読んだ後の再学習用です）。
+        落ちた設問がある＝設計がまだ自分の中で固まっていない箇所なので、<b>実装を始める前に</b>計画を見直してください。</div>
+      </div>`;
+  }
+
+  // ---- render questions ----
+  function renderSections() {
+    const root = document.getElementById("sections");
+    let html = "";
+    QUIZ.sections.forEach((sec, si) => {
+      html += `<div class="section">
+        <div class="section-head"><span class="sn">SECTION ${si + 1}</span><h2>${esc(sec.title)}</h2></div>
+        ${sec.brief ? `<div class="brief">${rich(sec.brief)}</div>` : ""}
+        ${sec.questions.map(renderQ).join("")}
+      </div>`;
+    });
+    root.innerHTML = html;
+    wireAnswers();
+  }
+
+  function renderQ(q) {
+    let body = "";
+    if (q.type === "choice") {
+      body = `<div class="opts">` + q.options.map((o, i) =>
+        `<label class="opt" data-i="${i}"><input type="radio" name="${q.id}" value="${i}"><span>${esc(o)}</span><span class="ok-mark">✓ 正解</span><span class="no-mark">✕</span></label>`
+      ).join("") + `</div>`;
+    } else if (q.type === "boolean") {
+      body = `<div class="bool">
+        <label data-v="true"><input type="radio" name="${q.id}" value="true"><span>YES</span></label>
+        <label data-v="false"><input type="radio" name="${q.id}" value="false"><span>NO</span></label>
+      </div>`;
+    } else if (q.type === "order") {
+      const ord = displayOrder(q.items.length);
+      body = `<div class="order-list" data-qid="${q.id}">` + ord.map((srcIdx, pos) =>
+        `<div class="order-item" data-src="${srcIdx}">
+           <span class="oi-idx">${pos + 1}</span>
+           <span class="oi-text">${esc(q.items[srcIdx])}</span>
+           <span class="oi-move"><button class="mv up" title="上へ">▲</button><button class="mv down" title="下へ">▼</button></span>
+         </div>`).join("") + `</div>
+      <div class="order-confirm-row"><button class="btn order-confirm" data-qid="${q.id}">この順で回答する</button></div>`;
+    }
+    return `<div class="q" id="q-${q.id}" data-type="${q.type}">
+      <div class="q-head"><span class="q-id">${esc(q.id)}</span><span class="q-type">${TYPE_LABEL[q.type]}</span></div>
+      <div class="q-prompt">${esc(q.prompt)}</div>
+      ${q.intent ? `<div class="q-intent">${esc(q.intent)}</div>` : ""}
+      ${body}
+      <div class="explain" id="ex-${q.id}"><div class="el">解説</div>${rich(q.explain)}</div>
+    </div>`;
+  }
+
+  // 回答イベントの配線: choice / boolean は選択した瞬間、order は「この順で回答する」で確定
+  function wireAnswers() {
+    Q.forEach((q) => {
+      if (q.type === "choice" || q.type === "boolean") {
+        document.querySelectorAll(`input[name="${q.id}"]`).forEach((inp) => {
+          inp.addEventListener("change", () => answer(q));
+        });
+      }
+    });
+    document.querySelectorAll(".order-confirm").forEach((btn) => {
+      btn.addEventListener("click", () => {
+        const q = Q.find((x) => x.id === btn.dataset.qid);
+        if (q) answer(q);
+      });
+    });
+    wireOrder();
+  }
+
+  function wireOrder() {
+    document.querySelectorAll(".order-list").forEach((list) => {
+      list.addEventListener("click", (e) => {
+        const btn = e.target.closest(".mv");
+        if (!btn) return;
+        const item = btn.closest(".order-item");
+        if (btn.classList.contains("up") && item.previousElementSibling) list.insertBefore(item, item.previousElementSibling);
+        if (btn.classList.contains("down") && item.nextElementSibling) list.insertBefore(item.nextElementSibling, item);
+        reindex(list);
+      });
+      reindex(list);
+    });
+  }
+  function reindex(list) {
+    [...list.children].forEach((el, i) => { el.querySelector(".oi-idx").textContent = i + 1; });
+  }
+
+  // ---- grading ----
+  function gradeChoice(q) {
+    const picked = document.querySelector(`input[name="${q.id}"]:checked`);
+    const card = document.getElementById(`q-${q.id}`);
+    card.querySelectorAll(".opt").forEach((o) => {
+      const i = +o.dataset.i;
+      if (i === q.answer) o.classList.add("is-answer");
+      if (picked && +picked.value === i && i !== q.answer) o.classList.add("is-picked-wrong");
+    });
+    return picked ? +picked.value === q.answer : false;
+  }
+  function gradeBool(q) {
+    const picked = document.querySelector(`input[name="${q.id}"]:checked`);
+    const card = document.getElementById(`q-${q.id}`);
+    card.querySelectorAll(".bool label").forEach((l) => {
+      const v = l.dataset.v === "true";
+      if (v === q.answer) l.classList.add("is-answer");
+      if (picked && (picked.value === "true") === v && v !== q.answer) l.classList.add("is-picked-wrong");
+    });
+    return picked ? (picked.value === "true") === q.answer : false;
+  }
+  function gradeOrder(q) {
+    const list = document.querySelector(`.order-list[data-qid="${q.id}"]`);
+    let ok = true;
+    [...list.children].forEach((el, pos) => {
+      const correct = +el.dataset.src === pos;
+      el.classList.add(correct ? "correct-pos" : "wrong-pos");
+      if (!correct) ok = false;
+    });
+    if (!ok) {
+      const ref = document.createElement("div");
+      ref.className = "order-ref";
+      ref.innerHTML = `<div class="or-head">✓ 正解の順序</div>` +
+        q.items.map((t, i) => `<div class="or-item"><span class="oi-idx">${i + 1}</span><span>${esc(t)}</span></div>`).join("");
+      list.after(ref);
+    }
+    return ok;
+  }
+
+  // 即時フィードバック: 回答した瞬間にその設問だけ採点・解説表示し、以降ロックする。
+  // スコアは常に初回の回答を反映する（正解が出るまで選び直す抜け道を作らない）
+  function answer(q) {
+    if (q.id in results) return;
+    let ok = false;
+    if (q.type === "choice") ok = gradeChoice(q);
+    else if (q.type === "boolean") ok = gradeBool(q);
+    else if (q.type === "order") ok = gradeOrder(q);
+    results[q.id] = ok;
+    const card = document.getElementById(`q-${q.id}`);
+    card.classList.add("done", ok ? "correct" : "wrong");
+    card.querySelectorAll("input").forEach((i) => { i.disabled = true; });
+    card.querySelectorAll(".mv").forEach((b) => { b.disabled = true; });
+    const row = card.querySelector(".order-confirm-row");
+    if (row) row.remove();
+    document.getElementById(`ex-${q.id}`).classList.add("show");
+    updateProgress();
+    if (Object.keys(results).length === Q.length) showVerdict();
+  }
+
+  function updateProgress() {
+    const answered = Object.keys(results).length;
+    const correct = Object.values(results).filter(Boolean).length;
+    document.getElementById("score-num").textContent = `${correct}/${Q.length}`;
+    document.getElementById("progress-lbl").textContent =
+      answered === Q.length ? "全問回答済み" : `残り ${Q.length - answered} 問`;
+  }
+
+  function showVerdict() {
+    const total = Q.length;
+    const correct = Object.values(results).filter(Boolean).length;
+    const ratio = total ? correct / total : 0;
+    const passLine = QUIZ.meta.passLine == null ? 0.8 : QUIZ.meta.passLine;
+    const pass = ratio >= passLine;
+    const numEl = document.getElementById("score-num");
+    numEl.textContent = `${correct}/${total}`;
+    numEl.className = "num " + (pass ? "pass" : "fail");
+    const v = document.getElementById("verdict");
+    v.className = "verdict show " + (pass ? "pass" : "fail");
+    v.innerHTML = pass
+      ? `<b>合格 (${Math.round(ratio * 100)}%)</b> — 設計の意図を自分の言葉で説明できています。実装セッションに進んでよいでしょう。間違えた設問があれば、その箇所だけ計画を読み直してください。`
+      : `<b>不合格 (${Math.round(ratio * 100)}% / 合格ライン ${Math.round(passLine * 100)}%)</b> — 赤い設問は設計がまだ固まっていない箇所です。実装を始める前に、その論点を計画・要件で詰め直すことをおすすめします。`;
+    v.scrollIntoView({ behavior: "smooth", block: "nearest" });
+  }
+
+  // リセットは解説を読んだ後の再学習用。合否は初回の通し回答で判断する
+  function reset() {
+    results = {};
+    renderSections();
+    const numEl = document.getElementById("score-num");
+    numEl.textContent = "—"; numEl.className = "num";
+    document.getElementById("progress-lbl").textContent = `全 ${Q.length} 問 / 未回答`;
+    document.getElementById("verdict").className = "verdict";
+  }
+
+  renderHero();
+  renderSections();
+  document.getElementById("progress-lbl").textContent = `全 ${Q.length} 問 / 未回答`;
+  document.getElementById("reset").addEventListener("click", reset);
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Issue #344 向けに spec-driven-dev ワークフローで実装計画を作成しました。

- Spec フォルダ: `docs/specs/001-plm-home-unification/`
- 作業コピー: `.plugin-workspace/.specs/001-plm-home-unification/`（gitignore）

## 確定した設計判断

| 項目 | 決定 |
|------|------|
| `PLM_HOME` セマンティクス | **案 A（HOME 代替）** — 実効パス `{root}/.plm` |
| 対象 | 5 レジストリのデフォルト構築を `PlmPaths` に集約 |
| 対象外 | `paths.rs` / `cleanup.rs`（Personal 配置用ユーザー HOME） |
| エラー | `plm_root` → `PlmError::General`、呼び出し側でドメイン別 `map_err` |
| `MarketplaceConfig` | `Result<_, String>` 維持（C-4） |

## 生成ファイル

| ファイル | 用途 |
|----------|------|
| [implementation-plan.md](docs/specs/001-plm-home-unification/implementation-plan.md) | 実装計画（システム図・変更案・DoD） |
| [tasks.md](docs/specs/001-plm-home-unification/tasks.md) | TDD タスクリスト |
| [test-cases.html](docs/specs/001-plm-home-unification/test-cases.html) | テスト網羅性レビュー UI（36 ケース） |
| [requirements.md](docs/specs/001-plm-home-unification/requirements.md) | ユースケース・要件 |
| [understanding-quiz-plan.html](docs/specs/001-plm-home-unification/understanding-quiz-plan.html) | 実装前理解度クイズ |

## Related

- Refs #344
- 事前レビュー: PR #389 / `docs/reviews/issue-344-plm-home.md`
- Related #333

## Test plan

- [ ] `implementation-plan.md` の設計判断をレビュー
- [ ] ブラウザで `test-cases.html` を開き網羅性を確認
- [ ] 必要なら `understanding-quiz-plan.html` で設計意図を自己確認
- [ ] 承認後、PLANNING / guard を削除して実装へ

## 実装開始（承認後）

```bash
rm .plugin-workspace/.specs/.guard/cloud-agent-344 \
   .plugin-workspace/.specs/001-plm-home-unification/PLANNING
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2d11e414-3459-47d8-ab00-410b5ba679df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2d11e414-3459-47d8-ab00-410b5ba679df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

