### PR TITLE
docs: Issue #339 配置リテラル集約の計画

### DIFF
--- a/docs/architecture/core-design.md
+++ b/docs/architecture/core-design.md
@@ -314,3 +314,7 @@ fn open_browser(url: &str) -> Result<()> {
 | `scope_support` | kind × scope の薄い `ScopeSupport` 表 |
 
 サポート判定の単一真実源は `Target::can_place_scope`（`supports_scope` はこれを呼ぶ）。各 env は `CAPABILITIES` 定数とパス用 `LAYOUT` 定数を持ち、振る舞いフック（Hook 上書きガード等）は各 `impl` に残す。
+
+### 配置リテラル集約（#339・計画中）
+
+#338 は骨格抽出まで。`"skills"` / `"SKILL.md"` / instruction ファイル名 / 環境ルート（`".codex"` 等）はなお `ComponentKind::plural()`・`scan/constants`・ヘルパ/cleanup ベアリテラルに分散している。表示用 `plural()`（例: `"commands"`）と配置用 subdir（例: Copilot `"prompts"`）の分離を含む集約計画は [placement-literals-refactor](../placement-literals-refactor/README.md) を参照。

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,6 +36,7 @@ GitHubからAI開発環境向けのプラグインをダウンロードし、複
 - [Architecture](./architecture/overview.md) - 内部アーキテクチャ
 - [Reference](./reference/config.md) - 技術リファレンス
 - [Roadmap](./roadmap.md) - 実装状況・ロードマップ
+- [配置リテラル集約計画 (#339)](./placement-literals-refactor/README.md) - ディレクトリ名・ファイル名の単一真実源化（計画）
 
 ## 対応規格
 

--- a/docs/placement-literals-refactor/README.md
+++ b/docs/placement-literals-refactor/README.md
@@ -1,0 +1,42 @@
+# 配置リテラル集約（#339）— 計画
+
+> **ステータス**: 計画フェーズ（未実装）  
+> **関連 Issue**: [#339](https://github.com/DIO0550/plugin-manager/issues/339)  
+> **前提**: [#338](https://github.com/DIO0550/plugin-manager/issues/338) Target Layout 集約（roadmap ✅ 完了）  
+> **方針**: 表示用 `plural()` と配置用パス断片を分離し、文字列の単一真実源を `ComponentKind` / `Target`（LAYOUT）に寄せる
+
+## ファイル
+
+| ファイル | 説明 |
+|----------|------|
+| [hearing-notes.md](./hearing-notes.md) | スコープ・設計論点・ユーザー確認事項 |
+| [exploration-report.md](./exploration-report.md) | 現状の 3+ 系統並立（行番号付き） |
+| [requirements.md](./requirements.md) | UC / FR / NFR / CON |
+| [implementation-plan.md](./implementation-plan.md) | 実装計画 Phase A〜F |
+| [tasks.md](./tasks.md) | TDD タスクリスト |
+
+## Phase 概要
+
+| Phase | 内容 |
+|-------|------|
+| A | リテラル棚卸し固定・責務境界の確定（コード変更なし） |
+| B | ターゲット非依存定数を `ComponentKind`（または共有 const）へ集約 |
+| C | ヘルパ / deployment / scan を B の定数消費に切替 |
+| D | Target 依存パス（instruction / env root / Command subdir）を公開し `cleanup`・`placement` が消費 |
+| E | wire / import の表示・入出力キーを `plural()` 呼び出しへ |
+| F | docs / 死コード削除 / 不変条件テスト |
+
+## #338 との関係
+
+```text
+#338: 制御フロー・サポート判定の骨格抽出（完了）
+#339: 配置文字列の単一真実源（本計画）
+```
+
+#338 で各 env に薄い `LAYOUT` / `CAPABILITIES` と `placed/` ヘルパができた。本 Issue はその **中身のリテラル** と、scan / cleanup / wire に残る **二重定義** を解消する。
+
+## 実装開始の前提
+
+- 振る舞い不変（配置パス・スキャン結果・クリーンアップ対象を変えない）
+- ビッグバン禁止（Phase 単位で独立コミット）
+- Issue 原文の行番号は #338 後にドリフトしている → [exploration-report.md](./exploration-report.md) §9 を正とする

--- a/docs/placement-literals-refactor/exploration-report.md
+++ b/docs/placement-literals-refactor/exploration-report.md
@@ -3,7 +3,8 @@
 > **日付**: 2026-07-25  
 > **対象**: [#339](https://github.com/DIO0550/plugin-manager/issues/339)  
 > **関連**: [#338](https://github.com/DIO0550/plugin-manager/issues/338)（Target Layout 集約 — roadmap 上 ✅ 完了、GitHub Issue は OPEN のまま）  
-> **調査 HEAD**: `71f0803`（`docs: Issue #338 Target Layout 宣言的ケイパビリティ集約の計画 (#394)` — 実装抽出込み）
+> **調査 HEAD**: `71f0803`（`docs: Issue #338 Target Layout 宣言的ケイパビリティ集約の計画 (#394)` — 実装抽出込み）  
+> **計画セット**: 本ファイルは [README.md](./README.md) 配下の探索正本。要件・実装計画・タスクと合わせて読む。
 
 ## 要約
 

--- a/docs/placement-literals-refactor/hearing-notes.md
+++ b/docs/placement-literals-refactor/hearing-notes.md
@@ -1,0 +1,82 @@
+# Hearing Notes: 配置ディレクトリ名・ファイル名リテラル集約 (Issue #339)
+
+## 目的
+
+コンポーネント配置のディレクトリ名・ファイル名という中核ドメイン知識が、(a) `ComponentKind::plural()`、(b) `scan/constants.rs`、(c) ヘルパ / env / cleanup / wire のベアリテラル、で並立している状態を解消する。ターゲット追加やパス規約変更を **1 系統の修正** にし、「掃除されないゴミ」「スキャン漏れ」系バグを構造的に防ぐ。
+
+## スコープ
+
+- **種別**: リファクタリング（振る舞い不変）
+- **影響範囲**: `src/component/`、`src/scan/`、`src/target/placed/`、`src/target/env/`、`src/plugin/cache/cleanup.rs`、`src/commands/{info,list,deploy}/`
+- **優先度**: 中〜高（#96 Claude Code 追加前に文字列二重定義を減らしたい。#338 hearing でも「並行可」と明記）
+- **対象外**:
+  - #338 で完了した制御フロー骨格の再設計
+  - 配置パス規約そのものの変更（例: Copilot を `commands/` に移す等）
+  - プラグインマニフェストのスキーマ変更
+
+## Issue 提案の要約（原文）
+
+1. `ComponentKind` に `placement_subdir(target?)` / `file_suffix()` / `skill_manifest()` を持たせ、`scan/constants.rs` は削除または re-export。`plural()` は表示専用と明記。
+2. 各 `Target` に `instruction_filename()` を持たせ、`scan/placement.rs` の除外集合は `all_targets()` から構築。
+3. 環境ディレクトリ名は `Target`（または `TargetKind` キーの const テーブル）から一元提供し、`cleanup.rs` はそれを消費する。
+
+## #338 完了後の前提（原文との差分）
+
+| Issue 作成時（2026-07-04） | 現行（#338 後） |
+|---------------------------|-----------------|
+| env 内に `CODEX_SUBDIR` 等の const | **廃止** → 各 env の private `LAYOUT` |
+| `SKILL.md` が各 env に散在 | 多くは `filter_skill_dir`（`filter.rs`）へ集約。ただしヘルパ内リテラルは残存 |
+| 制御フローが 5 重コピペ | `placed/` ヘルパ + `LAYOUT` / `CAPABILITIES` |
+| `plural()` vs Copilot `"prompts"` | **未解決**（本 Issue の核心） |
+
+原文の提案は方向として妥当。実装は **#338 の LAYOUT / ヘルパを消費側に寄せる** 形が、新規 DSL を増やさず安全。
+
+## 推奨する責務境界（レビュー結論）
+
+Issue 提案の `placement_subdir(target?)` はシグネチャが曖昧になりやすい。次の分割を推奨する。
+
+### A. ターゲット非依存（`ComponentKind` または共有 const）
+
+| 概念 | 例 | 置き場所 |
+|------|-----|----------|
+| 表示用複数形 | `"skills"`, `"commands"` | 既存 `plural()`（表示専用と doc 明記） |
+| スキルマニフェスト | `"SKILL.md"` | `ComponentKind::skill_manifest()` または共有 const |
+| ファイルサフィックス | `".agent.md"`, `".prompt.md"` | `ComponentKind::file_suffix()`（該当 kind のみ `Some`） |
+| プラグイン内デフォルト subdir | `"skills"` 等 | `plural()` と同一ソース（`scan/constants` の `DEFAULT_*` は re-export） |
+
+### B. ターゲット依存（`Target` / `LAYOUT`）
+
+| 概念 | 例 | 置き場所 |
+|------|-----|----------|
+| 配置サブディレクトリ | Copilot Command → `"prompts"`、Cursor Command → `"commands"` | `LAYOUT` または `Target::component_subdir(kind)` |
+| Instruction ファイル名 | `"AGENTS.md"` / `"copilot-instructions.md"` / `"GEMINI.md"` | `LAYOUT.instruction_file` → trait 公開 |
+| 環境ルート | `".codex"`, `".github"`, `".cursor"` | `LAYOUT` → cleanup が消費できる公開 API |
+
+**ポイント**: `placement_subdir` を `ComponentKind` に載せるより、**デフォルトは `plural()`、例外だけ Target が上書き** する方が Issue の意図（表示と配置の分離）に沿い、かつ #338 LAYOUT と整合する。
+
+## 品質要件
+
+- **振る舞い不変**: 配置パス、`list_placed` 結果、cleanup 対象ディレクトリを変えない
+- **テスト**: 既存 `*_test.rs` の期待値変更なし。不変条件テスト（「ヘルパが ComponentKind 定数を使う」「INSTRUCTION_FILE_NAMES ⊆ all_targets の instruction」等）を追加
+- **TDD**: Red → Green → Refactor
+- **テスト配置**: `foo_test.rs` 分離（リポジトリ規約）
+- **外向き CLI**: 変更なし。JSON キーは既に `plural()` 相当なので、ベア配列を `plural()` 呼び出しに置換するだけ（出力同一）
+
+## ユーザー確認が必要な点
+
+実装着手前に次を確定したい（計画レビュー向け）。
+
+1. **API 公開範囲**: `instruction_filename()` / env root を `Target` trait の公開メソッドにするか、`pub(crate)` の `TargetKind` テーブルに留めるか  
+   - 推奨: まず `pub(crate)` テーブル or LAYOUT 公開ヘルパ。trait 拡張は消費側が dyn Target 経由で必要な場合のみ。
+2. **`placement_subdir` の置き場**: Issue 原文どおり `ComponentKind` + target 引数か、本メモの「デフォルト plural + Target 上書き」か  
+   - 推奨: 後者（#338 LAYOUT と整合）
+3. **`Scope::description()`**: 全ターゲットを列挙する静的文字列に更新するか、動的生成に変えるか、現状の要約のまま残すか  
+   - 推奨: Phase E で現行ターゲットを含む静的文言に更新（動的化は過剰）
+4. **`scan/constants.rs`**: 削除して `ComponentKind` 経由に統一か、薄い re-export に残すか  
+   - 推奨: Phase B で re-export 化し、消費者移行完了後に Phase F で削除可否を判断
+
+## 追加コンテキスト
+
+- 関連: #338（骨格完了）、#96（Claude Code — 新ターゲット追加時に本 Issue の効果が効く）
+- 探索の正本: [exploration-report.md](./exploration-report.md)
+- Copilot Command の `"prompts"` は仕様上の差分であり、バグではない。集約後も **表示 `"commands"` ≠ 配置 `"prompts"`** を型/API で表現し続けること

--- a/docs/placement-literals-refactor/implementation-plan.md
+++ b/docs/placement-literals-refactor/implementation-plan.md
@@ -1,0 +1,150 @@
+# 配置リテラル集約 — 実装計画
+
+**関連 Issue**: [#339](https://github.com/DIO0550/plugin-manager/issues/339)  
+**方針**: 表示用 `plural()` と配置用パス断片を分離し、#338 の LAYOUT / `placed/` ヘルパを定数の消費側に揃える
+
+## ユーザーレビューが必要な点
+
+> **NOTE**
+> - 振る舞い不変のリファクタリング。CLI 仕様変更なし。
+> - Phase A〜F の段階移行。ビッグバンなし。
+> - Copilot の配置 `"prompts"` と表示 `"commands"` の差は仕様として維持する。
+> - Issue 原文の `ComponentKind::placement_subdir(target?)` は、本計画では **「デフォルトは plural 相当、例外は Target/LAYOUT」** に具体化（hearing-notes 参照）。
+
+---
+
+## システム図
+
+### 現状（3+ 系統並立）
+
+```text
+┌─────────────────────┐   ┌──────────────────────┐   ┌──────────────────────────┐
+│ ComponentKind       │   │ scan/constants.rs    │   │ ベアリテラル群            │
+│  plural()           │   │  SKILL_MANIFEST      │   │  placement_helpers       │
+│  "skills"/"commands"│   │  DEFAULT_*_DIR       │   │  env LAYOUT / list_placed│
+└─────────────────────┘   │  AGENT_SUFFIX ...    │   │  cleanup_specs           │
+                          └──────────────────────┘   │  wire / import           │
+                                                     │  INSTRUCTION_FILE_NAMES  │
+                                                     └──────────────────────────┘
+         ↑ 手同期が前提。コンパイラは乖離を検出できない
+```
+
+### 移行後（責務分離）
+
+```text
+┌──────────────────────────────────────────────┐
+│ ComponentKind（ターゲット非依存）              │
+│  plural()           … 表示・JSON キー専用      │
+│  skill_manifest()   … "SKILL.md"              │
+│  file_suffix()      … ".agent.md" 等          │
+│  default_subdir()   … プラグイン/デフォルト配置 │
+└───────────────────┬──────────────────────────┘
+                    │ 消費
+        ┌───────────┼────────────┬──────────────┐
+        ▼           ▼            ▼              ▼
+   scan/*     placed/filter  placement_helpers  wire/import
+   (re-export 可)
+
+┌──────────────────────────────────────────────┐
+│ Target / LAYOUT（ターゲット依存）              │
+│  instruction_file                            │
+│  personal/project root                       │
+│  component_subdir(kind)  … prompts 等の例外   │
+└───────────────────┬──────────────────────────┘
+                    │ 消費
+        ┌───────────┼────────────┐
+        ▼           ▼            ▼
+   env impl    scan/placement  cleanup_specs
+               (動的構築)
+```
+
+### Copilot Command の分離（核心例）
+
+```text
+表示・JSON:  ComponentKind::Command.plural()  → "commands"
+配置パス:    Copilot LAYOUT / named_file(..., "prompts", ..., ".prompt.md")
+プラグイン:  DEFAULT_COMMANDS_DIR / plural()  → "commands"（パッケージ内相対）
+
+※ 配置だけが "prompts"。plural() を join に使ってはいけない。
+```
+
+### Instruction 除外集合の構築
+
+```text
+【移行前】
+scan/placement.rs: INSTRUCTION_FILE_NAMES = ["AGENTS.md", "copilot-instructions.md", "GEMINI.md"]
+env LAYOUT:        同じ文字列を各ファイルに再定義
+
+【移行後】
+all_targets() / TargetKind テーブル
+    → instruction_filename() が Some のものだけ収集
+    → is_instruction_file() が参照
+env は LAYOUT.instruction_file を同 API 経由で公開（二重定義なし）
+```
+
+---
+
+## Phase 計画
+
+### Phase A: 棚卸し固定（コード変更なし）
+
+- exploration-report を正本としてリテラル一覧を凍結
+- hearing の責務境界（非依存 vs 依存）をレビュー確定
+- ベースライン: `cargo test` green
+
+### Phase B: ターゲット非依存定数の集約
+
+- `ComponentKind` に `skill_manifest()` / `file_suffix()` /（必要なら）`default_subdir()` を追加
+  - または `component/naming.rs` 等の共有 const + thin wrapper（Feature 凝集を優先）
+- `plural()` に「表示・シリアライズ専用。配置パスには使わない」doc を追加
+- `scan/constants.rs` を上記への re-export に変更（消費者の一斉置換は Phase C）
+
+### Phase C: ヘルパ / scan / deployment の消費切替
+
+- `filter_skill_dir`: `"SKILL.md"` → `ComponentKind::Skill.skill_manifest()`（または共有 const）
+- `skill_dir` / `agent_file`: `"skills"` / `"agents"` / `".agent.md"` を定数消費へ
+- `component/deployment.rs` の `"SKILL.md"` も同様
+- `scan/components.rs` 等の既存 constants 利用箇所は re-export 経由のままか、ComponentKind 直参照へ
+
+### Phase D: Target 依存パスの公開と cleanup / placement
+
+- Instruction: `instruction_filename()`（`Option<&'static str>`）を Target または `TargetKind` テーブルで公開
+- `scan/placement.rs`: 静的配列をやめ、公開 API から集合を構築（起動時一度 or const テーブル生成）
+- Env root + kind subdir: cleanup が消費できる `pub(crate)` API
+  - 推奨: `TargetKind` → `(personal_roots, project_roots, kind_subdirs)` の薄いテーブルを LAYOUT と共有ソース化
+  - 各 env の `LAYOUT` フィールドをそのテーブルの単一ソースにするか、テーブルが LAYOUT を読む形にする
+- Copilot `"prompts"` / Cursor `"commands"` 等の kind→subdir も同系統へ
+- env の `list_placed` / `placement_location` 内ベアリテラルを順次置換（Antigravity → Gemini → Codex → Copilot → Cursor）
+
+### Phase E: wire / import / Scope::description
+
+- `info/wire.rs` / `list/wire.rs`: キー配列を `ComponentKind::all().map(plural)` 相当に
+- `deploy/import.rs`: `"skills"` 等の match を `plural()` 逆引きヘルパへ（または match を `kind.plural()` と比較）
+- （任意）`Scope::description()` 更新
+
+### Phase F: docs / 掃除
+
+- `scan/constants.rs` 削除可否を判断（全消費者移行済みなら削除）
+- `docs/architecture/core-design.md` に定数層の短い節を追加
+- `docs/roadmap.md` に本 Issue を完了行として追記
+- 計画ディレクトリを `docs/old/` へ退避（実装完了 PR 時）
+
+---
+
+## リスクと緩和
+
+| リスク | 緩和 |
+|--------|------|
+| `plural()` を配置に誤用したまま残す | Phase B で doc + Phase C/D で grep ゲート（配置 join 近傍に plural が無いこと） |
+| trait 公開で FakeTarget が壊れる | まず `pub(crate)` テーブル。trait 追加は default 実装付き |
+| cleanup テーブルと can_place の乖離 | kind_subdir リストを CAPABILITIES / supported から導出できないか検討。難しければ不変条件テストで LAYOUT と cleanup を突き合わせ |
+| const での動的 `all_targets()` | `INSTRUCTION_FILE_NAMES` を実行時構築するか、`TargetKind::ALL` 静的テーブルから const 生成。後者推奨 |
+
+---
+
+## 完了条件
+
+1. 本番コードから、配置・環境ルート・instruction・マニフェスト名の **意図しない二重ベア定義** が消えている
+2. `plural()` ≠ Copilot `"prompts"` が API / doc で明示されている
+3. 既存テスト全 green + 不変条件テスト追加
+4. roadmap / core-design が現状を反映

--- a/docs/placement-literals-refactor/requirements.md
+++ b/docs/placement-literals-refactor/requirements.md
@@ -1,0 +1,79 @@
+# Requirements: 配置ディレクトリ名・ファイル名リテラル集約 (Issue #339)
+
+> exploration-report と hearing-notes を統合し、要件・制約を確定する中間ドキュメント。
+> Issue 原文の提案を、#338 完了後のコードベースに合わせて具体化している。
+
+## ユースケース
+
+### UC-1: メンテナが配置サブディレクトリ名を一系統で直す
+
+- **アクター**: PLM メンテナ
+- **状況/前提**: `"skills"` / `"agents"` / `"hooks"` 等が `placement_helpers`・各 env・`cleanup.rs`・`scan/constants` に分散している
+- **達成したいこと**: デフォルト配置名の変更が単一の定義（または明示的な Target 上書き 1 箇所）で済む
+- **成功条件**: デフォルト subdir 文字列の定義箇所が 1 系統になり、ベアリテラルの再定義が本番コードから消える（テスト内フィクスチャは除外可）
+
+### UC-2: メンテナが Copilot の `"prompts"` を表示用 `"commands"` と混同しない
+
+- **アクター**: PLM メンテナ
+- **状況/前提**: `ComponentKind::plural()` は `"commands"`、Copilot 実配置は `"prompts"`
+- **達成したいこと**: 表示用 API と配置用 API が分離され、誤用がコンパイルまたはレビューで防げる
+- **成功条件**: `plural()` の doc に「表示専用」と明記。配置パス組み立ては `plural()` を直接使わず、Target/ヘルパ経由の配置 API を使う
+
+### UC-3: メンテナが instruction ファイル名の二重定義を解消する
+
+- **アクター**: PLM メンテナ
+- **状況/前提**: `INSTRUCTION_FILE_NAMES`（scan）と各 env の `LAYOUT.instruction_file` が手同期
+- **達成したいこと**: 除外集合が Target 側の定義から構築される
+- **成功条件**: 新ターゲットの instruction を LAYOUT/公開 API に追加するだけで、scan の除外集合にも自動反映される（手編集の第 2 箇所が無い）
+
+### UC-4: メンテナが cleanup の環境パス漏れを防ぐ
+
+- **アクター**: PLM メンテナ
+- **状況/前提**: `cleanup_specs` が `".codex"` 等をベア再定義しており、LAYOUT と乖離しうる
+- **達成したいこと**: cleanup が Target/LAYOUT 由来のルート・subdir を消費する
+- **成功条件**: `cleanup.rs` 本番コードに環境ルート / kind subdir のベアリテラルが残らない（または単一テーブルからの参照のみ）
+
+### UC-5: テストが移行中の振る舞い不変を保証する
+
+- **アクター**: PLM メンテナ
+- **達成したいこと**: 既存テスト期待値を変えずに移行できる
+- **成功条件**: 各 Phase 完了後 `cargo test` 全 green。追加は不変条件テストのみ
+
+---
+
+## 要件・制約
+
+### 機能要件
+
+- **FR-001**: `ComponentKind::plural()` を表示・シリアライズキー専用と文書化する。配置パス組み立てから直接呼ばない
+- **FR-002**: ターゲット非依存のマニフェスト名 / サフィックス（`SKILL.md`, `.agent.md`, `.prompt.md`）を `ComponentKind` メソッドまたは共有 const に集約し、`scan/constants.rs` はそれへの re-export または削除とする
+- **FR-003**: `placement_helpers`（`skill_dir` / `agent_file`）と `filter_skill_dir` / `component/deployment.rs` が FR-002 の定数を消費する
+- **FR-004**: ターゲット依存の配置 subdir（特に Copilot Command → `"prompts"`、Cursor Command → `"commands"`）は Target/LAYOUT 側の単一定義から供給する
+- **FR-005**: Instruction ファイル名を Target 側から取得できる API（trait メソッドまたは `pub(crate)` テーブル）を用意し、`scan/placement.rs` の `INSTRUCTION_FILE_NAMES` をそれから構築する
+- **FR-006**: 環境ルート（personal / project subdir）を Target/LAYOUT から取得できる形にし、`plugin/cache/cleanup.rs` の `cleanup_specs` がそれを消費する
+- **FR-007**: `commands/info/wire.rs` / `commands/list/wire.rs` の kind キー配列、および `commands/deploy/import.rs` の kind 文字列マッチを `ComponentKind::plural()` / `as_str` 系に寄せる（出力値は不変）
+- **FR-008**: （任意）`Scope::description()` を現行サポートターゲットを含む説明に更新する
+
+### 非機能要件
+
+- **NFR-001**: 振る舞い不変（配置パス・list 結果・cleanup 対象・CLI/JSON 出力を変えない）
+- **NFR-002**: ビッグバン禁止（Phase A〜F。各 Phase 独立コミット）
+- **NFR-003**: 既存 `*_test.rs` の期待値変更なし（テスト追加のみ可）
+- **NFR-004**: ユーザー向け CLI フラグ・サブコマンド変更なし
+
+### 制約・設計方針
+
+- **CON-001**: Rust 2021、`mod.rs` 禁止
+- **CON-002**: 新規クレート追加なし
+- **CON-003**: #338 の `placed/` ヘルパ・`LAYOUT` / `CAPABILITIES` / `can_place_scope` を破壊せず、その上に定数層を載せる
+- **CON-004**: 表示用と配置用の概念を混同する API（例: 「常に `plural()` を join する」）を導入しない
+- **CON-005**: プラグインパッケージ内のデフォルト相対パス（`DEFAULT_SKILLS_DIR` 等）はターゲット配置パスと概念は別だが、**文字列ソースは共有**してよい
+- **CON-006**: テストは TDD。本体と同ディレクトリの `*_test.rs`
+- **CON-007**: FakeTarget / sync テストへの影響を最小化（公開 trait シグネチャ変更は必要最小限）
+- **CON-008**: 移行順序の目安 — 定数定義（B）→ ヘルパ/scan（C）→ Target 公開 + cleanup（D）→ wire（E）→ docs（F）
+
+---
+
+## 未解決の確認事項
+
+hearing-notes の「ユーザー確認が必要な点」参照。計画レビューで未回答でも実装 Phase A は進行可。API 公開範囲（trait vs `pub(crate)`）は Phase D 着手前に確定すること。

--- a/docs/placement-literals-refactor/tasks.md
+++ b/docs/placement-literals-refactor/tasks.md
@@ -1,0 +1,91 @@
+# Task: 配置リテラル集約 (#339)
+
+> 方針: 表示用 `plural()` と配置用パス断片を分離し、#338 LAYOUT / `placed/` の上に定数層を載せる
+
+---
+
+## Phase A: 棚卸し固定（コード変更なし）
+
+- [ ] [exploration-report.md](./exploration-report.md) のリテラル一覧が現行 HEAD と一致することを確認
+- [ ] [hearing-notes.md](./hearing-notes.md) の責務境界（非依存 vs 依存）をレビュー承認
+- [ ] Phase D の API 方針（`Target` trait vs `pub(crate)` `TargetKind` テーブル）を仮決め
+- [ ] `cargo test` でベースライン green を確認
+
+---
+
+## Phase B: ターゲット非依存定数
+
+> **TDD**: Red → Green → Refactor
+
+- [ ] RED: `ComponentKind::skill_manifest()` / `file_suffix()` の単体テスト（`kind_test.rs`）
+  - Skill → `"SKILL.md"`
+  - Agent → `Some(".agent.md")`、Command → `Some(".prompt.md")`、他 → `None`（設計どおり）
+- [ ] GREEN: API 実装
+- [ ] `plural()` に表示専用の doc comment を追加
+- [ ] （任意）`default_subdir()` を追加し `plural()` と同一値を返すか、doc で「プラグイン内相対は plural を使う」と明記
+- [ ] `scan/constants.rs` を上記への re-export に変更（または薄いラッパ）
+- [ ] `cargo test component::` green
+
+---
+
+## Phase C: ヘルパ / deployment / scan 消費切替
+
+- [ ] RED: `filter_skill_dir` が `skill_manifest()` と同じ文字列を使うことを固定するテスト（既存テスト維持 + 必要なら定数一致アサート）
+- [ ] GREEN: `filter.rs` の `"SKILL.md"` を定数参照へ
+- [ ] `placement_helpers.rs` の `"skills"` / `"agents"` / `".agent.md"` を定数参照へ
+- [ ] `component/deployment.rs` の `"SKILL.md"` を定数参照へ
+- [ ] `scan/components.rs` 等は re-export 経由のまま動作確認
+- [ ] `cargo test target::placed` / 関連モジュール green
+
+---
+
+## Phase D: Target 依存パス + cleanup / placement
+
+### Instruction
+
+- [ ] RED: 「全 Target の instruction ファイル名集合」と `is_instruction_file` が一致する不変条件テスト
+- [ ] GREEN: `instruction_filename()`（または同等テーブル）を追加し、各 env LAYOUT と接続
+- [ ] REFACTOR: `scan/placement.rs` の静的 `INSTRUCTION_FILE_NAMES` をその集合から構築
+- [ ] Antigravity（Instruction 非サポート）が `None` / 集合外であることを確認
+
+### Env root + cleanup
+
+- [ ] RED: `cleanup_specs` が返す base パスが、各 Target の LAYOUT ルートと一致するテスト
+- [ ] GREEN: LAYOUT / `TargetKind` テーブルから roots と kind_subdir を供給
+- [ ] REFACTOR: `cleanup.rs` のベアリテラル `".codex"` / `".github"` / `"prompts"` 等を除去
+- [ ] Copilot Personal（Agent/Hook のみ）など scope 差分が現行どおりか既存 cleanup テストで確認
+
+### Env list_placed / placement_location ベアリテラル
+
+- [ ] Antigravity / Gemini CLI の `"skills"` を定数・subdir API へ
+- [ ] Codex の `"skills"` / `"agents"` / `"hooks"` を同様に
+- [ ] Copilot の `"prompts"` を **Target 依存 subdir** として明示（`plural()` に置換しない）
+- [ ] Cursor の `"commands"` / `"skills"` / `"agents"` / `"hooks"` を同様に
+- [ ] `cargo test target::` / `plugin::cache` green
+
+---
+
+## Phase E: wire / import / description
+
+- [ ] `commands/info/wire.rs` / `list/wire.rs` のキー配列を `ComponentKind::plural()` ベースへ
+- [ ] `commands/deploy/import.rs` の kind 文字列マッチを `plural()` 逆引きへ
+- [ ] JSON 出力のスナップショット / 既存テストで値不変を確認
+- [ ] （任意）`Scope::description()` を現行ターゲット含む文言へ更新 + テスト
+
+---
+
+## Phase F: docs / 掃除
+
+- [ ] `scan/constants.rs` 削除 or re-export 残置を最終判断
+- [ ] `docs/architecture/core-design.md` に定数層の短い節を追加
+- [ ] `docs/roadmap.md` のリファクタ表に #339 完了を反映
+- [ ] 本番コードで配置リテラルの残留を `rg` で監査（許容リスト: テストフィクスチャ、doc comment）
+- [ ] 本計画ディレクトリを実装完了時に `docs/old/placement-literals-refactor/` へ退避
+
+---
+
+## 完了チェックリスト
+
+- [ ] UC-1〜UC-5（requirements）を満たす
+- [ ] `cargo fmt` / `cargo test` /（可能なら）`cargo clippy` 通過
+- [ ] 振る舞い不変（パス・cleanup・JSON）を確認済み

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -130,6 +130,7 @@ Epic: [#356](https://github.com/DIO0550/plugin-manager/issues/356)（仕様: `do
 | 項目 | 説明 | 状態 |
 |------|------|------|
 | Target Layout 集約 | `target/env/` の配置骨格コピペを共通ヘルパへ抽出（[#338](https://github.com/DIO0550/plugin-manager/issues/338)） | ✅ 完了 |
+| 配置リテラル集約 | `"skills"` / `"SKILL.md"` / instruction・環境ルート等の 3 系統並立を `ComponentKind` / Target に集約（[#339](https://github.com/DIO0550/plugin-manager/issues/339)） | 計画中（[docs/placement-literals-refactor/](./placement-literals-refactor/README.md)） |
 
 ### 追加ターゲット候補
 
@@ -137,7 +138,7 @@ Epic: [#356](https://github.com/DIO0550/plugin-manager/issues/356)（仕様: `do
 
 | ターゲット | 説明 | 状態 |
 |------------|------|------|
-| Claude Code | .claude/ ディレクトリ | 計画中（[#96](https://github.com/DIO0550/plugin-manager/issues/96)）。**#338 完了後に着手推奨** |
+| Claude Code | .claude/ ディレクトリ | 計画中（[#96](https://github.com/DIO0550/plugin-manager/issues/96)）。**#338 完了済み。#339（配置リテラル集約）完了後の着手が望ましい** |
 | Windsurf | Windsurf IDE | 調査対象 |
 | Aider | Aider CLI | 調査対象 |
 | その他 | SKILL.md対応ツール | 調査対象 |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

[#339](https://github.com/DIO0550/plugin-manager/issues/339) のレビュー結果として、配置ディレクトリ名・ファイル名リテラルを `ComponentKind` / `Target` に集約する計画ドキュメントを追加しました（実装コード変更なし）。

#338 完了後も `"skills"` / `"SKILL.md"` / instruction・環境ルートが (a) `plural()`、(b) `scan/constants`、(c) ヘルパ・cleanup・wire のベアリテラル、で並立していることを確認し、表示用と配置用の分離を含む段階計画に落としています。

## 計画ドキュメント

[docs/placement-literals-refactor/](docs/placement-literals-refactor/README.md)

| ファイル | 内容 |
|----------|------|
| `exploration-report.md` | 現行コードのリテラル棚卸し（行番号付き） |
| `hearing-notes.md` | 責務境界・ユーザー確認事項 |
| `requirements.md` | UC / FR / NFR / CON |
| `implementation-plan.md` | Phase A〜F |
| `tasks.md` | TDD タスクリスト |

## レビュー上の主な結論

1. **`plural()` は表示専用**（`"commands"`）。Copilot 実配置 `"prompts"` とは分離を維持する
2. **ターゲット非依存**（`SKILL.md` / suffixes）→ `ComponentKind`（または共有 const）
3. **ターゲット依存**（instruction・env root・Command subdir）→ LAYOUT / Target 公開 API → `cleanup` / `scan/placement` が消費
4. Issue 原文の `placement_subdir(target?)` より、**デフォルト plural + Target 上書き**の方が #338 LAYOUT と整合

## ユーザー確認事項（着手前）

hearing-notes に記載:

- API を `Target` trait 公開にするか `pub(crate)` テーブルに留めるか
- `scan/constants.rs` を re-export 残置するか最終削除するか
- `Scope::description()` の更新範囲

## 検証

ドキュメントのみのためビルド検証は不要。リンク先パスと roadmap / core-design / index の相互参照を確認済み。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1337933c-fc12-4d22-af3f-54ed79478bb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1337933c-fc12-4d22-af3f-54ed79478bb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

