### PR TITLE
feat: Antigravity Hooks 変換・配置を実装する (#309)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,7 @@ cargo deny check
 |------------|--------|--------|----------|--------------|-------|
 | OpenAI Codex | ○ | ○ | × | ○ | ○ |
 | VSCode Copilot | ○ | ○ | ○ | ○ | ○ |
-| Google Antigravity | ○ | × | × | × | × |
+| Google Antigravity | ○ | × | × | × | ○ |
 | Gemini CLI | ○ | × | × | ○ | × |
 | Cursor | ○ | ○ | ○ | ○* | ○ |
 

--- a/docs/commands/target.md
+++ b/docs/commands/target.md
@@ -17,7 +17,7 @@
 ```bash
 $ plm target list
 📍 Active targets:
-   • antigravity (skills)
+   • antigravity (skills, hooks)
    • codex       (skills, agents, instructions, hooks)
    • copilot     (skills, agents, commands, instructions, hooks)
    • cursor      (skills, agents, commands, instructions, hooks)
@@ -62,7 +62,7 @@ $ plm target add cursor
 
 | ターゲット | サポートするコンポーネント |
 |------------|----------------------------|
-| `antigravity` | Skills |
+| `antigravity` | Skills, Hooks |
 | `codex` | Skills, Agents, Instructions, Hooks |
 | `copilot` | Skills, Agents, Commands, Instructions, Hooks |
 | `cursor` | Skills, Agents, Commands, Instructions, Hooks |

--- a/docs/concepts/components.md
+++ b/docs/concepts/components.md
@@ -212,12 +212,12 @@ description: コマンドの説明
 | Agents | ✅ | ✅ | ❌* | ❌ | ✅ |
 | Commands | ❌ | ✅ | ❌* | ❌ | ✅ |
 | Instructions | ✅ | ✅ | ❌* | ✅** | ✅*** |
-| Hooks | ✅ | ✅ | ❌**** | ❌ | ✅***** |
+| Hooks | ✅ | ✅ | ✅**** | ❌ | ✅***** |
 
 > *Antigravity 公式は Agents / Workflows（Commands 相当）/ Rules・`AGENTS.md`（Instructions 相当）をサポート。PLM 実装は未着手（[#400](https://github.com/DIO0550/plugin-manager/issues/400)）。
 > **Gemini CLIは`GEMINI.md`形式で対応（`AGENTS.md`は設定で変更可能）。
 > ***CursorのInstructionsはProjectスコープ（`AGENTS.md`）のみ。
-> ****Antigravity Hooks は公式サポートあり。PLM 実装は [#309](https://github.com/DIO0550/plugin-manager/issues/309)。
+> ****Antigravity Hooks は変換・配置を実装済み（[#309](https://github.com/DIO0550/plugin-manager/issues/309)）。単一 `hooks.json`、複数 Hook 同時配置は拒否。
 > *****CursorのHooksは単一 `hooks.json`。非管理ファイルの上書きと複数 Hook 同時配置は拒否（フルマージ未実装）。
 
 ## 共通規格

--- a/docs/concepts/targets.md
+++ b/docs/concepts/targets.md
@@ -20,12 +20,12 @@ PLMがサポートするAI開発環境（ターゲット）について説明し
 | Agents | ✅ | ✅ | ❌* | ❌ | ✅ |
 | Commands | ❌ | ✅ | ❌* | ❌ | ✅ |
 | Instructions | ✅ | ✅ | ❌* | ✅** | ✅*** |
-| Hooks | ✅ | ✅ | ❌**** | ❌ | ✅***** |
+| Hooks | ✅ | ✅ | ✅**** | ❌ | ✅***** |
 
 > *Antigravity は公式に Agents（`agent.md`）/ Workflows（Commands 相当）/ Rules・`GEMINI.md`・`AGENTS.md`（Instructions 相当）をサポートする。PLM 実装は未着手（調査: [#400](https://github.com/DIO0550/plugin-manager/issues/400)）。
 > **Gemini CLIは`GEMINI.md`による階層的な指示システムを持ちます。
 > ***CursorのInstructionsはProjectスコープ（`AGENTS.md`）のみ。Personalスコープの指示（User Rules）はアプリ設定画面で管理されるため対象外。
-> ****Antigravity Hooks は公式サポートあり。PLM 実装は [#309](https://github.com/DIO0550/plugin-manager/issues/309) で追跡。
+> ****Antigravity Hooks は公式 5 イベント対応の変換・配置を実装済み（[#309](https://github.com/DIO0550/plugin-manager/issues/309)）。単一 `hooks.json`・複数 Hook 同時配置は拒否（フルマージ未実装）。stdin/stdout ラッパーは未生成（インライン command）。
 > *****CursorのHooksは単一の `hooks.json` に配置する。既存の非管理ファイルの上書きと、同一インストール内の複数 Hook コンポーネントは拒否する（フルマージは未実装）。
 
 ## OpenAI Codex
@@ -196,7 +196,7 @@ Hooks は stdin で JSON を受け取り、stdout で JSON を返します。
 
 ## Google Antigravity
 
-> **実装状況**: Skills 配置は実装済み。Agents / Commands（Workflows）/ Instructions（Rules・context files）/ Hooks は公式サポート確認済みだが PLM 未実装（調査 [#400](https://github.com/DIO0550/plugin-manager/issues/400)、Hooks [#309](https://github.com/DIO0550/plugin-manager/issues/309)）。
+> **実装状況**: Skills / Hooks 配置は実装済み。Agents / Commands（Workflows）/ Instructions（Rules・context files）は公式サポート確認済みだが PLM 未実装（調査 [#400](https://github.com/DIO0550/plugin-manager/issues/400)）。
 
 ### 概要
 
@@ -237,28 +237,31 @@ Google Antigravityはエージェント指向の開発プラットフォーム�
 
 ### コンポーネント配置場所
 
-#### PLM 実装済み（Skills）
+#### PLM 実装済み（Skills / Hooks）
 
 | 種別 | ファイル形式 | Personal | Project |
 |------|-------------|----------|---------|
 | Skills | `SKILL.md` | `~/.gemini/antigravity/skills/<marketplace>/<plugin>/<skill>/` | `.agent/skills/<marketplace>/<plugin>/<skill>/` |
+| Hooks | `hooks.json` | `~/.gemini/config/hooks.json` | `.agents/hooks.json` |
 
 > Skills の公式推奨パスは Personal `~/.gemini/config/skills/`、Project `.agents/skills/`。PLM 現状パスは IDE 互換だが CLI 非対応のため、パス移行は別 feature（[#402](https://github.com/DIO0550/plugin-manager/issues/402) 連携）で扱う。
+>
+> Hooks は Claude Code 形式から命名フックマップへ変換して単一 `hooks.json` に配置する（[#309](https://github.com/DIO0550/plugin-manager/issues/309)）。非管理ファイルの上書きと複数 Hook 同時配置は拒否。スキーマ詳細は [hooks-schema-mapping.md](../reference/hooks-schema-mapping.md)。
 
-#### 公式サポートあり・PLM 未実装（#400 / #309）
+#### 公式サポートあり・PLM 未実装（#400）
 
 | 種別 | ファイル形式 | Personal（想定） | Project（想定） |
 |------|-------------|------------------|-----------------|
 | Agents | `agent.md` | `~/.gemini/config/agents/<name>/agent.md` | `.agents/agents/<name>/agent.md` |
 | Commands（Workflows） | `*.md` | `~/.gemini/config/global_workflows/<name>.md` | `.agents/workflows/<name>.md` |
 | Instructions | `GEMINI.md` / `AGENTS.md` | `~/.gemini/GEMINI.md` | ルート `AGENTS.md`（または `GEMINI.md`）。複数ルールは `.agents/rules/` |
-| Hooks | `hooks.json` | `~/.gemini/config/hooks.json` | `.agents/hooks.json` |
 
 配置パス・形式の詳細は上記表と [#400](https://github.com/DIO0550/plugin-manager/issues/400) を参照。
 
 ### 制約事項
 
-- **PLM は現状 Skills のみ配置**: Agents / Commands / Instructions / Hooks は公式サポート確認済みだが未実装
+- **PLM は現状 Skills + Hooks**: Agents / Commands / Instructions は公式サポート確認済みだが未実装
+- **Hooks は単一ファイル**: Personal / Project とも 1 つの `hooks.json`。フルマージ未実装のため複数 Hook 同時配置は拒否
 - **Agent 形式は Claude Code 非互換**: `*.agent.md` ではなく `agent.md` + Antigravity 固有 frontmatter
 - **Workflows パスは公式 docs 未記載**: 実装前に IDE 実機で再確認すること
 - **Personal Instruction は Gemini CLI と `~/.gemini/GEMINI.md` を共有**しうる
@@ -420,7 +423,7 @@ Agents / Commands / Hooks は他ターゲットと同様に `flatten_name(plugin
 |-----------|----------------------|----------------|
 | Codex | `~/.codex/` に配置 | Hook 配置時のみ `~/.codex/config.toml` に `[features] codex_hooks = true` を自動追記（`--no-enable-flag` で抑止可、`codex_hooks = false` 既設定時は警告のみでスキップ） |
 | Copilot | ファイル配置 + VSCode設定追記 | `settings.json` への参照追加が必要 |
-| Antigravity | Skills: `~/.gemini/antigravity/`（実装済み）。Agents / Workflows / Instructions / Hooks は公式パスが `~/.gemini/config/` および `.agents/`（未実装・[#400](https://github.com/DIO0550/plugin-manager/issues/400) / [#309](https://github.com/DIO0550/plugin-manager/issues/309)） | Skills は不要（自動読み込み） |
+| Antigravity | Skills: `~/.gemini/antigravity/`。Hooks: `~/.gemini/config/hooks.json`（実装済み・[#309](https://github.com/DIO0550/plugin-manager/issues/309)）。Agents / Workflows / Instructions は未実装（[#400](https://github.com/DIO0550/plugin-manager/issues/400)） | Skills / Hooks は自動読み込み。Hooks は単一 `hooks.json`（上書きガードあり） |
 | Gemini CLI | `~/.gemini/skills/` に配置 | 不要（自動読み込み、要Settings有効化） |
 | Cursor | `~/.cursor/` に配置（Skills / Agents / Commands / Hooks） | 不要（自動読み込み）。Hooksは単一 `hooks.json` へ変換配置（上書きガードあり） |
 

--- a/docs/reference/hooks-schema-mapping.md
+++ b/docs/reference/hooks-schema-mapping.md
@@ -932,9 +932,10 @@ Antigravity のツール名は Claude Code / Copilot と大きく異なる。mat
 
 | 項目 | 状態 |
 |------|------|
-| `AntigravityTarget::supported_components` に `Hook` | ❌（Skills のみ） |
-| EventMap / KeyMap / StructureConverter | ❌ |
-| `create_layers` への登録 | ❌（「Hook conversion is not yet implemented for target」） |
-| `.agents/hooks.json` / `~/.gemini/config/hooks.json` 配置 | ❌ |
+| `AntigravityTarget::supported_components` に `Hook` | ✅ |
+| EventMap / KeyMap / StructureConverter / ToolMap | ✅ |
+| `create_layers` への登録 | ✅ |
+| `.agents/hooks.json` / `~/.gemini/config/hooks.json` 配置 | ✅（単一ファイル・上書き/複数 Hook 拒否） |
+| stdin/stdout ラッパースクリプト | ❌（command はインライン保持。I/O 差分は利用側で吸収） |
 
-実装は [#309](https://github.com/DIO0550/plugin-manager/issues/309) で追跡。本セクションを単一リファレンスとする。
+実装: [#309](https://github.com/DIO0550/plugin-manager/issues/309)。スキーマ整理: [#399](https://github.com/DIO0550/plugin-manager/issues/399)。

--- a/docs/reference/hooks-schema-mapping.md
+++ b/docs/reference/hooks-schema-mapping.md
@@ -1,7 +1,10 @@
-# Claude Code ↔ Copilot CLI Hooks スキーマ対応表
+# Claude Code ↔ 各ターゲット Hooks スキーマ対応表
 
 PLM でフック変換ツールを実装する際のリファレンス。
-公式ドキュメントから抽出した仕様を対比し、変換時の注意点をまとめる。
+Claude Code を入力元とし、Copilot CLI / Codex CLI / Google Antigravity への変換仕様を対比する。
+
+各セクションでは **公式仕様** と **PLM 実装状況** を区別して記載する。
+Antigravity の詳細は [セクション 10](#10-google-antigravity)（実装 Issue [#309](https://github.com/DIO0550/plugin-manager/issues/309) の単一リファレンス）。
 
 ## 公式ドキュメント
 
@@ -13,6 +16,8 @@ PLM でフック変換ツールを実装する際のリファレンス。
 | Copilot CLI Hooks ガイド | https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/use-hooks |
 | Copilot CLI Hooks チュートリアル | https://docs.github.com/en/copilot/tutorials/copilot-cli-hooks |
 | Codex CLI Hooks | https://developers.openai.com/codex/hooks |
+| Antigravity Hooks | https://antigravity.google/docs/hooks |
+| Antigravity Hooks フォーラム | https://discuss.ai.google.dev/t/hooks-in-antigravity/120458 |
 
 ---
 
@@ -70,25 +75,49 @@ PLM でフック変換ツールを実装する際のリファレンス。
 **配置場所:**
 - `.github/hooks/*.json`（プロジェクトレベル）
 
+### Google Antigravity（要約）
+
+詳細は [セクション 10](#10-google-antigravity)。トップレベルは **命名済みフック → イベント設定** のマップ。
+
+```json
+{
+  "my-linter-hook": {
+    "enabled": true,
+    "PostToolUse": [
+      {
+        "matcher": "run_command",
+        "hooks": [
+          { "type": "command", "command": "./scripts/lint.sh", "timeout": 10 }
+        ]
+      }
+    ]
+  }
+}
+```
+
+**配置場所:**
+- Project: `.agents/hooks.json`
+- Global（Personal）: `~/.gemini/config/hooks.json`
+
 ### 構造差分
 
-| 項目 | Claude Code | Copilot CLI |
-|------|-------------|-------------|
-| トップレベル `version` | なし | `1`（必須） |
-| ネスト深度 | event → matcher group → hooks[] | event → hooks[]（フラット） |
-| matcher | matcher group の `"matcher"` キー（regex） | なし（スクリプト内で `toolName` を判定） |
-| コマンドキー | `"command"` | `"bash"` / `"powershell"` |
-| タイムアウト | `"timeout"`（秒、デフォルト 600） | `"timeoutSec"`（秒、デフォルト 30） |
-| 作業ディレクトリ | なし（`CLAUDE_PROJECT_DIR` で代替） | `"cwd"` |
-| 環境変数 | なし（個別に `CLAUDE_*` が設定される） | `"env"` オブジェクト |
-| フック種別 | `command` / `http` / `prompt` / `agent` | `command` / `prompt`（sessionStart のみ） |
-| 無効化 | `"disableAllHooks": true` | なし |
-| 非同期実行 | `"async": true` | なし |
+| 項目 | Claude Code | Copilot CLI | Antigravity |
+|------|-------------|-------------|-------------|
+| トップレベル | `"hooks": { <Event>: ... }` | `"version": 1` + `"hooks"` | **命名フック → イベント設定** のマップ |
+| ネスト深度 | event → matcher group → hooks[] | event → hooks[]（フラット） | 命名フック → event →（ToolUse のみ）matcher group → hooks[] |
+| matcher | matcher group の `"matcher"`（regex） | なし（スクリプト内で判定） | `PreToolUse` / `PostToolUse` のみ。他イベントはフラット handlers |
+| コマンドキー | `"command"` | `"bash"` / `"powershell"` | `"command"` |
+| タイムアウト | `"timeout"`（秒、デフォルト 600） | `"timeoutSec"`（秒、デフォルト 30） | `"timeout"`（秒、デフォルト 30） |
+| 作業ディレクトリ | なし（`CLAUDE_PROJECT_DIR`） | `"cwd"` | なし（stdin の `workspacePaths`） |
+| 環境変数 | `CLAUDE_*` | `"env"` オブジェクト | フック専用 env なし（stdin JSON） |
+| フック種別 | `command` / `http` / `prompt` / `agent` | `command` / `prompt` | **`command` のみ** |
+| 無効化 | `"disableAllHooks": true` | なし | 命名フック単位の `"enabled": false` |
 
 **変換時の注意:**
 - Claude Code の matcher グループ構造を Copilot CLI のフラット構造に展開する必要がある
 - Claude Code の `http` / `agent` フックは Copilot CLI に直接変換できない（`command` ラッパーが必要）
 - Copilot CLI の `powershell` キーは Claude Code に対応がない
+- Antigravity はトップレベルを命名フックでラップし、非 ToolUse イベントは matcher グループではなくフラット handlers にする必要がある（詳細はセクション 10）
 
 ---
 
@@ -202,6 +231,26 @@ PLM は Codex hook を配置すると同時に、scope に応じた `config.toml
 - スキップ時は手動で `[features] codex_hooks = true` を追記する必要がある
 
 注: `features.codex_hooks` は公式ドキュメント上 deprecated alias と明記されており、将来名前が変わる可能性がある（出典: <https://developers.openai.com/codex/config-advanced>、確認日付: 2026-06-29）。実装側は `src/target/env/codex/feature_flag.rs` でテーブル名・キー名を定数化しており、名前変更時は 1 箇所修正で済む。
+
+### 3 ターゲット横断のイベント対応表（要約）
+
+○=公式サポート、×=非対応、〜=近似マッピング候補。詳細は各節・セクション 10。
+
+| Claude Code | Copilot CLI | Codex CLI | Antigravity（公式） |
+|-------------|-------------|-----------|---------------------|
+| `SessionStart` | `sessionStart` | `SessionStart` | 〜 `PreInvocation` |
+| `SessionEnd` | `sessionEnd` | × | 〜 `Stop` |
+| `PreToolUse` | `preToolUse` | `PreToolUse` | `PreToolUse` |
+| `PostToolUse` | `postToolUse` | `PostToolUse` | `PostToolUse` |
+| `UserPromptSubmit` | `userPromptSubmitted` | `UserPromptSubmit` | 〜 `PreInvocation` |
+| `Stop` | `agentStop` | `Stop` | `Stop` |
+| `SubagentStop` | `subagentStop` | `SubagentStop` | × |
+| `PermissionRequest` | （`preToolUse` 近似） | `PermissionRequest` | ×（`ask` / `force_ask` で部分代替） |
+| `PreCompact` / `PostCompact` | × | ○ | × |
+| `Notification` | × | × | × |
+| — | — | — | `PreInvocation` / `PostInvocation`（Antigravity 固有） |
+
+> **注:** Issue #309 / 初期調査では Antigravity に `SessionStart` / `SessionEnd` / `SubagentStop` / `UserPromptSubmit` / `PreCompact` / `Notification` が列挙されていたが、**2026-07-26 時点の公式ドキュメント**（https://antigravity.google/docs/hooks）ではサポートイベントは `PreToolUse` / `PostToolUse` / `PreInvocation` / `PostInvocation` / `Stop` の 5 種。本表は公式を正とする。
 
 ---
 
@@ -588,12 +637,12 @@ Claude Code は PascalCase、Copilot CLI は小文字。
 
 ## 8. フック種別
 
-| 種別 | Claude Code | Copilot CLI |
-|------|-------------|-------------|
-| `command` | 全イベントで使用可。シェルコマンドを実行 | 全イベントで使用可 |
-| `http` | HTTP POST でウェブフックを呼び出し。`headers` で `$VAR` 展開可能 | **なし** |
-| `prompt` | `$ARGUMENTS` に入力 JSON を展開し LLM に評価させる。`{ok, reason}` で応答 | `sessionStart` のみ。テキストを自動送信 |
-| `agent` | サブエージェント（Read/Grep/Glob 使用可、最大50ターン）で調査。`{ok, reason}` で応答 | **なし** |
+| 種別 | Claude Code | Copilot CLI | Antigravity |
+|------|-------------|-------------|-------------|
+| `command` | 全イベントで使用可 | 全イベントで使用可 | **唯一のサポート種別**（省略時も `command`） |
+| `http` | HTTP POST。`headers` で `$VAR` 展開可 | **なし** | **なし** |
+| `prompt` | LLM 評価フック。`{ok, reason}` | `sessionStart` のみ（自動送信） | **なし** |
+| `agent` | サブエージェント調査。`{ok, reason}` | **なし** | **なし** |
 
 **`prompt` の意味の違い:**
 - Claude Code: LLM にフック入力を評価させ、`ok: false` でブロックする判定フック
@@ -613,6 +662,19 @@ Claude Code は PascalCase、Copilot CLI は小文字。
 6. `http` / `agent` フックは `command` ラッパースクリプトに変換
 7. Copilot CLI に対応のないイベント（`Notification`, `PreCompact` 等）は除外または警告
 
+### Claude Code → Antigravity
+
+1. トップレベルを **命名フック → イベント設定** のマップに包む（プラグイン名などから一意な hook 名を生成）
+2. `PreToolUse` / `PostToolUse` は matcher グループ構造を維持（ツール名は Antigravity 名へリマップ）
+3. `PreInvocation` / `PostInvocation` / `Stop` は **フラットな handlers 配列**（`{matcher, hooks:[]}` でラップすると無視される）
+4. イベント近似: `SessionStart` / `UserPromptSubmit` → `PreInvocation`、`SessionEnd` → `Stop`（意味が一致しない点を警告）
+5. 対応のないイベント（`SubagentStop`, `PreCompact`, `Notification` 等）は除外 + 警告
+6. `http` / `prompt` / `agent` は `command` へ変換できない場合は除外 + 警告（公式は `command` のみ）
+7. stdin/stdout 差分はラッパースクリプトで吸収（`tool_name`/`tool_input` ↔ `toolCall`、`permissionDecision` ↔ `decision`）
+8. 配置先: Project `.agents/hooks.json` / Personal `~/.gemini/config/hooks.json`（単一ファイル・マージ戦略は #309 で決定）
+
+詳細はセクション 10。
+
 ### Copilot CLI → Claude Code
 
 1. `"version"` フィールドを除去
@@ -622,3 +684,257 @@ Claude Code は PascalCase、Copilot CLI は小文字。
 5. `"timeoutSec"` → `"timeout"` にキー名変更
 6. `"cwd"` / `"env"` は Claude Code に対応がないため除外または警告
 7. `errorOccurred` は除外
+
+---
+
+## 10. Google Antigravity
+
+> **出典:** [Antigravity Hooks](https://antigravity.google/docs/hooks)（本文取得・確認日: 2026-07-26）  
+> **PLM 実装状況:** 未実装（[#309](https://github.com/DIO0550/plugin-manager/issues/309)）  
+> **関連:** [#399](https://github.com/DIO0550/plugin-manager/issues/399)（本セクション追加）、`docs/concepts/targets.md`、`docs/hooks-conversion/index.md`
+
+### 10.1 配置先
+
+| スコープ | パス | 備考 |
+|----------|------|------|
+| Project（workspace） | `.agents/hooks.json` | AGY / AGY CLI / AGY IDE 共通 |
+| Global（Personal） | `~/.gemini/config/hooks.json` | 同上 |
+
+公式は customization directory として `.agents/`（workspace）と `~/.gemini/config/`（global）を明記。ファイル名は `hooks.json`。
+
+> 一部の二次記事では CLI 専用に `~/.gemini/antigravity-cli/hooks.json` と記載されるが、2026-07 時点の公式および実機検証記事（Atamel, 2026-07-16）は **`~/.gemini/config/hooks.json` を Global 正とする**。実装前に最新公式で再確認すること。
+
+### 10.2 設定構造（公式）
+
+トップレベルは **フック名 → イベント設定** のマップ。Claude Code（`hooks.<Event>`）や Copilot（`hooks.<event>`）とは異なり、複数の命名フックを 1 ファイルに同居できる。
+
+```json
+{
+  "my-linter-hook": {
+    "PostToolUse": [
+      {
+        "matcher": "run_command",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./scripts/lint.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  },
+  "safety-gate": {
+    "enabled": false,
+    "PreToolUse": [
+      {
+        "matcher": "run_command",
+        "hooks": [
+          {
+            "command": "./scripts/safety-check.sh"
+          }
+        ]
+      }
+    ]
+  },
+  "reminder": {
+    "PreInvocation": [
+      {
+        "type": "command",
+        "command": "./scripts/reminder.sh"
+      }
+    ]
+  }
+}
+```
+
+#### 命名フックのフィールド
+
+| フィールド | 型 | 説明 |
+|------------|-----|------|
+| `enabled` | boolean | 省略時 `true`。`false` で個別無効化（削除不要） |
+| `PreToolUse` / `PostToolUse` / `PreInvocation` / `PostInvocation` / `Stop` | array | 各イベントのハンドラ定義 |
+
+#### ハンドラ設定（`hooks` 配列要素）
+
+| フィールド | 型 | 説明 |
+|------------|-----|------|
+| `type` | string | 省略可。現状 `"command"` のみ。デフォルト `"command"` |
+| `command` | string | 必須。実行するシェルコマンド |
+| `timeout` | integer | 秒。デフォルト **30**（Claude Code の 600 と異なる） |
+
+#### 構造の非対称性（変換時に重要）
+
+| イベント | 配列要素の形 | matcher |
+|----------|--------------|---------|
+| `PreToolUse` / `PostToolUse` | `{ "matcher": "<regex>", "hooks": [ ... ] }` | ツール名に対する regex。`""` / `"*"` は全ツール |
+| `PreInvocation` / `PostInvocation` / `Stop` | `{ "type": "command", "command": "..." }`（**フラット**） | 無視。`{matcher, hooks:[]}` でラップすると ** silently skip** される報告あり |
+
+### 10.3 サポートイベント
+
+| イベント | 発火タイミング | Matcher |
+|----------|----------------|---------|
+| `PreToolUse` | ツール実行前 | ツール名（例: `run_command`） |
+| `PostToolUse` | ツール完了後 | ツール名 |
+| `PreInvocation` | モデル呼び出し前 | N/A |
+| `PostInvocation` | ツール呼び出し群の後 | N/A |
+| `Stop` | 実行ループ終了時 | N/A |
+
+#### Claude Code からのイベント対応方針（#309 向け）
+
+| Claude Code | Antigravity | 変換方針 |
+|-------------|-------------|---------|
+| `PreToolUse` | `PreToolUse` | 直接変換。matcher のツール名をリマップ |
+| `PostToolUse` | `PostToolUse` | 直接変換。stdout は `{}` 固定寄り |
+| `Stop` | `Stop` | 直接変換。出力意味が異なる（後述） |
+| `SessionStart` | `PreInvocation`（近似） | 警告付き近似。毎モデル呼び出しで発火する点に注意 |
+| `UserPromptSubmit` | `PreInvocation`（近似） | 同上。`invocationNum` 等でフィルタが必要な場合あり |
+| `SessionEnd` | `Stop`（近似） | 警告付き近似。`terminationReason` / `fullyIdle` が異なる |
+| `SubagentStop` / `SubagentStart` | × | 除外 + 警告 |
+| `PreCompact` / `PostCompact` / `Notification` / `PermissionRequest` 等 | × | 除外 + 警告 |
+| — | `PostInvocation` | Claude Code 側に直接対応なし（生成しない） |
+
+### 10.4 サポートツール名（matcher 用）
+
+Antigravity のツール名は Claude Code / Copilot と大きく異なる。matcher 変換時に必須。
+
+| カテゴリ | Antigravity ツール名（例） |
+|----------|---------------------------|
+| ファイル | `view_file`, `write_to_file`, `replace_file_content`, `multi_replace_file_content`, `list_dir`, `find_by_name` |
+| 検索 | `grep_search`, `search_web`, `read_url_content` |
+| 実行 | `run_command`, `manage_task`, `schedule`, `list_permissions`, `ask_permission` |
+| エージェント | `invoke_subagent`, `define_subagent`, `send_message`, `manage_subagents` |
+| その他 | `ask_question`, `generate_image` |
+
+#### Claude Code → Antigravity（matcher 用の代表マッピング）
+
+| Claude Code | Antigravity | 備考 |
+|-------------|-------------|------|
+| `Bash` | `run_command` | |
+| `Read` | `view_file` | |
+| `Write` | `write_to_file` | |
+| `Edit` | `replace_file_content` | |
+| `MultiEdit` | `multi_replace_file_content` | |
+| `Glob` | `find_by_name` | |
+| `Grep` | `grep_search` | |
+| `WebFetch` | `read_url_content` | |
+| `WebSearch` | `search_web` | |
+| `Agent` | `invoke_subagent` | 近似 |
+
+### 10.5 stdin / stdout 契約
+
+フィールド名は **camelCase**。全イベント共通メタデータ:
+
+| フィールド | 型 | 説明 |
+|------------|-----|------|
+| `conversationId` | string | 会話 UUID |
+| `workspacePaths` | string[] | マウント済みワークスペースの絶対パス |
+| `transcriptPath` | string | `transcript.jsonl` の絶対パス（`~/.gemini/antigravity/...` または CLI 相当） |
+| `artifactDirectoryPath` | string | 成果物・スクリーンショットディレクトリ |
+
+> AGY は stdin にイベント名を含めない（Atamel 記事で確認）。スクリプト側で CLI 引数等によりイベントを識別する必要がある場合がある。
+
+#### PreToolUse
+
+**stdin（例）:**
+
+```json
+{
+  "toolCall": {
+    "name": "run_command",
+    "args": {
+      "CommandLine": "npm test",
+      "Cwd": "/workspace/project",
+      "WaitMsBeforeAsync": 5000
+    }
+  },
+  "stepIdx": 19,
+  "conversationId": "ec33ebf9-0cba-4100-8142-c61503f6c587",
+  "workspacePaths": ["/workspace/project"],
+  "transcriptPath": "~/.gemini/antigravity/brain/.../transcript.jsonl",
+  "artifactDirectoryPath": "~/.gemini/antigravity/brain/..."
+}
+```
+
+**stdout:**
+
+| フィールド | 型 | 説明 |
+|------------|-----|------|
+| `decision` | string | **必須。** `"allow"` / `"deny"` / `"ask"` / `"force_ask"` |
+| `reason` | string | 任意。決定理由（エージェント/ユーザー向け） |
+| `permissionOverrides` | string[] | 任意。例: `["command(npm test)"]` |
+
+```json
+{
+  "decision": "ask",
+  "reason": "Requires confirmation for test execution.",
+  "permissionOverrides": ["command(npm test)"]
+}
+```
+
+> Issue #399 提案の `allow` / `deny` / `ask` に加え、公式は `"force_ask"`（キャッシュ済み Always Allow を無視して必ず確認）も定義する。
+
+#### PostToolUse
+
+**stdin:** `stepIdx`, `error`（成功時は空文字）, 共通フィールド。実機では `toolCall` が付与される場合あり。  
+**stdout:** `{}`（空オブジェクト）。
+
+#### PreInvocation
+
+**stdin:** `invocationNum`（0 始まり）, `initialNumSteps`, 共通フィールド。  
+**stdout:** 任意で `injectSteps`（`toolCall` / `userMessage` / `ephemeralMessage` のいずれか）。
+
+#### PostInvocation
+
+**stdin:** PreInvocation と同型。  
+**stdout:** `injectSteps`（任意）, `terminationBehavior`（`""` / `"force_continue"` / `"terminate"`）。
+
+#### Stop
+
+**stdin:** `executionNum`, `terminationReason`（例: `model_stop`, `max_steps_exceeded`, `error`）, `error`, `fullyIdle`（必須 boolean）, 共通フィールド。  
+**stdout:**
+
+```json
+{
+  "decision": "continue",
+  "reason": "Not done yet"
+}
+```
+
+- `decision: "continue"` → 停止を阻止してループ再突入。`reason` はシステムメッセージとして注入。
+- それ以外 → 停止を許可。
+
+#### Claude Code との I/O 差分（ラッパー必須箇所）
+
+| 項目 | Claude Code | Antigravity | 変換 |
+|------|-------------|-------------|------|
+| ツール名 | `tool_name` (PascalCase) | `toolCall.name` (snake_case 系) | リマップ |
+| ツール引数 | `tool_input` オブジェクト | `toolCall.args`（キーは PascalCase 寄り） | 構造変換 |
+| セッション ID | `session_id` | `conversationId` | リネーム |
+| cwd | `cwd` | `workspacePaths[0]` 等 | 抽出 |
+| PreToolUse 許可 | `hookSpecificOutput.permissionDecision` (`allow`/`deny`) | トップレベル `decision`（+ `ask`/`force_ask`） | アンラップ + 値域拡張 |
+| Stop 阻止 | `decision: "block"` | `decision: "continue"` | **値の意味が逆方向に見える**ため要注意 |
+| exit code 2 | ブロック | 公式は JSON `decision` 中心。非 0 exit の扱いは実装時に再確認 | ラッパーで JSON へ正規化推奨 |
+
+### 10.6 Claude Code 形式からの変換チェックリスト（#309）
+
+1. **構造:** `hooks.<Event>` → `{ "<plugin-or-hook-name>": { <Event>: ... } }`
+2. **非 ToolUse:** matcher グループをフラット handlers に展開する（ラップし直さない）
+3. **イベント:** 直接対応 3 種 + 近似 2 種。それ以外は警告除外
+4. **ツール名:** matcher とラッパー内の両方で Antigravity 名へ変換
+5. **ハンドラ種別:** `command` 以外は除外またはスタブ方針を決める（公式は command のみ）
+6. **timeout:** Claude の 600 デフォルトをそのまま持ち込まない（Antigravity 既定 30）
+7. **単一ファイル配置:** Personal / Project とも 1 つの `hooks.json`。複数プラグイン時のマージ / 所有権は Codex/Cursor と同様の未解決課題
+8. **パス:** CLI では相対パスが起動 cwd 依存で失敗しうるため、配置時に絶対パスへ正規化する方針を検討
+9. **旧二次情報の排除:** `allow_tool` / `deny_reason` や `SessionStart` 等の旧イベント一覧は公式と不一致。実装は本セクション（公式）に従う
+
+### 10.7 PLM 実装メモ
+
+| 項目 | 状態 |
+|------|------|
+| `AntigravityTarget::supported_components` に `Hook` | ❌（Skills のみ） |
+| EventMap / KeyMap / StructureConverter | ❌ |
+| `create_layers` への登録 | ❌（「Hook conversion is not yet implemented for target」） |
+| `.agents/hooks.json` / `~/.gemini/config/hooks.json` 配置 | ❌ |
+
+実装は [#309](https://github.com/DIO0550/plugin-manager/issues/309) で追跡。本セクションを単一リファレンスとする。

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -17,7 +17,7 @@ use crate::commands::{
 Supported environments:
   - OpenAI Codex: Skills, Agents, Instructions
   - VSCode Copilot: Skills, Agents, Commands, Instructions
-  - Google Antigravity: Skills
+  - Google Antigravity: Skills, Hooks
   - Gemini CLI: Skills, Instructions
 
 Install plugins from GitHub or marketplaces, manage their lifecycle, and keep them synchronized across environments."#

--- a/src/component/deployment/hook_deploy.rs
+++ b/src/component/deployment/hook_deploy.rs
@@ -14,14 +14,27 @@ use std::path::Path;
 impl ComponentDeployment {
     /// 変換後 JSON に残った hook 定義数を数える。
     ///
-    /// Copilot は `hooks.<event>[]` のフラット構造、Codex は
-    /// `hooks.<event>[].hooks[]` の matcher group 構造を使うため両方を扱う。
+    /// - Copilot / Cursor: `hooks.<event>[]`（フラットまたは entry matcher）
+    /// - Codex: `hooks.<event>[].hooks[]`（matcher group）
+    /// - Antigravity: `<named-hook>.<event>[]`（トップに `hooks` キーなし）
     fn count_hooks_in_json(json: &serde_json::Value) -> usize {
-        let Some(hooks) = json.get("hooks").and_then(|h| h.as_object()) else {
-            return 0;
-        };
+        if let Some(hooks) = json.get("hooks").and_then(|h| h.as_object()) {
+            return Self::count_event_hook_entries(hooks);
+        }
 
-        hooks
+        // Antigravity named-hook map: each top-level value is an event object.
+        json.as_object()
+            .map(|root| {
+                root.values()
+                    .filter_map(|v| v.as_object())
+                    .map(Self::count_event_hook_entries)
+                    .sum()
+            })
+            .unwrap_or(0)
+    }
+
+    fn count_event_hook_entries(events: &serde_json::Map<String, serde_json::Value>) -> usize {
+        events
             .values()
             .filter_map(|event_hooks| event_hooks.as_array())
             .flat_map(|event_hooks| event_hooks.iter())
@@ -32,6 +45,22 @@ impl ComponentDeployment {
                     .map_or(1, |nested| nested.len())
             })
             .sum()
+    }
+
+    /// Rename Antigravity's default `"converted"` key to the component safe name.
+    fn rename_antigravity_hook_key(json: &mut serde_json::Value, safe_name: &str) {
+        use crate::hooks::converter::antigravity_default_hook_name;
+
+        let Some(root) = json.as_object_mut() else {
+            return;
+        };
+        let default_key = antigravity_default_hook_name();
+        if default_key == safe_name {
+            return;
+        }
+        if let Some(events) = root.remove(default_key) {
+            root.insert(safe_name.to_string(), events);
+        }
     }
 
     /// JSON 内の hooks[].bash / hooks[].command パスを名前空間付きに書き換える
@@ -102,6 +131,12 @@ impl ComponentDeployment {
         // Hook 名をサニタイズ（パスセグメント・シェルコマンドで安全に使えるようにする）
         let hook_name = HookName::new(self.name());
         let safe_name = hook_name.as_safe();
+
+        if target_kind == TargetKind::Antigravity
+            && convert_result.source_format == SourceFormat::ClaudeCode
+        {
+            Self::rename_antigravity_hook_key(&mut convert_result.json, safe_name);
+        }
 
         if !convert_result.scripts.is_empty() {
             let original_paths: HashSet<String> = convert_result

--- a/src/component/deployment/hook_deploy.rs
+++ b/src/component/deployment/hook_deploy.rs
@@ -14,15 +14,14 @@ use std::path::Path;
 impl ComponentDeployment {
     /// 変換後 JSON に残った hook 定義数を数える。
     ///
-    /// - Copilot / Cursor: `hooks.<event>[]`（フラットまたは entry matcher）
-    /// - Codex: `hooks.<event>[].hooks[]`（matcher group）
-    /// - Antigravity: `<named-hook>.<event>[]`（トップに `hooks` キーなし）
+    /// - 標準形式: `hooks.<event>[]`（フラットまたは matcher group）
+    /// - 命名フック形式: `<named-hook>.<event>[]`（トップに `hooks` キーなし）
     fn count_hooks_in_json(json: &serde_json::Value) -> usize {
         if let Some(hooks) = json.get("hooks").and_then(|h| h.as_object()) {
             return Self::count_event_hook_entries(hooks);
         }
 
-        // Antigravity named-hook map: each top-level value is an event object.
+        // Named-hook map: each top-level value is an event object.
         json.as_object()
             .map(|root| {
                 root.values()
@@ -47,18 +46,20 @@ impl ComponentDeployment {
             .sum()
     }
 
-    /// Rename Antigravity's default `"converted"` key to the component safe name.
-    fn rename_antigravity_hook_key(json: &mut serde_json::Value, safe_name: &str) {
-        use crate::hooks::converter::antigravity_default_hook_name;
-
+    /// 命名フック形式（トップに `hooks` が無い単一ルートキー）なら、
+    /// そのキーをコンポーネント名へリネームする。標準形式では何もしない。
+    fn apply_component_name_to_root(json: &mut serde_json::Value, safe_name: &str) {
         let Some(root) = json.as_object_mut() else {
             return;
         };
-        let default_key = antigravity_default_hook_name();
-        if default_key == safe_name {
+        if root.contains_key("hooks") || root.len() != 1 {
             return;
         }
-        if let Some(events) = root.remove(default_key) {
+        let old_key = root.keys().next().expect("len == 1").clone();
+        if old_key == safe_name {
+            return;
+        }
+        if let Some(events) = root.remove(&old_key) {
             root.insert(safe_name.to_string(), events);
         }
     }
@@ -132,10 +133,8 @@ impl ComponentDeployment {
         let hook_name = HookName::new(self.name());
         let safe_name = hook_name.as_safe();
 
-        if target_kind == TargetKind::Antigravity
-            && convert_result.source_format == SourceFormat::ClaudeCode
-        {
-            Self::rename_antigravity_hook_key(&mut convert_result.json, safe_name);
+        if convert_result.source_format == SourceFormat::ClaudeCode {
+            Self::apply_component_name_to_root(&mut convert_result.json, safe_name);
         }
 
         if !convert_result.scripts.is_empty() {

--- a/src/hooks/converter.rs
+++ b/src/hooks/converter.rs
@@ -14,11 +14,6 @@ mod cursor;
 
 pub use self::converter::*;
 
-/// Default named-hook key used by Antigravity conversion (before deploy rename).
-pub fn antigravity_default_hook_name() -> &'static str {
-    antigravity::ANTIGRAVITY_DEFAULT_HOOK_NAME
-}
-
 #[cfg(test)]
 mod antigravity_test;
 #[cfg(test)]

--- a/src/hooks/converter.rs
+++ b/src/hooks/converter.rs
@@ -1,10 +1,11 @@
 //! Hook conversion sub-parent.
 //!
 //! Groups the polymorphic conversion engine (`converter`) with target-specific
-//! adapters (`codex`, `copilot`). Lifts the leaf `converter` symbols into the
-//! sub-parent's namespace so the external path
+//! adapters (`antigravity`, `codex`, `copilot`, `cursor`). Lifts the leaf
+//! `converter` symbols into the sub-parent's namespace so the external path
 //! `crate::hooks::converter::*` continues to resolve unchanged.
 
+mod antigravity;
 mod codex;
 #[allow(clippy::module_inception)]
 mod converter;
@@ -13,6 +14,13 @@ mod cursor;
 
 pub use self::converter::*;
 
+/// Default named-hook key used by Antigravity conversion (before deploy rename).
+pub fn antigravity_default_hook_name() -> &'static str {
+    antigravity::ANTIGRAVITY_DEFAULT_HOOK_NAME
+}
+
+#[cfg(test)]
+mod antigravity_test;
 #[cfg(test)]
 mod codex_test;
 #[cfg(test)]

--- a/src/hooks/converter/antigravity.rs
+++ b/src/hooks/converter/antigravity.rs
@@ -2,8 +2,8 @@
 //!
 //! EventMap is in `event/antigravity.rs`; ToolMap is in `tool/antigravity.rs`.
 //! Antigravity uses a top-level **named hook → event map** structure (unlike
-//! Claude Code / Copilot / Codex `hooks.<Event>`). ToolUse events keep matcher
-//! groups; PreInvocation / PostInvocation / Stop use flat handler arrays.
+//! Claude Code / Copilot / Codex `hooks.<Event>`). Matcher-group vs flat
+//! handler shape is decided by [`AntigravityEventMap::preserve_matcher_groups`].
 
 use serde_json::Value;
 
@@ -13,13 +13,11 @@ use crate::hooks::converter::{ConversionWarning, ScriptInfo, SourceFormat};
 
 use super::converter::{KeyMap, ScriptGenerator, StructureConverter};
 
-pub(crate) use super::super::event::antigravity::{
-    AntigravityEventMap, ANTIGRAVITY_FLAT_HANDLER_EVENTS,
-};
+pub(crate) use super::super::event::antigravity::AntigravityEventMap;
 
 /// Default key used when wrapping converted events under a named hook.
-/// Deploy renames this to the component's sanitized name.
-pub(crate) const ANTIGRAVITY_DEFAULT_HOOK_NAME: &str = "converted";
+/// Deploy renames the single root key to the component's sanitized name.
+pub(crate) const DEFAULT_HOOK_NAME: &str = "converted";
 
 pub(crate) struct AntigravityKeyMap;
 
@@ -84,6 +82,19 @@ impl KeyMap for AntigravityKeyMap {
 pub(crate) struct AntigravityStructureConverter;
 
 impl StructureConverter for AntigravityStructureConverter {
+    fn validate_input(&self, value: &Value) -> Result<(), PlmError> {
+        // Native format is a named-hook map (no top-level `hooks`). Claude Code
+        // input still has `hooks` and is accepted here; ClaudeCode branch
+        // re-validates that object before conversion.
+        if value.is_object() {
+            Ok(())
+        } else {
+            Err(PlmError::HookConversion(
+                "Hooks config must be a JSON object".to_string(),
+            ))
+        }
+    }
+
     fn detect_format(&self, value: &Value) -> SourceFormat {
         // Claude Code / Copilot / Codex shaped input has a top-level `hooks` object.
         if value.get("hooks").and_then(|h| h.as_object()).is_some() {
@@ -118,8 +129,14 @@ impl StructureConverter for AntigravityStructureConverter {
             });
         }
 
-        // Final assembly replaces the root with a named-hook map.
+        // `assemble` replaces the root with a named-hook map.
         (Value::Object(serde_json::Map::new()), warnings)
+    }
+
+    fn assemble(&self, _top_level: Value, events: Value) -> Value {
+        let mut root = serde_json::Map::new();
+        root.insert(DEFAULT_HOOK_NAME.to_string(), events);
+        Value::Object(root)
     }
 }
 
@@ -133,7 +150,7 @@ impl ScriptGenerator for AntigravityScriptGenerator {
         _matcher: Option<&str>,
         _index: usize,
     ) -> ScriptInfo {
-        // Phase 1: keep commands inline (structure conversion only).
+        // Keep commands inline (structure conversion only).
         // stdin/stdout bridging wrappers are a follow-up if needed.
         ScriptInfo {
             path: String::new(),

--- a/src/hooks/converter/antigravity.rs
+++ b/src/hooks/converter/antigravity.rs
@@ -1,0 +1,179 @@
+//! Antigravity implementation of the hook conversion layers.
+//!
+//! EventMap is in `event/antigravity.rs`; ToolMap is in `tool/antigravity.rs`.
+//! Antigravity uses a top-level **named hook → event map** structure (unlike
+//! Claude Code / Copilot / Codex `hooks.<Event>`). ToolUse events keep matcher
+//! groups; PreInvocation / PostInvocation / Stop use flat handler arrays.
+
+use serde_json::Value;
+
+use super::super::model::{CommandHook, HttpHook, StubHook};
+use crate::error::PlmError;
+use crate::hooks::converter::{ConversionWarning, ScriptInfo, SourceFormat};
+
+use super::converter::{KeyMap, ScriptGenerator, StructureConverter};
+
+pub(crate) use super::super::event::antigravity::{
+    AntigravityEventMap, ANTIGRAVITY_FLAT_HANDLER_EVENTS,
+};
+
+/// Default key used when wrapping converted events under a named hook.
+/// Deploy renames this to the component's sanitized name.
+pub(crate) const ANTIGRAVITY_DEFAULT_HOOK_NAME: &str = "converted";
+
+pub(crate) struct AntigravityKeyMap;
+
+impl KeyMap for AntigravityKeyMap {
+    fn map_keys(&self, hook: &Value, hook_type: &str) -> (Value, Vec<ConversionWarning>) {
+        let Some(hook_obj) = hook.as_object() else {
+            return (hook.clone(), vec![]);
+        };
+
+        let mut output = serde_json::Map::new();
+        let mut warnings = Vec::new();
+
+        for (key, value) in hook_obj {
+            match key.as_str() {
+                "async" => warnings.push(ConversionWarning::RemovedField {
+                    field: "async".to_string(),
+                    reason: "Antigravity hooks do not support async hooks".to_string(),
+                }),
+                "once" => warnings.push(ConversionWarning::RemovedField {
+                    field: "once".to_string(),
+                    reason: "Antigravity hooks do not support once hooks".to_string(),
+                }),
+                "bash" => warnings.push(ConversionWarning::RemovedField {
+                    field: "bash".to_string(),
+                    reason: "Antigravity hooks use command, not bash".to_string(),
+                }),
+                "timeoutSec" if !output.contains_key("timeout") => {
+                    output.insert("timeout".to_string(), value.clone());
+                }
+                "timeoutSec" => {}
+                "statusMessage" | "comment" => {
+                    warnings.push(ConversionWarning::RemovedField {
+                        field: key.clone(),
+                        reason: "Antigravity hooks do not support statusMessage/comment"
+                            .to_string(),
+                    });
+                }
+                "command_windows" | "commandWindows" => {
+                    warnings.push(ConversionWarning::RemovedField {
+                        field: key.clone(),
+                        reason: "Antigravity hooks do not support Windows command fields"
+                            .to_string(),
+                    });
+                }
+                _ => {
+                    output.insert(key.clone(), value.clone());
+                }
+            }
+        }
+
+        if hook_type == "command" {
+            if let Some(command) = hook_obj.get("command") {
+                output.insert("command".to_string(), command.clone());
+            }
+            output.insert("type".to_string(), Value::from("command"));
+        }
+
+        (Value::Object(output), warnings)
+    }
+}
+
+pub(crate) struct AntigravityStructureConverter;
+
+impl StructureConverter for AntigravityStructureConverter {
+    fn detect_format(&self, value: &Value) -> SourceFormat {
+        // Claude Code / Copilot / Codex shaped input has a top-level `hooks` object.
+        if value.get("hooks").and_then(|h| h.as_object()).is_some() {
+            return SourceFormat::ClaudeCode;
+        }
+        // Native Antigravity: top-level named-hook map (no `hooks` wrapper).
+        SourceFormat::TargetFormat
+    }
+
+    fn handle_target_format(
+        &self,
+        value: Value,
+    ) -> Result<(Value, Vec<ConversionWarning>), PlmError> {
+        Ok((value, vec![]))
+    }
+
+    fn convert_top_level(&self, value: &Value) -> (Value, Vec<ConversionWarning>) {
+        let mut warnings = Vec::new();
+
+        if value.get("version").is_some() {
+            warnings.push(ConversionWarning::RemovedField {
+                field: "version".to_string(),
+                reason: "Antigravity hooks do not use Copilot CLI's version field".to_string(),
+            });
+        }
+
+        if value.get("disableAllHooks").is_some() {
+            warnings.push(ConversionWarning::RemovedField {
+                field: "disableAllHooks".to_string(),
+                reason: "Antigravity hooks use per-hook enabled:false instead of disableAllHooks"
+                    .to_string(),
+            });
+        }
+
+        // Final assembly replaces the root with a named-hook map.
+        (Value::Object(serde_json::Map::new()), warnings)
+    }
+}
+
+pub(crate) struct AntigravityScriptGenerator;
+
+impl ScriptGenerator for AntigravityScriptGenerator {
+    fn generate_command_script(
+        &self,
+        hook: &CommandHook<'_>,
+        _event: &str,
+        _matcher: Option<&str>,
+        _index: usize,
+    ) -> ScriptInfo {
+        // Phase 1: keep commands inline (structure conversion only).
+        // stdin/stdout bridging wrappers are a follow-up if needed.
+        ScriptInfo {
+            path: String::new(),
+            content: String::new(),
+            original_config: hook.raw.clone(),
+            matcher: None,
+        }
+    }
+
+    fn generate_http_script(
+        &self,
+        hook: &HttpHook<'_>,
+        _event: &str,
+        matcher: Option<&str>,
+        _index: usize,
+    ) -> Result<ScriptInfo, PlmError> {
+        Ok(ScriptInfo {
+            path: String::new(),
+            content: String::new(),
+            original_config: hook.raw.clone(),
+            matcher: matcher.map(|s| s.to_string()),
+        })
+    }
+
+    fn generate_stub_script(
+        &self,
+        hook: &StubHook<'_>,
+        _event: &str,
+        matcher: Option<&str>,
+        _index: usize,
+    ) -> ScriptInfo {
+        ScriptInfo {
+            path: String::new(),
+            content: String::new(),
+            original_config: hook.raw.clone(),
+            matcher: matcher.map(|s| s.to_string()),
+        }
+    }
+
+    fn preserves_stub_inline(&self) -> bool {
+        false
+    }
+}

--- a/src/hooks/converter/antigravity_test.rs
+++ b/src/hooks/converter/antigravity_test.rs
@@ -3,8 +3,7 @@
 use serde_json::json;
 
 use super::antigravity::{
-    AntigravityEventMap, AntigravityKeyMap, AntigravityStructureConverter,
-    ANTIGRAVITY_DEFAULT_HOOK_NAME,
+    AntigravityEventMap, AntigravityKeyMap, AntigravityStructureConverter, DEFAULT_HOOK_NAME,
 };
 use super::converter::{
     convert, ConversionWarning, EventMap, KeyMap, SourceFormat, StructureConverter,
@@ -105,7 +104,7 @@ fn test_convert_wraps_named_hook_and_remaps_matcher() {
     let root = result.json.as_object().unwrap();
     assert!(root.get("hooks").is_none());
     let named = root
-        .get(ANTIGRAVITY_DEFAULT_HOOK_NAME)
+        .get(DEFAULT_HOOK_NAME)
         .and_then(|v| v.as_object())
         .expect("named hook wrapper");
 
@@ -141,9 +140,7 @@ fn test_convert_merges_events_mapping_to_same_target() {
     }"#;
 
     let result = convert(input, TargetKind::Antigravity).unwrap();
-    let named = result.json[ANTIGRAVITY_DEFAULT_HOOK_NAME]
-        .as_object()
-        .unwrap();
+    let named = result.json[DEFAULT_HOOK_NAME].as_object().unwrap();
     let pre_inv = named
         .get("PreInvocation")
         .and_then(|v| v.as_array())
@@ -190,7 +187,7 @@ fn test_convert_excludes_http_and_stub_hooks() {
     }"#;
 
     let result = convert(input, TargetKind::Antigravity).unwrap();
-    let hooks = &result.json[ANTIGRAVITY_DEFAULT_HOOK_NAME]["PreToolUse"][0]["hooks"];
+    let hooks = &result.json[DEFAULT_HOOK_NAME]["PreToolUse"][0]["hooks"];
     assert_eq!(hooks.as_array().unwrap().len(), 1);
     assert_eq!(hooks[0]["command"], "./ok.sh");
     assert!(result.warnings.iter().any(|w| matches!(

--- a/src/hooks/converter/antigravity_test.rs
+++ b/src/hooks/converter/antigravity_test.rs
@@ -1,0 +1,204 @@
+//! Unit tests for Antigravity conversion layers and end-to-end convert().
+
+use serde_json::json;
+
+use super::antigravity::{
+    AntigravityEventMap, AntigravityKeyMap, AntigravityStructureConverter,
+    ANTIGRAVITY_DEFAULT_HOOK_NAME,
+};
+use super::converter::{
+    convert, ConversionWarning, EventMap, KeyMap, SourceFormat, StructureConverter,
+};
+use crate::target::TargetKind;
+
+#[test]
+fn test_event_map_via_converter_module() {
+    let map = AntigravityEventMap;
+    assert_eq!(map.map_event("PreToolUse"), Some("PreToolUse"));
+    assert_eq!(map.map_event("SessionStart"), Some("PreInvocation"));
+}
+
+#[test]
+fn test_key_map_keeps_command_and_strips_unsupported() {
+    let map = AntigravityKeyMap;
+    let hook = json!({
+        "type": "command",
+        "command": "./lint.sh",
+        "timeout": 10,
+        "async": true,
+        "bash": "./wrappers/x.sh",
+        "statusMessage": "linting"
+    });
+
+    let (mapped, warnings) = map.map_keys(&hook, "command");
+    let obj = mapped.as_object().unwrap();
+
+    assert_eq!(obj.get("command").unwrap(), "./lint.sh");
+    assert_eq!(obj.get("timeout").unwrap(), 10);
+    assert_eq!(obj.get("type").unwrap(), "command");
+    assert!(obj.get("async").is_none());
+    assert!(obj.get("bash").is_none());
+    assert!(obj.get("statusMessage").is_none());
+    assert!(warnings
+        .iter()
+        .any(|w| matches!(w, ConversionWarning::RemovedField { field, .. } if field == "async")));
+}
+
+#[test]
+fn test_detect_format_claude_code_has_hooks() {
+    let conv = AntigravityStructureConverter;
+    let value = json!({ "hooks": { "PreToolUse": [] } });
+    assert!(matches!(
+        conv.detect_format(&value),
+        SourceFormat::ClaudeCode
+    ));
+}
+
+#[test]
+fn test_detect_format_native_named_hook_map() {
+    let conv = AntigravityStructureConverter;
+    let value = json!({
+        "my-hook": {
+            "PreToolUse": [
+                { "matcher": "run_command", "hooks": [{ "type": "command", "command": "./x.sh" }] }
+            ]
+        }
+    });
+    assert!(matches!(
+        conv.detect_format(&value),
+        SourceFormat::TargetFormat
+    ));
+}
+
+#[test]
+fn test_convert_wraps_named_hook_and_remaps_matcher() {
+    let input = r#"{
+        "hooks": {
+            "PreToolUse": [
+                {
+                    "matcher": "Bash",
+                    "hooks": [
+                        { "type": "command", "command": "./validate.sh", "timeout": 10 }
+                    ]
+                }
+            ],
+            "Stop": [
+                {
+                    "hooks": [
+                        { "type": "command", "command": "./on-stop.sh" }
+                    ]
+                }
+            ],
+            "Notification": [
+                {
+                    "hooks": [
+                        { "type": "command", "command": "./notify.sh" }
+                    ]
+                }
+            ]
+        }
+    }"#;
+
+    let result = convert(input, TargetKind::Antigravity).unwrap();
+    assert_eq!(result.source_format, SourceFormat::ClaudeCode);
+
+    let root = result.json.as_object().unwrap();
+    assert!(root.get("hooks").is_none());
+    let named = root
+        .get(ANTIGRAVITY_DEFAULT_HOOK_NAME)
+        .and_then(|v| v.as_object())
+        .expect("named hook wrapper");
+
+    let pre = named.get("PreToolUse").and_then(|v| v.as_array()).unwrap();
+    assert_eq!(pre.len(), 1);
+    assert_eq!(pre[0]["matcher"], "run_command");
+    assert_eq!(pre[0]["hooks"][0]["command"], "./validate.sh");
+    assert_eq!(pre[0]["hooks"][0]["type"], "command");
+
+    // Stop must be flat handlers (not matcher groups).
+    let stop = named.get("Stop").and_then(|v| v.as_array()).unwrap();
+    assert_eq!(stop.len(), 1);
+    assert!(stop[0].get("hooks").is_none());
+    assert_eq!(stop[0]["command"], "./on-stop.sh");
+    assert_eq!(stop[0]["type"], "command");
+
+    assert!(result.warnings.iter().any(
+        |w| matches!(w, ConversionWarning::UnsupportedEvent { event } if event == "Notification")
+    ));
+}
+
+#[test]
+fn test_convert_merges_events_mapping_to_same_target() {
+    let input = r#"{
+        "hooks": {
+            "SessionStart": [
+                { "hooks": [{ "type": "command", "command": "./session.sh" }] }
+            ],
+            "UserPromptSubmit": [
+                { "hooks": [{ "type": "command", "command": "./prompt.sh" }] }
+            ]
+        }
+    }"#;
+
+    let result = convert(input, TargetKind::Antigravity).unwrap();
+    let named = result.json[ANTIGRAVITY_DEFAULT_HOOK_NAME]
+        .as_object()
+        .unwrap();
+    let pre_inv = named
+        .get("PreInvocation")
+        .and_then(|v| v.as_array())
+        .unwrap();
+    assert_eq!(pre_inv.len(), 2);
+    assert!(pre_inv.iter().all(|h| h.get("hooks").is_none()));
+}
+
+#[test]
+fn test_convert_passthrough_native_format() {
+    let input = r#"{
+        "safety-gate": {
+            "enabled": false,
+            "PreToolUse": [
+                {
+                    "matcher": "run_command",
+                    "hooks": [{ "type": "command", "command": "./safety.sh" }]
+                }
+            ]
+        }
+    }"#;
+
+    let result = convert(input, TargetKind::Antigravity).unwrap();
+    assert_eq!(result.source_format, SourceFormat::TargetFormat);
+    assert_eq!(result.json["safety-gate"]["enabled"], false);
+    assert!(result.scripts.is_empty());
+}
+
+#[test]
+fn test_convert_excludes_http_and_stub_hooks() {
+    let input = r#"{
+        "hooks": {
+            "PreToolUse": [
+                {
+                    "matcher": "Bash",
+                    "hooks": [
+                        { "type": "http", "url": "https://example.com" },
+                        { "type": "prompt", "prompt": "ok?" },
+                        { "type": "command", "command": "./ok.sh" }
+                    ]
+                }
+            ]
+        }
+    }"#;
+
+    let result = convert(input, TargetKind::Antigravity).unwrap();
+    let hooks = &result.json[ANTIGRAVITY_DEFAULT_HOOK_NAME]["PreToolUse"][0]["hooks"];
+    assert_eq!(hooks.as_array().unwrap().len(), 1);
+    assert_eq!(hooks[0]["command"], "./ok.sh");
+    assert!(result.warnings.iter().any(|w| matches!(
+        w,
+        ConversionWarning::UnsupportedHookType { hook_type, .. } if hook_type == "http"
+    )));
+    assert!(result.warnings.iter().any(|w| matches!(
+        w,
+        ConversionWarning::UnsupportedHookType { hook_type, .. } if hook_type == "prompt"
+    )));
+}

--- a/src/hooks/converter/converter.rs
+++ b/src/hooks/converter/converter.rs
@@ -256,6 +256,12 @@ pub(crate) struct HookConversionLayers {
     /// each flat hook entry instead of moving it into a wrapper script.
     /// Used by Cursor, which supports entry-level `matcher` on flat arrays.
     pub attach_matcher_to_entries: bool,
+    /// Events that must use flat handler arrays even when
+    /// `preserve_matcher_groups` is true (Antigravity non-ToolUse events).
+    pub flat_handler_events: &'static [&'static str],
+    /// When set, wrap converted events under this named-hook key instead of
+    /// a top-level `"hooks"` object (Antigravity format).
+    pub named_hook_key: Option<&'static str>,
 }
 
 /// Create conversion layers for the given target.
@@ -273,6 +279,8 @@ pub(crate) fn create_layers(target: TargetKind) -> Result<HookConversionLayers, 
             script_gen: Box::new(super::copilot::CopilotScriptGenerator),
             preserve_matcher_groups: false,
             attach_matcher_to_entries: false,
+            flat_handler_events: &[],
+            named_hook_key: None,
         }),
         TargetKind::Codex => Ok(HookConversionLayers {
             event_map: Box::new(super::codex::CodexEventMap),
@@ -282,6 +290,8 @@ pub(crate) fn create_layers(target: TargetKind) -> Result<HookConversionLayers, 
             script_gen: Box::new(super::codex::CodexScriptGenerator),
             preserve_matcher_groups: true,
             attach_matcher_to_entries: false,
+            flat_handler_events: &[],
+            named_hook_key: None,
         }),
         TargetKind::Cursor => Ok(HookConversionLayers {
             event_map: Box::new(super::cursor::CursorEventMap),
@@ -291,6 +301,21 @@ pub(crate) fn create_layers(target: TargetKind) -> Result<HookConversionLayers, 
             script_gen: Box::new(super::cursor::CursorScriptGenerator),
             preserve_matcher_groups: false,
             attach_matcher_to_entries: true,
+            flat_handler_events: &[],
+            named_hook_key: None,
+        }),
+        TargetKind::Antigravity => Ok(HookConversionLayers {
+            event_map: Box::new(super::antigravity::AntigravityEventMap),
+            tool_map: Some(Box::new(
+                super::super::tool::antigravity::AntigravityToolMap,
+            )),
+            key_map: Box::new(super::antigravity::AntigravityKeyMap),
+            structure: Box::new(super::antigravity::AntigravityStructureConverter),
+            script_gen: Box::new(super::antigravity::AntigravityScriptGenerator),
+            preserve_matcher_groups: true,
+            attach_matcher_to_entries: false,
+            flat_handler_events: super::antigravity::ANTIGRAVITY_FLAT_HANDLER_EVENTS,
+            named_hook_key: Some(super::antigravity::ANTIGRAVITY_DEFAULT_HOOK_NAME),
         }),
         other => Err(PlmError::HookConversion(format!(
             "Hook conversion is not yet implemented for target: {}",
@@ -346,18 +371,23 @@ pub fn convert(input: &str, target: TargetKind) -> Result<ConvertOutcome, PlmErr
     let value: Value = serde_json::from_str(input)
         .map_err(|e| PlmError::HookConversion(format!("Invalid JSON: {}", e)))?;
 
-    // Validate hooks field exists and is an object (borrow is dropped before match)
-    match value.get("hooks") {
-        Some(h) if h.is_object() => {}
-        Some(_) => {
-            return Err(PlmError::HookConversion(
-                "'hooks' field must be an object".to_string(),
-            ));
-        }
-        None => {
-            return Err(PlmError::HookConversion(
-                "Missing 'hooks' field".to_string(),
-            ));
+    // Copilot / Codex / Cursor always use a top-level `hooks` object.
+    // Antigravity native format is a named-hook map without that wrapper, so
+    // skip this check for Antigravity (Claude Code → Antigravity still
+    // validates inside the ClaudeCode branch below).
+    if !matches!(target, TargetKind::Antigravity) {
+        match value.get("hooks") {
+            Some(h) if h.is_object() => {}
+            Some(_) => {
+                return Err(PlmError::HookConversion(
+                    "'hooks' field must be an object".to_string(),
+                ));
+            }
+            None => {
+                return Err(PlmError::HookConversion(
+                    "Missing 'hooks' field".to_string(),
+                ));
+            }
         }
     }
 
@@ -372,6 +402,22 @@ pub fn convert(input: &str, target: TargetKind) -> Result<ConvertOutcome, PlmErr
             })
         }
         SourceFormat::ClaudeCode => {
+            // Claude Code shaped input requires a `hooks` object (also needed
+            // for Antigravity, which skipped the early check above).
+            match value.get("hooks") {
+                Some(h) if h.is_object() => {}
+                Some(_) => {
+                    return Err(PlmError::HookConversion(
+                        "'hooks' field must be an object".to_string(),
+                    ));
+                }
+                None => {
+                    return Err(PlmError::HookConversion(
+                        "Missing 'hooks' field".to_string(),
+                    ));
+                }
+            }
+
             let (mut result, mut warnings) = layers.structure.convert_top_level(&value);
             let mut scripts = Vec::new();
             let mut out = ConvertOutput {
@@ -379,13 +425,20 @@ pub fn convert(input: &str, target: TargetKind) -> Result<ConvertOutcome, PlmErr
                 scripts: &mut scripts,
             };
 
-            // Re-access hooks from the original value (validation done above)
             let hooks_value = value.get("hooks").unwrap();
             let new_hooks = convert_event_hooks(hooks_value, &layers, &mut out)?;
-            result
-                .as_object_mut()
-                .unwrap()
-                .insert("hooks".to_string(), new_hooks);
+
+            if let Some(name) = layers.named_hook_key {
+                // Antigravity: `{ "<hook-name>": { <Event>: [...] } }`
+                let mut root = serde_json::Map::new();
+                root.insert(name.to_string(), new_hooks);
+                result = Value::Object(root);
+            } else {
+                result
+                    .as_object_mut()
+                    .unwrap()
+                    .insert("hooks".to_string(), new_hooks);
+            }
 
             Ok(ConvertOutcome {
                 json: result,
@@ -421,13 +474,23 @@ fn convert_event_hooks(
     for (event_name, event_value) in hooks_obj {
         match layers.event_map.map_event(event_name) {
             Some(target_event) => {
-                let converted_hooks = if layers.preserve_matcher_groups {
+                let preserve = layers.preserve_matcher_groups
+                    && !layers.flat_handler_events.contains(&target_event);
+                let converted_hooks = if preserve {
                     preserve_matcher_groups(event_value, target_event, layers, out)?
                 } else {
                     flatten_matchers(event_value, target_event, layers, out)?
                 };
-                if !converted_hooks.is_empty() {
-                    output.insert(target_event.to_string(), Value::Array(converted_hooks));
+                if converted_hooks.is_empty() {
+                    continue;
+                }
+                // Merge when multiple source events map to the same target
+                // (e.g. SessionStart + UserPromptSubmit → PreInvocation).
+                match output.get_mut(target_event) {
+                    Some(Value::Array(existing)) => existing.extend(converted_hooks),
+                    _ => {
+                        output.insert(target_event.to_string(), Value::Array(converted_hooks));
+                    }
                 }
             }
             None => {
@@ -511,6 +574,10 @@ fn preserve_matcher_groups(
 
         let mut converted_group = group_obj.clone();
         converted_group.insert("hooks".to_string(), Value::Array(converted_hooks));
+        if let Some(m) = matcher {
+            let mapped = map_matcher_pattern(m, layers.tool_map.as_deref());
+            converted_group.insert("matcher".to_string(), Value::from(mapped));
+        }
         result.push(Value::Object(converted_group));
     }
 

--- a/src/hooks/converter/converter.rs
+++ b/src/hooks/converter/converter.rs
@@ -128,6 +128,14 @@ pub(crate) trait EventMap {
     ///
     /// * `event` - Claude Code event name to translate.
     fn map_event(&self, event: &str) -> Option<&'static str>;
+
+    /// Whether the target keeps Claude-style matcher groups for this mapped event.
+    ///
+    /// Defaults to `false` (flat handler arrays). Codex / Antigravity ToolUse
+    /// events override to `true`.
+    fn preserve_matcher_groups(&self, _target_event: &str) -> bool {
+        false
+    }
 }
 
 /// Layer 1b: Tool name mapping (optional).
@@ -162,6 +170,22 @@ pub(crate) trait StructureConverter {
     /// * `value` - Root JSON value to inspect.
     fn detect_format(&self, value: &Value) -> SourceFormat;
 
+    /// Validate the raw input before conversion / passthrough.
+    ///
+    /// Default: require a top-level `"hooks"` object (Copilot / Codex / Cursor).
+    /// Targets whose native format omits that wrapper override this.
+    fn validate_input(&self, value: &Value) -> Result<(), PlmError> {
+        match value.get("hooks") {
+            Some(h) if h.is_object() => Ok(()),
+            Some(_) => Err(PlmError::HookConversion(
+                "'hooks' field must be an object".to_string(),
+            )),
+            None => Err(PlmError::HookConversion(
+                "Missing 'hooks' field".to_string(),
+            )),
+        }
+    }
+
     /// Handle input that is already in the target format (passthrough).
     /// Returns an error if the target format is invalid (e.g., unsupported version).
     ///
@@ -180,6 +204,17 @@ pub(crate) trait StructureConverter {
     ///
     /// * `value` - Root JSON value in Claude Code format.
     fn convert_top_level(&self, value: &Value) -> (Value, Vec<ConversionWarning>);
+
+    /// Assemble the final document from top-level fields and converted events.
+    ///
+    /// Default: insert events under `"hooks"`. Targets with a different root
+    /// shape (e.g. named-hook maps) override this.
+    fn assemble(&self, mut top_level: Value, events: Value) -> Value {
+        if let Some(obj) = top_level.as_object_mut() {
+            obj.insert("hooks".to_string(), events);
+        }
+        top_level
+    }
 }
 
 /// Layer 4: Script generation for different hook types.
@@ -251,17 +286,10 @@ pub(crate) struct HookConversionLayers {
     pub key_map: Box<dyn KeyMap>,
     pub structure: Box<dyn StructureConverter>,
     pub script_gen: Box<dyn ScriptGenerator>,
-    pub preserve_matcher_groups: bool,
     /// When flattening matcher groups, attach the (tool-mapped) matcher to
     /// each flat hook entry instead of moving it into a wrapper script.
     /// Used by Cursor, which supports entry-level `matcher` on flat arrays.
     pub attach_matcher_to_entries: bool,
-    /// Events that must use flat handler arrays even when
-    /// `preserve_matcher_groups` is true (Antigravity non-ToolUse events).
-    pub flat_handler_events: &'static [&'static str],
-    /// When set, wrap converted events under this named-hook key instead of
-    /// a top-level `"hooks"` object (Antigravity format).
-    pub named_hook_key: Option<&'static str>,
 }
 
 /// Create conversion layers for the given target.
@@ -277,10 +305,7 @@ pub(crate) fn create_layers(target: TargetKind) -> Result<HookConversionLayers, 
             key_map: Box::new(super::copilot::CopilotKeyMap),
             structure: Box::new(super::copilot::CopilotStructureConverter),
             script_gen: Box::new(super::copilot::CopilotScriptGenerator),
-            preserve_matcher_groups: false,
             attach_matcher_to_entries: false,
-            flat_handler_events: &[],
-            named_hook_key: None,
         }),
         TargetKind::Codex => Ok(HookConversionLayers {
             event_map: Box::new(super::codex::CodexEventMap),
@@ -288,10 +313,7 @@ pub(crate) fn create_layers(target: TargetKind) -> Result<HookConversionLayers, 
             key_map: Box::new(super::codex::CodexKeyMap),
             structure: Box::new(super::codex::CodexStructureConverter),
             script_gen: Box::new(super::codex::CodexScriptGenerator),
-            preserve_matcher_groups: true,
             attach_matcher_to_entries: false,
-            flat_handler_events: &[],
-            named_hook_key: None,
         }),
         TargetKind::Cursor => Ok(HookConversionLayers {
             event_map: Box::new(super::cursor::CursorEventMap),
@@ -299,10 +321,7 @@ pub(crate) fn create_layers(target: TargetKind) -> Result<HookConversionLayers, 
             key_map: Box::new(super::cursor::CursorKeyMap),
             structure: Box::new(super::cursor::CursorStructureConverter),
             script_gen: Box::new(super::cursor::CursorScriptGenerator),
-            preserve_matcher_groups: false,
             attach_matcher_to_entries: true,
-            flat_handler_events: &[],
-            named_hook_key: None,
         }),
         TargetKind::Antigravity => Ok(HookConversionLayers {
             event_map: Box::new(super::antigravity::AntigravityEventMap),
@@ -312,10 +331,7 @@ pub(crate) fn create_layers(target: TargetKind) -> Result<HookConversionLayers, 
             key_map: Box::new(super::antigravity::AntigravityKeyMap),
             structure: Box::new(super::antigravity::AntigravityStructureConverter),
             script_gen: Box::new(super::antigravity::AntigravityScriptGenerator),
-            preserve_matcher_groups: true,
             attach_matcher_to_entries: false,
-            flat_handler_events: super::antigravity::ANTIGRAVITY_FLAT_HANDLER_EVENTS,
-            named_hook_key: Some(super::antigravity::ANTIGRAVITY_DEFAULT_HOOK_NAME),
         }),
         other => Err(PlmError::HookConversion(format!(
             "Hook conversion is not yet implemented for target: {}",
@@ -371,25 +387,7 @@ pub fn convert(input: &str, target: TargetKind) -> Result<ConvertOutcome, PlmErr
     let value: Value = serde_json::from_str(input)
         .map_err(|e| PlmError::HookConversion(format!("Invalid JSON: {}", e)))?;
 
-    // Copilot / Codex / Cursor always use a top-level `hooks` object.
-    // Antigravity native format is a named-hook map without that wrapper, so
-    // skip this check for Antigravity (Claude Code → Antigravity still
-    // validates inside the ClaudeCode branch below).
-    if !matches!(target, TargetKind::Antigravity) {
-        match value.get("hooks") {
-            Some(h) if h.is_object() => {}
-            Some(_) => {
-                return Err(PlmError::HookConversion(
-                    "'hooks' field must be an object".to_string(),
-                ));
-            }
-            None => {
-                return Err(PlmError::HookConversion(
-                    "Missing 'hooks' field".to_string(),
-                ));
-            }
-        }
-    }
+    layers.structure.validate_input(&value)?;
 
     match layers.structure.detect_format(&value) {
         SourceFormat::TargetFormat => {
@@ -402,10 +400,8 @@ pub fn convert(input: &str, target: TargetKind) -> Result<ConvertOutcome, PlmErr
             })
         }
         SourceFormat::ClaudeCode => {
-            // Claude Code shaped input requires a `hooks` object (also needed
-            // for Antigravity, which skipped the early check above).
-            match value.get("hooks") {
-                Some(h) if h.is_object() => {}
+            let hooks_value = match value.get("hooks") {
+                Some(h) if h.is_object() => h,
                 Some(_) => {
                     return Err(PlmError::HookConversion(
                         "'hooks' field must be an object".to_string(),
@@ -416,29 +412,17 @@ pub fn convert(input: &str, target: TargetKind) -> Result<ConvertOutcome, PlmErr
                         "Missing 'hooks' field".to_string(),
                     ));
                 }
-            }
+            };
 
-            let (mut result, mut warnings) = layers.structure.convert_top_level(&value);
+            let (top_level, mut warnings) = layers.structure.convert_top_level(&value);
             let mut scripts = Vec::new();
             let mut out = ConvertOutput {
                 warnings: &mut warnings,
                 scripts: &mut scripts,
             };
 
-            let hooks_value = value.get("hooks").unwrap();
             let new_hooks = convert_event_hooks(hooks_value, &layers, &mut out)?;
-
-            if let Some(name) = layers.named_hook_key {
-                // Antigravity: `{ "<hook-name>": { <Event>: [...] } }`
-                let mut root = serde_json::Map::new();
-                root.insert(name.to_string(), new_hooks);
-                result = Value::Object(root);
-            } else {
-                result
-                    .as_object_mut()
-                    .unwrap()
-                    .insert("hooks".to_string(), new_hooks);
-            }
+            let result = layers.structure.assemble(top_level, new_hooks);
 
             Ok(ConvertOutcome {
                 json: result,
@@ -474,9 +458,7 @@ fn convert_event_hooks(
     for (event_name, event_value) in hooks_obj {
         match layers.event_map.map_event(event_name) {
             Some(target_event) => {
-                let preserve = layers.preserve_matcher_groups
-                    && !layers.flat_handler_events.contains(&target_event);
-                let converted_hooks = if preserve {
+                let converted_hooks = if layers.event_map.preserve_matcher_groups(target_event) {
                     preserve_matcher_groups(event_value, target_event, layers, out)?
                 } else {
                     flatten_matchers(event_value, target_event, layers, out)?

--- a/src/hooks/event.rs
+++ b/src/hooks/event.rs
@@ -1,8 +1,11 @@
+pub(crate) mod antigravity;
 pub(crate) mod claude_code;
 pub(crate) mod codex;
 pub(crate) mod copilot;
 pub(crate) mod cursor;
 
+#[cfg(test)]
+mod antigravity_test;
 #[cfg(test)]
 mod claude_code_test;
 #[cfg(test)]

--- a/src/hooks/event/antigravity.rs
+++ b/src/hooks/event/antigravity.rs
@@ -33,15 +33,17 @@ const ANTIGRAVITY_EVENT_ENTRIES: &[EventBridge] = &[
     },
 ];
 
-/// Events that must use flat handler arrays (not matcher groups).
-pub(crate) const ANTIGRAVITY_FLAT_HANDLER_EVENTS: &[&str] =
-    &["PreInvocation", "PostInvocation", "Stop"];
-
 pub(crate) struct AntigravityEventMap;
 
 impl EventMap for AntigravityEventMap {
     fn map_event(&self, event: &str) -> Option<&'static str> {
         let hook_event = HookEvent::from_str(event.trim());
         to_target_event(ANTIGRAVITY_EVENT_ENTRIES, &hook_event)
+    }
+
+    fn preserve_matcher_groups(&self, target_event: &str) -> bool {
+        // ToolUse keeps matcher groups; PreInvocation / PostInvocation / Stop
+        // use flat handler arrays (official schema asymmetry).
+        matches!(target_event, "PreToolUse" | "PostToolUse")
     }
 }

--- a/src/hooks/event/antigravity.rs
+++ b/src/hooks/event/antigravity.rs
@@ -1,0 +1,47 @@
+use crate::hooks::converter::EventMap;
+use crate::hooks::event::claude_code::{to_target_event, EventBridge, HookEvent};
+
+/// Antigravity 公式イベント（PascalCase）への対応表。
+///
+/// 直接対応: `PreToolUse` / `PostToolUse` / `Stop`
+/// 近似: `SessionStart` / `UserPromptSubmit` → `PreInvocation`、`SessionEnd` → `Stop`
+/// （出典: https://antigravity.google/docs/hooks 、docs/reference/hooks-schema-mapping.md §10）
+const ANTIGRAVITY_EVENT_ENTRIES: &[EventBridge] = &[
+    EventBridge {
+        event: HookEvent::PreToolUse,
+        target: "PreToolUse",
+    },
+    EventBridge {
+        event: HookEvent::PostToolUse,
+        target: "PostToolUse",
+    },
+    EventBridge {
+        event: HookEvent::Stop,
+        target: "Stop",
+    },
+    EventBridge {
+        event: HookEvent::SessionStart,
+        target: "PreInvocation",
+    },
+    EventBridge {
+        event: HookEvent::UserPromptSubmit,
+        target: "PreInvocation",
+    },
+    EventBridge {
+        event: HookEvent::SessionEnd,
+        target: "Stop",
+    },
+];
+
+/// Events that must use flat handler arrays (not matcher groups).
+pub(crate) const ANTIGRAVITY_FLAT_HANDLER_EVENTS: &[&str] =
+    &["PreInvocation", "PostInvocation", "Stop"];
+
+pub(crate) struct AntigravityEventMap;
+
+impl EventMap for AntigravityEventMap {
+    fn map_event(&self, event: &str) -> Option<&'static str> {
+        let hook_event = HookEvent::from_str(event.trim());
+        to_target_event(ANTIGRAVITY_EVENT_ENTRIES, &hook_event)
+    }
+}

--- a/src/hooks/event/antigravity_test.rs
+++ b/src/hooks/event/antigravity_test.rs
@@ -29,3 +29,13 @@ fn test_antigravity_event_map_unsupported_events() {
     assert_eq!(map.map_event("PermissionRequest"), None);
     assert_eq!(map.map_event("UnknownEvent"), None);
 }
+
+#[test]
+fn test_antigravity_event_map_preserve_matcher_groups() {
+    let map = AntigravityEventMap;
+    assert!(map.preserve_matcher_groups("PreToolUse"));
+    assert!(map.preserve_matcher_groups("PostToolUse"));
+    assert!(!map.preserve_matcher_groups("PreInvocation"));
+    assert!(!map.preserve_matcher_groups("PostInvocation"));
+    assert!(!map.preserve_matcher_groups("Stop"));
+}

--- a/src/hooks/event/antigravity_test.rs
+++ b/src/hooks/event/antigravity_test.rs
@@ -1,0 +1,31 @@
+//! Unit tests for Antigravity EventMap.
+
+use super::antigravity::AntigravityEventMap;
+use crate::hooks::converter::EventMap;
+
+#[test]
+fn test_antigravity_event_map_direct_events() {
+    let map = AntigravityEventMap;
+    assert_eq!(map.map_event("PreToolUse"), Some("PreToolUse"));
+    assert_eq!(map.map_event("PostToolUse"), Some("PostToolUse"));
+    assert_eq!(map.map_event("Stop"), Some("Stop"));
+}
+
+#[test]
+fn test_antigravity_event_map_approximate_events() {
+    let map = AntigravityEventMap;
+    assert_eq!(map.map_event("SessionStart"), Some("PreInvocation"));
+    assert_eq!(map.map_event("UserPromptSubmit"), Some("PreInvocation"));
+    assert_eq!(map.map_event("SessionEnd"), Some("Stop"));
+}
+
+#[test]
+fn test_antigravity_event_map_unsupported_events() {
+    let map = AntigravityEventMap;
+    assert_eq!(map.map_event("SubagentStop"), None);
+    assert_eq!(map.map_event("SubagentStart"), None);
+    assert_eq!(map.map_event("PreCompact"), None);
+    assert_eq!(map.map_event("Notification"), None);
+    assert_eq!(map.map_event("PermissionRequest"), None);
+    assert_eq!(map.map_event("UnknownEvent"), None);
+}

--- a/src/hooks/event/codex.rs
+++ b/src/hooks/event/codex.rs
@@ -20,4 +20,8 @@ impl EventMap for CodexEventMap {
             _ => None,
         }
     }
+
+    fn preserve_matcher_groups(&self, _target_event: &str) -> bool {
+        true
+    }
 }

--- a/src/hooks/tool.rs
+++ b/src/hooks/tool.rs
@@ -1,8 +1,11 @@
+pub(crate) mod antigravity;
 pub(crate) mod claude_code;
 pub(crate) mod codex;
 pub(crate) mod copilot;
 pub(crate) mod cursor;
 
+#[cfg(test)]
+mod antigravity_test;
 #[cfg(test)]
 mod claude_code_test;
 #[cfg(test)]

--- a/src/hooks/tool/antigravity.rs
+++ b/src/hooks/tool/antigravity.rs
@@ -1,0 +1,66 @@
+use crate::hooks::converter::ToolMap;
+use crate::hooks::tool::claude_code::{to_target_tool, HookTool, ToolBridge};
+
+/// Claude Code → Antigravity tool names for matcher remapping.
+///
+/// 出典: https://antigravity.google/docs/hooks 、docs/reference/hooks-schema-mapping.md §10.4
+pub(crate) const ANTIGRAVITY_TOOL_ENTRIES: &[ToolBridge] = &[
+    ToolBridge {
+        claude_code_tools: &[HookTool::Bash],
+        target_name: "run_command",
+        representative_index: 0,
+    },
+    ToolBridge {
+        claude_code_tools: &[HookTool::Read],
+        target_name: "view_file",
+        representative_index: 0,
+    },
+    ToolBridge {
+        claude_code_tools: &[HookTool::Write],
+        target_name: "write_to_file",
+        representative_index: 0,
+    },
+    ToolBridge {
+        claude_code_tools: &[HookTool::Edit],
+        target_name: "replace_file_content",
+        representative_index: 0,
+    },
+    ToolBridge {
+        claude_code_tools: &[HookTool::MultiEdit],
+        target_name: "multi_replace_file_content",
+        representative_index: 0,
+    },
+    ToolBridge {
+        claude_code_tools: &[HookTool::Glob],
+        target_name: "find_by_name",
+        representative_index: 0,
+    },
+    ToolBridge {
+        claude_code_tools: &[HookTool::Grep],
+        target_name: "grep_search",
+        representative_index: 0,
+    },
+    ToolBridge {
+        claude_code_tools: &[HookTool::WebFetch],
+        target_name: "read_url_content",
+        representative_index: 0,
+    },
+    ToolBridge {
+        claude_code_tools: &[HookTool::Agent],
+        target_name: "invoke_subagent",
+        representative_index: 0,
+    },
+];
+
+pub(crate) struct AntigravityToolMap;
+
+impl ToolMap for AntigravityToolMap {
+    fn map_tool(&self, tool: &str) -> String {
+        let trimmed = tool.trim();
+        let hook_tool = HookTool::from_str(trimmed);
+        match to_target_tool(ANTIGRAVITY_TOOL_ENTRIES, &hook_tool) {
+            Some(target) => target.to_string(),
+            None => trimmed.to_string(),
+        }
+    }
+}

--- a/src/hooks/tool/antigravity_test.rs
+++ b/src/hooks/tool/antigravity_test.rs
@@ -1,0 +1,25 @@
+//! Unit tests for Antigravity ToolMap.
+
+use super::antigravity::AntigravityToolMap;
+use crate::hooks::converter::ToolMap;
+
+#[test]
+fn test_antigravity_tool_map_known_tools() {
+    let map = AntigravityToolMap;
+    assert_eq!(map.map_tool("Bash"), "run_command");
+    assert_eq!(map.map_tool("Read"), "view_file");
+    assert_eq!(map.map_tool("Write"), "write_to_file");
+    assert_eq!(map.map_tool("Edit"), "replace_file_content");
+    assert_eq!(map.map_tool("MultiEdit"), "multi_replace_file_content");
+    assert_eq!(map.map_tool("Glob"), "find_by_name");
+    assert_eq!(map.map_tool("Grep"), "grep_search");
+    assert_eq!(map.map_tool("WebFetch"), "read_url_content");
+    assert_eq!(map.map_tool("Agent"), "invoke_subagent");
+}
+
+#[test]
+fn test_antigravity_tool_map_unknown_passthrough() {
+    let map = AntigravityToolMap;
+    assert_eq!(map.map_tool("run_command"), "run_command");
+    assert_eq!(map.map_tool("CustomTool"), "CustomTool");
+}

--- a/src/install_test.rs
+++ b/src/install_test.rs
@@ -175,7 +175,7 @@ fn test_place_plugin_skill_to_codex() {
 fn test_place_plugin_unsupported_component_skipped() {
     let temp = TempDir::new().unwrap();
     let project_dir = TempDir::new().unwrap();
-    // Antigravity only supports Skills
+    // Antigravity does not support Agents (Skills + Hooks only)
     let cached = create_test_cached_package(temp.path(), &[], &["my-agent"], &[]);
     let package = MarketplaceContent::try_from(cached).unwrap();
     let scanned = scan_plugin(&package, None).unwrap();

--- a/src/placement_names.rs
+++ b/src/placement_names.rs
@@ -28,6 +28,11 @@ pub const COPILOT_PROJECT_SUBDIR: &str = ".github";
 pub const ANTIGRAVITY_PERSONAL_PARENT: &str = ".gemini";
 pub const ANTIGRAVITY_PERSONAL_CHILD: &str = "antigravity";
 pub const ANTIGRAVITY_PROJECT_SUBDIR: &str = ".agent";
+/// Antigravity Hooks の Global（Personal）配置: `~/.gemini/config/hooks.json`
+pub const ANTIGRAVITY_HOOKS_PERSONAL_CHILD: &str = "config";
+/// Antigravity Hooks の Project 配置ディレクトリ（Skills の `.agent` とは別）
+pub const ANTIGRAVITY_HOOKS_PROJECT_SUBDIR: &str = ".agents";
+pub const ANTIGRAVITY_HOOKS_FILE: &str = "hooks.json";
 pub const GEMINI_SUBDIR: &str = ".gemini";
 pub const CURSOR_SUBDIR: &str = ".cursor";
 

--- a/src/target.rs
+++ b/src/target.rs
@@ -178,7 +178,7 @@ impl TargetKind {
     /// ターゲット環境が期待する Command ファイル形式を返す。
     pub fn command_format(&self) -> CommandFormat {
         match self {
-            TargetKind::Antigravity => CommandFormat::ClaudeCode, // Antigravity は Skills のみ
+            TargetKind::Antigravity => CommandFormat::ClaudeCode, // Agents/Commands は未実装
             TargetKind::Codex => CommandFormat::Codex,
             TargetKind::Copilot => CommandFormat::Copilot,
             // Cursor は Claude Code 互換の Command 形式（#359 で配置対応）

--- a/src/target/env/antigravity.rs
+++ b/src/target/env/antigravity.rs
@@ -1,35 +1,45 @@
-//! Google Antigravity ターゲット実装
+//! Google Antigravity ターゲット実装（Skills / Hooks）
 
-use crate::component::{ComponentKind, PlacementContext, PlacementLocation, Scope};
+use crate::component::{Component, ComponentKind, PlacementContext, PlacementLocation, Scope};
 use crate::error::Result;
 use crate::placement_names::{
+    ANTIGRAVITY_HOOKS_FILE, ANTIGRAVITY_HOOKS_PERSONAL_CHILD, ANTIGRAVITY_HOOKS_PROJECT_SUBDIR,
     ANTIGRAVITY_PERSONAL_CHILD, ANTIGRAVITY_PERSONAL_PARENT, ANTIGRAVITY_PROJECT_SUBDIR,
 };
-use crate::target::filter::filter_skill_dir;
-use crate::target::list_helpers::scan_and_filter;
+use crate::target::filter::{filter_exact_file, filter_skill_dir};
+use crate::target::list_helpers::{scan_and_filter, scan_and_filter_in};
 use crate::target::paths::home_dir;
 use crate::target::placement_helpers::skill_dir;
 use crate::target::scope_support::{allows_scope, ScopeSupport};
-use crate::target::{Target, TargetKind};
+use crate::target::{PostPlaceOutcome, Target, TargetKind};
 use std::path::{Path, PathBuf};
 
 /// Antigravity のパス定数（#339: placement_names を正とする）。
+/// Skills と Hooks でルートが異なる（公式仕様）。
 struct AntigravityLayout {
     personal_parent: &'static str,
-    personal_child: &'static str,
-    project_subdir: &'static str,
+    skills_personal_child: &'static str,
+    skills_project_subdir: &'static str,
+    hooks_personal_child: &'static str,
+    hooks_project_subdir: &'static str,
+    hooks_file: &'static str,
 }
 
 const LAYOUT: AntigravityLayout = AntigravityLayout {
     personal_parent: ANTIGRAVITY_PERSONAL_PARENT,
-    personal_child: ANTIGRAVITY_PERSONAL_CHILD,
-    project_subdir: ANTIGRAVITY_PROJECT_SUBDIR,
+    skills_personal_child: ANTIGRAVITY_PERSONAL_CHILD,
+    skills_project_subdir: ANTIGRAVITY_PROJECT_SUBDIR,
+    hooks_personal_child: ANTIGRAVITY_HOOKS_PERSONAL_CHILD,
+    hooks_project_subdir: ANTIGRAVITY_HOOKS_PROJECT_SUBDIR,
+    hooks_file: ANTIGRAVITY_HOOKS_FILE,
 };
 
-const SUPPORTED: &[ComponentKind] = &[ComponentKind::Skill];
+const SUPPORTED: &[ComponentKind] = &[ComponentKind::Skill, ComponentKind::Hook];
 
-const CAPABILITIES: &[(ComponentKind, ScopeSupport)] =
-    &[(ComponentKind::Skill, ScopeSupport::Both)];
+const CAPABILITIES: &[(ComponentKind, ScopeSupport)] = &[
+    (ComponentKind::Skill, ScopeSupport::Both),
+    (ComponentKind::Hook, ScopeSupport::Both),
+];
 
 /// Google Antigravity ターゲット
 pub struct AntigravityTarget;
@@ -39,13 +49,58 @@ impl AntigravityTarget {
         Self
     }
 
-    fn base_dir(scope: Scope, project_root: &Path) -> PathBuf {
+    fn skills_base_dir(scope: Scope, project_root: &Path) -> PathBuf {
         match scope {
             Scope::Personal => home_dir()
                 .join(LAYOUT.personal_parent)
-                .join(LAYOUT.personal_child),
-            Scope::Project => project_root.join(LAYOUT.project_subdir),
+                .join(LAYOUT.skills_personal_child),
+            Scope::Project => project_root.join(LAYOUT.skills_project_subdir),
         }
+    }
+
+    fn hooks_base_dir(scope: Scope, project_root: &Path) -> PathBuf {
+        match scope {
+            Scope::Personal => home_dir()
+                .join(LAYOUT.personal_parent)
+                .join(LAYOUT.hooks_personal_child),
+            Scope::Project => project_root.join(LAYOUT.hooks_project_subdir),
+        }
+    }
+
+    /// Antigravity は 1 スコープにつき単一の `hooks.json` を読むため、複数 Hook を拒否する。
+    pub fn hook_component_conflict_error(components: &[Component]) -> Option<String> {
+        let hook_count = components
+            .iter()
+            .filter(|component| component.kind == ComponentKind::Hook)
+            .count();
+
+        (hook_count > 1).then(|| {
+            format!(
+                "Antigravity target supports a single hooks.json per scope; {} Hook components would overwrite each other. Select one Hook component or wait for merge support.",
+                hook_count
+            )
+        })
+    }
+
+    pub fn hook_overwrite_error(target_path: &Path, plugin_root: &Path) -> Option<String> {
+        if !Self::path_conflicts_with_unowned(target_path, plugin_root) {
+            return None;
+        }
+        Some(format!(
+            "{} already exists and is not managed by this plugin. \
+             Refusing to overwrite; remove the file or merge it manually before re-installing.",
+            target_path.display()
+        ))
+    }
+
+    fn path_conflicts_with_unowned(target_path: &Path, plugin_root: &Path) -> bool {
+        if !target_path.exists() {
+            return false;
+        }
+        let already_owned = crate::plugin::meta::load_meta(plugin_root)
+            .map(|meta| meta.manages_file("antigravity", target_path))
+            .unwrap_or(false);
+        !already_owned
     }
 }
 
@@ -79,11 +134,48 @@ impl Target for AntigravityTarget {
             return None;
         }
 
-        let base = Self::base_dir(scope, context.project_root());
         Some(match kind {
-            ComponentKind::Skill => skill_dir(&base, context.name()),
+            ComponentKind::Skill => {
+                let base = Self::skills_base_dir(scope, context.project_root());
+                skill_dir(&base, context.name())
+            }
+            ComponentKind::Hook => {
+                let base = Self::hooks_base_dir(scope, context.project_root());
+                PlacementLocation::file(base.join(LAYOUT.hooks_file))
+            }
             _ => return None,
         })
+    }
+
+    fn component_conflict_error(&self, components: &[Component]) -> Option<String> {
+        Self::hook_component_conflict_error(components)
+    }
+
+    fn pre_place_check(
+        &self,
+        context: &PlacementContext,
+        target_path: &Path,
+        plugin_root: &Path,
+    ) -> std::result::Result<(), String> {
+        if context.kind() == ComponentKind::Hook {
+            if let Some(error) = Self::hook_overwrite_error(target_path, plugin_root) {
+                return Err(error);
+            }
+        }
+        Ok(())
+    }
+
+    fn post_place(
+        &self,
+        context: &PlacementContext,
+        deployed_path: &Path,
+        plugin_root: &Path,
+        _enable_feature_flag: bool,
+    ) -> PostPlaceOutcome {
+        if context.kind() == ComponentKind::Hook {
+            crate::install::record_hook_file_ownership(plugin_root, deployed_path, "antigravity");
+        }
+        PostPlaceOutcome::default()
     }
 
     fn list_placed(
@@ -96,10 +188,16 @@ impl Target for AntigravityTarget {
             return Ok(vec![]);
         }
 
-        let base = Self::base_dir(scope, project_root);
         match kind {
             ComponentKind::Skill => {
+                let base = Self::skills_base_dir(scope, project_root);
                 scan_and_filter(&base, ComponentKind::Skill.plural(), filter_skill_dir)
+            }
+            ComponentKind::Hook => {
+                let base = Self::hooks_base_dir(scope, project_root);
+                scan_and_filter_in(&base, |c| {
+                    filter_exact_file(c, LAYOUT.hooks_file, ComponentKind::Hook.plural())
+                })
             }
             _ => Ok(vec![]),
         }

--- a/src/target/env/antigravity_test.rs
+++ b/src/target/env/antigravity_test.rs
@@ -22,8 +22,9 @@ fn test_antigravity_display_name() {
 fn test_antigravity_supported_components() {
     let target = AntigravityTarget::new();
     let supported = target.supported_components();
-    assert_eq!(supported.len(), 1);
-    assert_eq!(supported[0], ComponentKind::Skill);
+    assert_eq!(supported.len(), 2);
+    assert!(supported.contains(&ComponentKind::Skill));
+    assert!(supported.contains(&ComponentKind::Hook));
 }
 
 #[test]
@@ -51,9 +52,9 @@ fn test_antigravity_not_supports_instruction() {
 }
 
 #[test]
-fn test_antigravity_not_supports_hook() {
+fn test_antigravity_supports_hook() {
     let target = AntigravityTarget::new();
-    assert!(!target.supports(ComponentKind::Hook));
+    assert!(target.supports(ComponentKind::Hook));
 }
 
 #[test]
@@ -242,4 +243,71 @@ fn test_antigravity_list_placed_agent_returns_empty() {
         .list_placed(ComponentKind::Agent, Scope::Project, project_root)
         .unwrap();
     assert!(result.is_empty());
+}
+
+#[test]
+fn test_antigravity_placement_location_hook_project() {
+    let target = AntigravityTarget::new();
+    let project_root = Path::new("/project");
+    let origin = PluginOrigin::from_marketplace("official", "my-plugin");
+
+    let ctx = PlacementContext {
+        component: ComponentRef::new(ComponentKind::Hook, "my-hooks"),
+        origin: &origin,
+        scope: PlacementScope::new(Scope::Project),
+        project: ProjectContext::new(project_root),
+    };
+    let location = target.placement_location(&ctx).unwrap();
+    assert!(location.is_file());
+    assert_eq!(location.as_path(), Path::new("/project/.agents/hooks.json"));
+}
+
+#[test]
+fn test_antigravity_placement_location_hook_personal() {
+    let target = AntigravityTarget::new();
+    let project_root = Path::new("/project");
+    let origin = PluginOrigin::from_marketplace("official", "my-plugin");
+
+    let ctx = PlacementContext {
+        component: ComponentRef::new(ComponentKind::Hook, "my-hooks"),
+        origin: &origin,
+        scope: PlacementScope::new(Scope::Personal),
+        project: ProjectContext::new(project_root),
+    };
+    let location = target.placement_location(&ctx).unwrap();
+    let home = std::env::var("HOME").unwrap();
+    let expected = std::path::PathBuf::from(home)
+        .join(".gemini")
+        .join("config")
+        .join("hooks.json");
+    assert_eq!(location.as_path(), expected.as_path());
+}
+
+#[test]
+fn test_antigravity_hook_component_conflict_rejects_multiple() {
+    use crate::component::Component;
+    use std::path::PathBuf;
+
+    let components = vec![
+        Component::new(ComponentKind::Hook, "a", PathBuf::from("hooks/a.json")),
+        Component::new(ComponentKind::Hook, "b", PathBuf::from("hooks/b.json")),
+    ];
+    let err = AntigravityTarget::hook_component_conflict_error(&components);
+    assert!(err.unwrap().contains("single hooks.json"));
+}
+
+#[test]
+fn test_antigravity_list_placed_hooks() {
+    let target = AntigravityTarget::new();
+    let temp_dir = TempDir::new().unwrap();
+    let project_root = temp_dir.path();
+
+    let hooks_dir = project_root.join(".agents");
+    std::fs::create_dir_all(&hooks_dir).unwrap();
+    std::fs::write(hooks_dir.join("hooks.json"), "{}").unwrap();
+
+    let result = target
+        .list_placed(ComponentKind::Hook, Scope::Project, project_root)
+        .unwrap();
+    assert_eq!(result, vec!["hooks"]);
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

Issue #309 に対応し、Google Antigravity 向けの Hooks 変換・配置を実装しました。

共有オーケストレータに Antigravity 専用分岐を増やさず、既存どおり **EventMap / StructureConverter などターゲット専用型** に振る舞いを持たせています。

## 設計

| 関心事 | 置き場所 |
|--------|----------|
| イベント名マッピング / matcher グループ要否 | `AntigravityEventMap`（`EventMap`） |
| 入力検証・形式検出・ルート組み立て | `AntigravityStructureConverter`（`StructureConverter`） |
| キー正規化 | `AntigravityKeyMap` |
| ツール名リマップ | `AntigravityToolMap` |
| 配置パス・上書きガード | `AntigravityTarget` |

共有の `convert()` / `hook_deploy` は `TargetKind::Antigravity` を直接見ません。命名フック形式は「トップに `hooks` が無い単一ルートキー」として汎用処理します。

## 変更内容

### 変換レイヤー
- 直接対応: `PreToolUse` / `PostToolUse` / `Stop`
- 近似: `SessionStart`・`UserPromptSubmit` → `PreInvocation`、`SessionEnd` → `Stop`
- ToolUse は matcher グループ維持、それ以外はフラット handlers（`EventMap::preserve_matcher_groups`）
- ルートは `StructureConverter::assemble` で命名フックマップに組み立て

### 配置
- Personal: `~/.gemini/config/hooks.json`
- Project: `.agents/hooks.json`
- 単一ファイル上書きガード・複数 Hook 拒否（Codex/Cursor と同型）

### ドキュメント
- `hooks-schema-mapping.md` §10、`concepts/targets.md` 等

## スコープ外
- stdin/stdout ラッパースクリプト（command はインライン）
- 複数 Hook のマージ

## 検証
- `cargo fmt` / `cargo check --tests`
- `cargo test antigravity`（45 passed）
- `cargo test hooks::`（200 passed）

## 関連
- Closes #309
- Relates to #399

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-54350880-6614-4430-8ea9-abad55daaaeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-54350880-6614-4430-8ea9-abad55daaaeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

