### PR TITLE
docs: Antigravity セクションを hooks-schema-mapping に追加 (#399)

### DIFF
--- a/docs/reference/hooks-schema-mapping.md
+++ b/docs/reference/hooks-schema-mapping.md
@@ -1,7 +1,10 @@
-# Claude Code ↔ Copilot CLI Hooks スキーマ対応表
+# Claude Code ↔ 各ターゲット Hooks スキーマ対応表
 
 PLM でフック変換ツールを実装する際のリファレンス。
-公式ドキュメントから抽出した仕様を対比し、変換時の注意点をまとめる。
+Claude Code を入力元とし、Copilot CLI / Codex CLI / Google Antigravity への変換仕様を対比する。
+
+各セクションでは **公式仕様** と **PLM 実装状況** を区別して記載する。
+Antigravity の詳細は [セクション 10](#10-google-antigravity)（実装 Issue [#309](https://github.com/DIO0550/plugin-manager/issues/309) の単一リファレンス）。
 
 ## 公式ドキュメント
 
@@ -13,6 +16,8 @@ PLM でフック変換ツールを実装する際のリファレンス。
 | Copilot CLI Hooks ガイド | https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/use-hooks |
 | Copilot CLI Hooks チュートリアル | https://docs.github.com/en/copilot/tutorials/copilot-cli-hooks |
 | Codex CLI Hooks | https://developers.openai.com/codex/hooks |
+| Antigravity Hooks | https://antigravity.google/docs/hooks |
+| Antigravity Hooks フォーラム | https://discuss.ai.google.dev/t/hooks-in-antigravity/120458 |
 
 ---
 
@@ -70,25 +75,49 @@ PLM でフック変換ツールを実装する際のリファレンス。
 **配置場所:**
 - `.github/hooks/*.json`（プロジェクトレベル）
 
+### Google Antigravity（要約）
+
+詳細は [セクション 10](#10-google-antigravity)。トップレベルは **命名済みフック → イベント設定** のマップ。
+
+```json
+{
+  "my-linter-hook": {
+    "enabled": true,
+    "PostToolUse": [
+      {
+        "matcher": "run_command",
+        "hooks": [
+          { "type": "command", "command": "./scripts/lint.sh", "timeout": 10 }
+        ]
+      }
+    ]
+  }
+}
+```
+
+**配置場所:**
+- Project: `.agents/hooks.json`
+- Global（Personal）: `~/.gemini/config/hooks.json`
+
 ### 構造差分
 
-| 項目 | Claude Code | Copilot CLI |
-|------|-------------|-------------|
-| トップレベル `version` | なし | `1`（必須） |
-| ネスト深度 | event → matcher group → hooks[] | event → hooks[]（フラット） |
-| matcher | matcher group の `"matcher"` キー（regex） | なし（スクリプト内で `toolName` を判定） |
-| コマンドキー | `"command"` | `"bash"` / `"powershell"` |
-| タイムアウト | `"timeout"`（秒、デフォルト 600） | `"timeoutSec"`（秒、デフォルト 30） |
-| 作業ディレクトリ | なし（`CLAUDE_PROJECT_DIR` で代替） | `"cwd"` |
-| 環境変数 | なし（個別に `CLAUDE_*` が設定される） | `"env"` オブジェクト |
-| フック種別 | `command` / `http` / `prompt` / `agent` | `command` / `prompt`（sessionStart のみ） |
-| 無効化 | `"disableAllHooks": true` | なし |
-| 非同期実行 | `"async": true` | なし |
+| 項目 | Claude Code | Copilot CLI | Antigravity |
+|------|-------------|-------------|-------------|
+| トップレベル | `"hooks": { <Event>: ... }` | `"version": 1` + `"hooks"` | **命名フック → イベント設定** のマップ |
+| ネスト深度 | event → matcher group → hooks[] | event → hooks[]（フラット） | 命名フック → event →（ToolUse のみ）matcher group → hooks[] |
+| matcher | matcher group の `"matcher"`（regex） | なし（スクリプト内で判定） | `PreToolUse` / `PostToolUse` のみ。他イベントはフラット handlers |
+| コマンドキー | `"command"` | `"bash"` / `"powershell"` | `"command"` |
+| タイムアウト | `"timeout"`（秒、デフォルト 600） | `"timeoutSec"`（秒、デフォルト 30） | `"timeout"`（秒、デフォルト 30） |
+| 作業ディレクトリ | なし（`CLAUDE_PROJECT_DIR`） | `"cwd"` | なし（stdin の `workspacePaths`） |
+| 環境変数 | `CLAUDE_*` | `"env"` オブジェクト | フック専用 env なし（stdin JSON） |
+| フック種別 | `command` / `http` / `prompt` / `agent` | `command` / `prompt` | **`command` のみ** |
+| 無効化 | `"disableAllHooks": true` | なし | 命名フック単位の `"enabled": false` |
 
 **変換時の注意:**
 - Claude Code の matcher グループ構造を Copilot CLI のフラット構造に展開する必要がある
 - Claude Code の `http` / `agent` フックは Copilot CLI に直接変換できない（`command` ラッパーが必要）
 - Copilot CLI の `powershell` キーは Claude Code に対応がない
+- Antigravity はトップレベルを命名フックでラップし、非 ToolUse イベントは matcher グループではなくフラット handlers にする必要がある（詳細はセクション 10）
 
 ---
 
@@ -202,6 +231,26 @@ PLM は Codex hook を配置すると同時に、scope に応じた `config.toml
 - スキップ時は手動で `[features] codex_hooks = true` を追記する必要がある
 
 注: `features.codex_hooks` は公式ドキュメント上 deprecated alias と明記されており、将来名前が変わる可能性がある（出典: <https://developers.openai.com/codex/config-advanced>、確認日付: 2026-06-29）。実装側は `src/target/env/codex/feature_flag.rs` でテーブル名・キー名を定数化しており、名前変更時は 1 箇所修正で済む。
+
+### 3 ターゲット横断のイベント対応表（要約）
+
+○=公式サポート、×=非対応、〜=近似マッピング候補。詳細は各節・セクション 10。
+
+| Claude Code | Copilot CLI | Codex CLI | Antigravity（公式） |
+|-------------|-------------|-----------|---------------------|
+| `SessionStart` | `sessionStart` | `SessionStart` | 〜 `PreInvocation` |
+| `SessionEnd` | `sessionEnd` | × | 〜 `Stop` |
+| `PreToolUse` | `preToolUse` | `PreToolUse` | `PreToolUse` |
+| `PostToolUse` | `postToolUse` | `PostToolUse` | `PostToolUse` |
+| `UserPromptSubmit` | `userPromptSubmitted` | `UserPromptSubmit` | 〜 `PreInvocation` |
+| `Stop` | `agentStop` | `Stop` | `Stop` |
+| `SubagentStop` | `subagentStop` | `SubagentStop` | × |
+| `PermissionRequest` | （`preToolUse` 近似） | `PermissionRequest` | ×（`ask` / `force_ask` で部分代替） |
+| `PreCompact` / `PostCompact` | × | ○ | × |
+| `Notification` | × | × | × |
+| — | — | — | `PreInvocation` / `PostInvocation`（Antigravity 固有） |
+
+> **注:** Issue #309 / 初期調査では Antigravity に `SessionStart` / `SessionEnd` / `SubagentStop` / `UserPromptSubmit` / `PreCompact` / `Notification` が列挙されていたが、**2026-07-26 時点の公式ドキュメント**（https://antigravity.google/docs/hooks）ではサポートイベントは `PreToolUse` / `PostToolUse` / `PreInvocation` / `PostInvocation` / `Stop` の 5 種。本表は公式を正とする。
 
 ---
 
@@ -588,12 +637,12 @@ Claude Code は PascalCase、Copilot CLI は小文字。
 
 ## 8. フック種別
 
-| 種別 | Claude Code | Copilot CLI |
-|------|-------------|-------------|
-| `command` | 全イベントで使用可。シェルコマンドを実行 | 全イベントで使用可 |
-| `http` | HTTP POST でウェブフックを呼び出し。`headers` で `$VAR` 展開可能 | **なし** |
-| `prompt` | `$ARGUMENTS` に入力 JSON を展開し LLM に評価させる。`{ok, reason}` で応答 | `sessionStart` のみ。テキストを自動送信 |
-| `agent` | サブエージェント（Read/Grep/Glob 使用可、最大50ターン）で調査。`{ok, reason}` で応答 | **なし** |
+| 種別 | Claude Code | Copilot CLI | Antigravity |
+|------|-------------|-------------|-------------|
+| `command` | 全イベントで使用可 | 全イベントで使用可 | **唯一のサポート種別**（省略時も `command`） |
+| `http` | HTTP POST。`headers` で `$VAR` 展開可 | **なし** | **なし** |
+| `prompt` | LLM 評価フック。`{ok, reason}` | `sessionStart` のみ（自動送信） | **なし** |
+| `agent` | サブエージェント調査。`{ok, reason}` | **なし** | **なし** |
 
 **`prompt` の意味の違い:**
 - Claude Code: LLM にフック入力を評価させ、`ok: false` でブロックする判定フック
@@ -613,6 +662,19 @@ Claude Code は PascalCase、Copilot CLI は小文字。
 6. `http` / `agent` フックは `command` ラッパースクリプトに変換
 7. Copilot CLI に対応のないイベント（`Notification`, `PreCompact` 等）は除外または警告
 
+### Claude Code → Antigravity
+
+1. トップレベルを **命名フック → イベント設定** のマップに包む（プラグイン名などから一意な hook 名を生成）
+2. `PreToolUse` / `PostToolUse` は matcher グループ構造を維持（ツール名は Antigravity 名へリマップ）
+3. `PreInvocation` / `PostInvocation` / `Stop` は **フラットな handlers 配列**（`{matcher, hooks:[]}` でラップすると無視される）
+4. イベント近似: `SessionStart` / `UserPromptSubmit` → `PreInvocation`、`SessionEnd` → `Stop`（意味が一致しない点を警告）
+5. 対応のないイベント（`SubagentStop`, `PreCompact`, `Notification` 等）は除外 + 警告
+6. `http` / `prompt` / `agent` は `command` へ変換できない場合は除外 + 警告（公式は `command` のみ）
+7. stdin/stdout 差分はラッパースクリプトで吸収（`tool_name`/`tool_input` ↔ `toolCall`、`permissionDecision` ↔ `decision`）
+8. 配置先: Project `.agents/hooks.json` / Personal `~/.gemini/config/hooks.json`（単一ファイル・マージ戦略は #309 で決定）
+
+詳細はセクション 10。
+
 ### Copilot CLI → Claude Code
 
 1. `"version"` フィールドを除去
@@ -622,3 +684,257 @@ Claude Code は PascalCase、Copilot CLI は小文字。
 5. `"timeoutSec"` → `"timeout"` にキー名変更
 6. `"cwd"` / `"env"` は Claude Code に対応がないため除外または警告
 7. `errorOccurred` は除外
+
+---
+
+## 10. Google Antigravity
+
+> **出典:** [Antigravity Hooks](https://antigravity.google/docs/hooks)（本文取得・確認日: 2026-07-26）  
+> **PLM 実装状況:** 未実装（[#309](https://github.com/DIO0550/plugin-manager/issues/309)）  
+> **関連:** [#399](https://github.com/DIO0550/plugin-manager/issues/399)（本セクション追加）、`docs/concepts/targets.md`、`docs/hooks-conversion/index.md`
+
+### 10.1 配置先
+
+| スコープ | パス | 備考 |
+|----------|------|------|
+| Project（workspace） | `.agents/hooks.json` | AGY / AGY CLI / AGY IDE 共通 |
+| Global（Personal） | `~/.gemini/config/hooks.json` | 同上 |
+
+公式は customization directory として `.agents/`（workspace）と `~/.gemini/config/`（global）を明記。ファイル名は `hooks.json`。
+
+> 一部の二次記事では CLI 専用に `~/.gemini/antigravity-cli/hooks.json` と記載されるが、2026-07 時点の公式および実機検証記事（Atamel, 2026-07-16）は **`~/.gemini/config/hooks.json` を Global 正とする**。実装前に最新公式で再確認すること。
+
+### 10.2 設定構造（公式）
+
+トップレベルは **フック名 → イベント設定** のマップ。Claude Code（`hooks.<Event>`）や Copilot（`hooks.<event>`）とは異なり、複数の命名フックを 1 ファイルに同居できる。
+
+```json
+{
+  "my-linter-hook": {
+    "PostToolUse": [
+      {
+        "matcher": "run_command",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./scripts/lint.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  },
+  "safety-gate": {
+    "enabled": false,
+    "PreToolUse": [
+      {
+        "matcher": "run_command",
+        "hooks": [
+          {
+            "command": "./scripts/safety-check.sh"
+          }
+        ]
+      }
+    ]
+  },
+  "reminder": {
+    "PreInvocation": [
+      {
+        "type": "command",
+        "command": "./scripts/reminder.sh"
+      }
+    ]
+  }
+}
+```
+
+#### 命名フックのフィールド
+
+| フィールド | 型 | 説明 |
+|------------|-----|------|
+| `enabled` | boolean | 省略時 `true`。`false` で個別無効化（削除不要） |
+| `PreToolUse` / `PostToolUse` / `PreInvocation` / `PostInvocation` / `Stop` | array | 各イベントのハンドラ定義 |
+
+#### ハンドラ設定（`hooks` 配列要素）
+
+| フィールド | 型 | 説明 |
+|------------|-----|------|
+| `type` | string | 省略可。現状 `"command"` のみ。デフォルト `"command"` |
+| `command` | string | 必須。実行するシェルコマンド |
+| `timeout` | integer | 秒。デフォルト **30**（Claude Code の 600 と異なる） |
+
+#### 構造の非対称性（変換時に重要）
+
+| イベント | 配列要素の形 | matcher |
+|----------|--------------|---------|
+| `PreToolUse` / `PostToolUse` | `{ "matcher": "<regex>", "hooks": [ ... ] }` | ツール名に対する regex。`""` / `"*"` は全ツール |
+| `PreInvocation` / `PostInvocation` / `Stop` | `{ "type": "command", "command": "..." }`（**フラット**） | 無視。`{matcher, hooks:[]}` でラップすると ** silently skip** される報告あり |
+
+### 10.3 サポートイベント
+
+| イベント | 発火タイミング | Matcher |
+|----------|----------------|---------|
+| `PreToolUse` | ツール実行前 | ツール名（例: `run_command`） |
+| `PostToolUse` | ツール完了後 | ツール名 |
+| `PreInvocation` | モデル呼び出し前 | N/A |
+| `PostInvocation` | ツール呼び出し群の後 | N/A |
+| `Stop` | 実行ループ終了時 | N/A |
+
+#### Claude Code からのイベント対応方針（#309 向け）
+
+| Claude Code | Antigravity | 変換方針 |
+|-------------|-------------|---------|
+| `PreToolUse` | `PreToolUse` | 直接変換。matcher のツール名をリマップ |
+| `PostToolUse` | `PostToolUse` | 直接変換。stdout は `{}` 固定寄り |
+| `Stop` | `Stop` | 直接変換。出力意味が異なる（後述） |
+| `SessionStart` | `PreInvocation`（近似） | 警告付き近似。毎モデル呼び出しで発火する点に注意 |
+| `UserPromptSubmit` | `PreInvocation`（近似） | 同上。`invocationNum` 等でフィルタが必要な場合あり |
+| `SessionEnd` | `Stop`（近似） | 警告付き近似。`terminationReason` / `fullyIdle` が異なる |
+| `SubagentStop` / `SubagentStart` | × | 除外 + 警告 |
+| `PreCompact` / `PostCompact` / `Notification` / `PermissionRequest` 等 | × | 除外 + 警告 |
+| — | `PostInvocation` | Claude Code 側に直接対応なし（生成しない） |
+
+### 10.4 サポートツール名（matcher 用）
+
+Antigravity のツール名は Claude Code / Copilot と大きく異なる。matcher 変換時に必須。
+
+| カテゴリ | Antigravity ツール名（例） |
+|----------|---------------------------|
+| ファイル | `view_file`, `write_to_file`, `replace_file_content`, `multi_replace_file_content`, `list_dir`, `find_by_name` |
+| 検索 | `grep_search`, `search_web`, `read_url_content` |
+| 実行 | `run_command`, `manage_task`, `schedule`, `list_permissions`, `ask_permission` |
+| エージェント | `invoke_subagent`, `define_subagent`, `send_message`, `manage_subagents` |
+| その他 | `ask_question`, `generate_image` |
+
+#### Claude Code → Antigravity（matcher 用の代表マッピング）
+
+| Claude Code | Antigravity | 備考 |
+|-------------|-------------|------|
+| `Bash` | `run_command` | |
+| `Read` | `view_file` | |
+| `Write` | `write_to_file` | |
+| `Edit` | `replace_file_content` | |
+| `MultiEdit` | `multi_replace_file_content` | |
+| `Glob` | `find_by_name` | |
+| `Grep` | `grep_search` | |
+| `WebFetch` | `read_url_content` | |
+| `WebSearch` | `search_web` | |
+| `Agent` | `invoke_subagent` | 近似 |
+
+### 10.5 stdin / stdout 契約
+
+フィールド名は **camelCase**。全イベント共通メタデータ:
+
+| フィールド | 型 | 説明 |
+|------------|-----|------|
+| `conversationId` | string | 会話 UUID |
+| `workspacePaths` | string[] | マウント済みワークスペースの絶対パス |
+| `transcriptPath` | string | `transcript.jsonl` の絶対パス（`~/.gemini/antigravity/...` または CLI 相当） |
+| `artifactDirectoryPath` | string | 成果物・スクリーンショットディレクトリ |
+
+> AGY は stdin にイベント名を含めない（Atamel 記事で確認）。スクリプト側で CLI 引数等によりイベントを識別する必要がある場合がある。
+
+#### PreToolUse
+
+**stdin（例）:**
+
+```json
+{
+  "toolCall": {
+    "name": "run_command",
+    "args": {
+      "CommandLine": "npm test",
+      "Cwd": "/workspace/project",
+      "WaitMsBeforeAsync": 5000
+    }
+  },
+  "stepIdx": 19,
+  "conversationId": "ec33ebf9-0cba-4100-8142-c61503f6c587",
+  "workspacePaths": ["/workspace/project"],
+  "transcriptPath": "~/.gemini/antigravity/brain/.../transcript.jsonl",
+  "artifactDirectoryPath": "~/.gemini/antigravity/brain/..."
+}
+```
+
+**stdout:**
+
+| フィールド | 型 | 説明 |
+|------------|-----|------|
+| `decision` | string | **必須。** `"allow"` / `"deny"` / `"ask"` / `"force_ask"` |
+| `reason` | string | 任意。決定理由（エージェント/ユーザー向け） |
+| `permissionOverrides` | string[] | 任意。例: `["command(npm test)"]` |
+
+```json
+{
+  "decision": "ask",
+  "reason": "Requires confirmation for test execution.",
+  "permissionOverrides": ["command(npm test)"]
+}
+```
+
+> Issue #399 提案の `allow` / `deny` / `ask` に加え、公式は `"force_ask"`（キャッシュ済み Always Allow を無視して必ず確認）も定義する。
+
+#### PostToolUse
+
+**stdin:** `stepIdx`, `error`（成功時は空文字）, 共通フィールド。実機では `toolCall` が付与される場合あり。  
+**stdout:** `{}`（空オブジェクト）。
+
+#### PreInvocation
+
+**stdin:** `invocationNum`（0 始まり）, `initialNumSteps`, 共通フィールド。  
+**stdout:** 任意で `injectSteps`（`toolCall` / `userMessage` / `ephemeralMessage` のいずれか）。
+
+#### PostInvocation
+
+**stdin:** PreInvocation と同型。  
+**stdout:** `injectSteps`（任意）, `terminationBehavior`（`""` / `"force_continue"` / `"terminate"`）。
+
+#### Stop
+
+**stdin:** `executionNum`, `terminationReason`（例: `model_stop`, `max_steps_exceeded`, `error`）, `error`, `fullyIdle`（必須 boolean）, 共通フィールド。  
+**stdout:**
+
+```json
+{
+  "decision": "continue",
+  "reason": "Not done yet"
+}
+```
+
+- `decision: "continue"` → 停止を阻止してループ再突入。`reason` はシステムメッセージとして注入。
+- それ以外 → 停止を許可。
+
+#### Claude Code との I/O 差分（ラッパー必須箇所）
+
+| 項目 | Claude Code | Antigravity | 変換 |
+|------|-------------|-------------|------|
+| ツール名 | `tool_name` (PascalCase) | `toolCall.name` (snake_case 系) | リマップ |
+| ツール引数 | `tool_input` オブジェクト | `toolCall.args`（キーは PascalCase 寄り） | 構造変換 |
+| セッション ID | `session_id` | `conversationId` | リネーム |
+| cwd | `cwd` | `workspacePaths[0]` 等 | 抽出 |
+| PreToolUse 許可 | `hookSpecificOutput.permissionDecision` (`allow`/`deny`) | トップレベル `decision`（+ `ask`/`force_ask`） | アンラップ + 値域拡張 |
+| Stop 阻止 | `decision: "block"` | `decision: "continue"` | **値の意味が逆方向に見える**ため要注意 |
+| exit code 2 | ブロック | 公式は JSON `decision` 中心。非 0 exit の扱いは実装時に再確認 | ラッパーで JSON へ正規化推奨 |
+
+### 10.6 Claude Code 形式からの変換チェックリスト（#309）
+
+1. **構造:** `hooks.<Event>` → `{ "<plugin-or-hook-name>": { <Event>: ... } }`
+2. **非 ToolUse:** matcher グループをフラット handlers に展開する（ラップし直さない）
+3. **イベント:** 直接対応 3 種 + 近似 2 種。それ以外は警告除外
+4. **ツール名:** matcher とラッパー内の両方で Antigravity 名へ変換
+5. **ハンドラ種別:** `command` 以外は除外またはスタブ方針を決める（公式は command のみ）
+6. **timeout:** Claude の 600 デフォルトをそのまま持ち込まない（Antigravity 既定 30）
+7. **単一ファイル配置:** Personal / Project とも 1 つの `hooks.json`。複数プラグイン時のマージ / 所有権は Codex/Cursor と同様の未解決課題
+8. **パス:** CLI では相対パスが起動 cwd 依存で失敗しうるため、配置時に絶対パスへ正規化する方針を検討
+9. **旧二次情報の排除:** `allow_tool` / `deny_reason` や `SessionStart` 等の旧イベント一覧は公式と不一致。実装は本セクション（公式）に従う
+
+### 10.7 PLM 実装メモ
+
+| 項目 | 状態 |
+|------|------|
+| `AntigravityTarget::supported_components` に `Hook` | ❌（Skills のみ） |
+| EventMap / KeyMap / StructureConverter | ❌ |
+| `create_layers` への登録 | ❌（「Hook conversion is not yet implemented for target」） |
+| `.agents/hooks.json` / `~/.gemini/config/hooks.json` 配置 | ❌ |
+
+実装は [#309](https://github.com/DIO0550/plugin-manager/issues/309) で追跡。本セクションを単一リファレンスとする。


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

Issue #399 に対応し、`docs/reference/hooks-schema-mapping.md` に Google Antigravity Hooks の公式仕様セクションを追加しました。#309 実装時の単一リファレンスとします。

## 変更内容

- 公式ドキュメント表に Antigravity Hooks URL を追加
- セクション 1 に配置先・構造要約と 3 環境の構造差分表を追加
- セクション 2 に 3 ターゲット横断イベント対応表を追加（公式 5 イベントを正とする）
- セクション 8〜9 に Antigravity のフック種別・変換手順を追加
- **セクション 10（本丸）**: 配置先、命名フックマップ、イベント非対称構造、stdin/stdout（`decision`: allow/deny/ask/force_ask）、ツール名マッピング、Claude Code 変換チェックリスト、PLM 実装状況

## 公式との差分注記

Issue #309 / 初期調査のイベント一覧（`SessionStart` 等）は、2026-07-26 時点の公式（https://antigravity.google/docs/hooks）と不一致のため、本ドキュメントは公式の 5 イベント（`PreToolUse` / `PostToolUse` / `PreInvocation` / `PostInvocation` / `Stop`）を正として記載しています。

## 検証

- 公式ページ https://antigravity.google/docs/hooks の本文を取得して突合
- 二次情報（Atamel 2026-07-16 等）で配置パス・構造非対称性をクロスチェック
- ドキュメントのみの変更（Rust コード変更なし）

## 関連

- Closes #399
- Relates to #309

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-54350880-6614-4430-8ea9-abad55daaaeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-54350880-6614-4430-8ea9-abad55daaaeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

