### PR TITLE
docs: OpenCode ターゲット仕様と実装 Issue（#416）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 ## プロジェクト概要
 
-PLM (Plugin Manager CLI) は、複数のAI開発環境（OpenAI Codex、VSCode Copilot、Google Antigravity、Gemini CLI、Cursor、Claude Code）のプラグインを統合管理するRust製CLIツールです。Skills、Agents、Prompts、Instructionsのダウンロード、インストール、同期を行います。
+PLM (Plugin Manager CLI) は、複数のAI開発環境（OpenAI Codex、VSCode Copilot、Google Antigravity、Gemini CLI、Cursor、OpenCode、Claude Code）のプラグインを統合管理するRust製CLIツールです。Skills、Agents、Prompts、Instructionsのダウンロード、インストール、同期を行います。
 
 ## ビルドコマンド
 
@@ -103,8 +103,11 @@ cargo deny check
 | Google Antigravity | ○ | × | × | × | ○ |
 | Gemini CLI | ○ | × | × | ○ | × |
 | Cursor | ○ | ○ | ○ | ○* | ○ |
+| OpenCode | ○** | ○** | ○** | ○** | ×*** |
 
-> \*Cursor の Instructions は Project スコープ（`AGENTS.md`）のみ。Personal（User Rules）は対象外。
+> \*Cursor の Instructions は Project スコープ（`AGENTS.md`）のみ。Personal（User Rules）は対象外。  
+> \*\*OpenCode は仕様策定済み・実装未着手（Epic #416）。Skills は `original_name` 配置、Instructions は Personal + Project。  
+> \*\*\*OpenCode の拡張は JS/TS Plugin モデルのため Hook コンポーネント対象外。
 
 **Component** - コンポーネントタイプを抽象化（`ComponentKind` enum）：
 - Skills: YAMLフロントマター付き `SKILL.md`
@@ -113,7 +116,7 @@ cargo deny check
 - Instructions: `AGENTS.md` / `copilot-instructions.md` / `GEMINI.md`
 - Hooks: イベントハンドラ
 
-**スコープ** - Personal（`~/.codex/`, `~/.copilot/`, `~/.gemini/antigravity/`, `~/.gemini/skills/`, `~/.cursor/`）vs Project（`.codex/`, `.github/`, `.agent/`, `.gemini/skills/`, `.cursor/`）
+**スコープ** - Personal（`~/.codex/`, `~/.copilot/`, `~/.gemini/antigravity/`, `~/.gemini/skills/`, `~/.cursor/`, `~/.config/opencode/`）vs Project（`.codex/`, `.github/`, `.agent/`, `.gemini/skills/`, `.cursor/`, `.opencode/`）
 
 ## 主要依存関係
 - `clap` v4 - deriveマクロによるCLIパース

--- a/README.ja.md
+++ b/README.ja.md
@@ -9,7 +9,7 @@ AIコーディングアシスタント（OpenAI Codex、VSCode Copilot、Google 
 
 ## 特徴
 
-- **マルチ環境対応**: OpenAI Codex、VSCode Copilot、Google Antigravity、Gemini CLIにプラグインを単一ツールでデプロイ
+- **マルチ環境対応**: OpenAI Codex、VSCode Copilot、Google Antigravity、Gemini CLI、Cursor、OpenCode（仕様策定中）にプラグインを単一ツールでデプロイ
 - **Claude Code Pluginインポート**: 既存のClaude Code Pluginsをインポートして他の環境で使用
 - **コンポーネントタイプ**: Skills、Agents、Prompts、Instructionsに対応
 - **マーケットプレイス連携**: マーケットプレイスからプラグインを検索・インストール
@@ -213,9 +213,11 @@ plm init my-plugin --type skill
 | OpenAI Codex | 対応 | - | - | 対応 |
 | VSCode Copilot | 対応 | 対応 | 対応 | 対応 |
 | Google Antigravity | 対応 | -\* | -\* | -\* |
-
-\* Antigravity 公式は Agents（`agent.md`）/ Workflows（スラッシュコマンド）/ Rules・`AGENTS.md`・`GEMINI.md` をサポート。PLM 実装は未着手（[#400](https://github.com/DIO0550/plugin-manager/issues/400)）。
 | Gemini CLI | 対応 | - | - | 対応 |
+| Cursor | 対応 | 対応 | 対応 | 対応 |
+| OpenCode | 仕様策定中 | 仕様策定中 | 仕様策定中 | 仕様策定中 |
+
+\* Antigravity 公式は Agents（`agent.md`）/ Workflows（スラッシュコマンド）/ Rules・`AGENTS.md`・`GEMINI.md` をサポート。PLM 実装は未着手（[#400](https://github.com/DIO0550/plugin-manager/issues/400)）。OpenCode の詳細は [`docs/concepts/targets.md`](docs/concepts/targets.md) を参照。
 
 ## 設定
 

--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Rust](https://img.shields.io/badge/rust-2021-orange.svg)](https://www.rust-lang.org/)
 
-A unified CLI tool for managing plugins across AI coding assistants (OpenAI Codex, VSCode Copilot, Google Antigravity, Gemini CLI). Import Claude Code Plugins and deploy them to other environments. Download, install, and sync Skills, Agents, Prompts, and Instructions seamlessly.
+A unified CLI tool for managing plugins across AI coding assistants (OpenAI Codex, VSCode Copilot, Google Antigravity, Gemini CLI, Cursor, OpenCode). Import Claude Code Plugins and deploy them to other environments. Download, install, and sync Skills, Agents, Prompts, and Instructions seamlessly.
 
 [日本語版 README](README.ja.md)
 
 ## Features
 
-- **Multi-Environment Support**: Deploy plugins to OpenAI Codex, VSCode Copilot, Google Antigravity, and Gemini CLI from a single tool
+- **Multi-Environment Support**: Deploy plugins to OpenAI Codex, VSCode Copilot, Google Antigravity, Gemini CLI, Cursor, and OpenCode (spec in progress) from a single tool
 - **Claude Code Plugin Import**: Import existing Claude Code Plugins and use them in other environments
 - **Component Types**: Handle Skills, Agents, Prompts, and Instructions
 - **Marketplace Integration**: Browse and install plugins from marketplaces
@@ -236,9 +236,11 @@ plm init my-plugin --type skill
 | OpenAI Codex | Yes | - | - | Yes |
 | VSCode Copilot | Yes | Yes | Yes | Yes |
 | Google Antigravity | Yes | -* | -* | -* |
-
-\* Antigravity officially supports Agents (`agent.md`), Workflows (slash commands), and Rules / `AGENTS.md` / `GEMINI.md`. PLM support is not implemented yet ([#400](https://github.com/DIO0550/plugin-manager/issues/400)).
 | Gemini CLI | Yes | - | - | Yes |
+| Cursor | Yes | Yes | Yes | Yes |
+| OpenCode | Spec in progress | Spec in progress | Spec in progress | Spec in progress |
+
+\* Antigravity officially supports Agents (`agent.md`), Workflows (slash commands), and Rules / `AGENTS.md` / `GEMINI.md`. PLM support is not implemented yet ([#400](https://github.com/DIO0550/plugin-manager/issues/400)). OpenCode details: [`docs/concepts/targets.md`](docs/concepts/targets.md) / Epic [#416](https://github.com/DIO0550/plugin-manager/issues/416).
 
 ## Configuration
 

--- a/docs/architecture/file-formats.md
+++ b/docs/architecture/file-formats.md
@@ -1,19 +1,19 @@
 # ファイルフォーマット仕様
 
-各AI開発環境（Claude Code、Copilot、Codex、Gemini CLI、Cursor）のコンポーネントファイル形式を定義します。
+各AI開発環境（Claude Code、Copilot、Codex、Gemini CLI、Cursor、OpenCode）のコンポーネントファイル形式を定義します。
 
 ## 概要
 
-PLMはClaude Code Pluginからコンポーネントをインポートし、Codex/Copilot/Gemini CLI/Cursorへ変換・配置します。
+PLMはClaude Code Pluginからコンポーネントをインポートし、Codex/Copilot/Gemini CLI/Cursor/OpenCodeへ変換・配置します。
 各環境でファイル形式が異なるため、変換が必要です。
 
 | コンポーネント | 形式の違い | 変換要否 |
 |---------------|-----------|---------|
 | Skills | 共通形式（SKILL.md） | 不要（Gemini CLIは frontmatter 削減あり） |
-| Agents | 環境ごとに差異あり | **必要**（Cursorは内容無変換・拡張子のみ） |
-| Commands/Prompts | 環境ごとに異なる | **必要**（Cursorは内容無変換・拡張子のみ） |
+| Agents | 環境ごとに差異あり | **必要**（Cursor / OpenCode は内容無変換・拡張子のみ） |
+| Commands/Prompts | 環境ごとに異なる | **必要**（Cursor / OpenCode は内容無変換・拡張子のみ） |
 | Instructions | 共通形式（AGENTS.md） | 不要 |
-| Hooks | 環境ごとに差異あり | **必要**（Cursor含む） |
+| Hooks | 環境ごとに差異あり | **必要**（Cursor含む。OpenCode は初回対象外） |
 
 ---
 
@@ -344,6 +344,45 @@ Personal（User Rules）はアプリ設定画面管理のため PLM 対象外。
 
 ---
 
+## OpenCode
+
+OpenCode は Skills / Agents / Commands / AGENTS.md をファイルベースでサポートする。PLM はネイティブパス（`.opencode/` / `~/.config/opencode/`）へ配置する。Hooks 相当は JS/TS Plugin のため初回対象外。
+
+詳細な配置方針は [concepts/targets.md の OpenCode セクション](../concepts/targets.md#opencode) を参照。
+
+### Skills
+
+**パス:** `~/.config/opencode/skills/<original_name>/SKILL.md` / `.opencode/skills/<original_name>/SKILL.md`
+
+Claude Code / Codex と同じ `SKILL.md`（YAML frontmatter + Markdown）。内容変換は不要。  
+発見パターンは `skills/*/SKILL.md`（1 階層）のため、**`original_name` フラット配置**が必須。`name` は親ディレクトリ名と一致し、`^[a-z0-9]+(-[a-z0-9]+)*$` を満たすこと。
+
+### Agents
+
+**パス:** `~/.config/opencode/agents/<flattened_name>.md` / `.opencode/agents/<flattened_name>.md`
+
+プレーン Markdown（YAML frontmatter 可）。PLM 内部の `.agent.md` サフィックスは OpenCode ではファイル名がエージェント名になるため、配置時に `.md` へリネームする（内容は無変換。OpenCode 固有の `mode` / `permission` は v1 で自動付与しない）。
+
+### Commands
+
+**パス:** `~/.config/opencode/commands/<flattened_name>.md` / `.opencode/commands/<flattened_name>.md`
+
+プレーン Markdown。`.prompt.md` は `.md` へリネーム（内容無変換）。本文の `$ARGUMENTS` / `$1` は OpenCode ネイティブ互換。
+
+### Instructions (AGENTS.md)
+
+**パス:**
+- Personal: `~/.config/opencode/AGENTS.md`
+- Project: プロジェクトルートの `AGENTS.md`
+
+Cursor と異なり Personal もファイルベースでサポートする。Project `AGENTS.md` は Codex / Cursor と同一ファイルを共有しうる。
+
+### Hooks / Plugins
+
+**対象外（v1）**。OpenCode は `.opencode/plugins/*.ts` の JS/TS モジュールでライフサイクルフックを提供する。JSON Hooks 変換パイプラインとは別モデルのため、別 Epic で扱う。
+
+---
+
 ## 変換マッピング
 
 Claude Code形式から各環境への変換時のフィールド割り当てを定義します。
@@ -599,8 +638,11 @@ plugins/spec-plugin/
 | Antigravity | `~/.gemini/antigravity/plugins/spec-plugin/references/...` | `.agent/plugins/spec-plugin/references/...` |
 | Gemini CLI | `~/.gemini/plugins/spec-plugin/references/...` | `.gemini/plugins/spec-plugin/references/...` |
 | Cursor | `~/.cursor/plugins/spec-plugin/references/...` | `.cursor/plugins/spec-plugin/references/...` |
+| OpenCode | `~/.config/opencode/plugins/spec-plugin/references/...`※ | `.opencode/plugins/spec-plugin/references/...`※ |
 
-コンポーネントはフラット配置のまま。プラグインリソースだけが `plugins/<plugin_name>/` に構造維持で置かれる。Skill 無しでもリソースがあれば同ルートへ配置する。配置はステージング後 `replace_dir` でプラグイン単位ルートを置換する。命名衝突ルールは不要。Claude Code（#96）はターゲット追加後に同写像で追随。
+※ OpenCode ネイティブの `plugins/` は JS/TS 拡張モジュール用ディレクトリでもある。PLM の「プラグインリソース」配置パスと同名衝突しうるため、実装時は `plugins/<plugin_name>/` 以外のプレフィックス（例: `plm-plugins/`）またはサブディレクトリ方針を Epic で確定する。
+
+コンポーネントはフラット配置のまま。プラグインリソースだけが `plugins/<plugin_name>/` に構造維持で置かれる。Skill 無しでもリソースがあれば同ルートへ配置する。配置はステージング後 `replace_dir` でプラグイン単位ルートを置換する。命名衝突ルールは不要。Claude Code（#96）および OpenCode はターゲット追加後に同写像で追随（OpenCode は上記衝突に注意）。
 
 ### ライフサイクル
 
@@ -673,6 +715,13 @@ plugins/spec-plugin/
 - [Subagents](https://cursor.com/docs/agent/subagents)
 - [Rules / AGENTS.md](https://cursor.com/docs/context/rules)
 - [Hooks](https://cursor.com/docs/agent/hooks)
+
+### OpenCode
+- [Agent Skills](https://opencode.ai/docs/skills/)
+- [Agents](https://opencode.ai/docs/agents/)
+- [Commands](https://opencode.ai/docs/commands/)
+- [Rules / AGENTS.md](https://opencode.ai/docs/rules/)
+- [Plugins](https://opencode.ai/docs/plugins/)
 
 ---
 

--- a/docs/architecture/opencode-target-plan.md
+++ b/docs/architecture/opencode-target-plan.md
@@ -1,0 +1,120 @@
+# OpenCode ターゲット追加 — 実装計画
+
+> 状態: 仕様策定済み / 実装未着手  
+> Epic: [#416](https://github.com/DIO0550/plugin-manager/issues/416)  
+> 参照仕様: [`docs/concepts/targets.md`](../concepts/targets.md) の「OpenCode」セクション  
+> 参考 Epic: Cursor [#356](https://github.com/DIO0550/plugin-manager/issues/356)
+
+## 目的
+
+PLM に OpenCode を新しいターゲット環境として追加する。`plm install --target opencode`、`plm list --target opencode`、`plm enable/disable --target opencode` 等が動作するようにする。
+
+## スコープ
+
+| コンポーネント | 対応 | Personal | Project |
+|----------------|------|----------|---------|
+| Skills | ✅ | `~/.config/opencode/skills/<original_name>/` | `.opencode/skills/<original_name>/` |
+| Agents | ✅ | `~/.config/opencode/agents/<flattened>.md` | `.opencode/agents/<flattened>.md` |
+| Commands | ✅ | `~/.config/opencode/commands/<flattened>.md` | `.opencode/commands/<flattened>.md` |
+| Instructions | ✅ | `~/.config/opencode/AGENTS.md` | `AGENTS.md` |
+| Hooks | ❌ | —（JS/TS Plugin モデルのため別 Epic） | — |
+
+## Issue 一覧
+
+| # | タイトル | Phase | blocked_by |
+|:--|:---------|:------|:-----------|
+| [#417](https://github.com/DIO0550/plugin-manager/issues/417) | TargetKind に OpenCode バリアントを追加する | Phase 1 | - |
+| [#418](https://github.com/DIO0550/plugin-manager/issues/418) | OpenCodeTarget を実装する（Skills 配置） | Phase 2 | #417 |
+| [#419](https://github.com/DIO0550/plugin-manager/issues/419) | OpenCode の Agents / Commands 配置に対応する | Phase 3 | #418 |
+| [#420](https://github.com/DIO0550/plugin-manager/issues/420) | OpenCode の Instructions 配置に対応する | Phase 4 | #418 |
+| [#421](https://github.com/DIO0550/plugin-manager/issues/421) | OpenCode 対応のドキュメント・整合性更新 | 最終 | #418, #419, #420 |
+
+## 依存関係図
+
+```
+Epic #416: OpenCode ターゲット追加
+|
++-- #417: TargetKind に OpenCode バリアントを追加する
+|
++-- #418: OpenCodeTarget を実装する（Skills 配置）  [blocked_by: #417]
+|
++-- #419: Agents / Commands 配置  [blocked_by: #418]
++-- #420: Instructions（Personal + Project）配置  [blocked_by: #418]
+|
++-- #421: ドキュメント・整合性更新  [blocked_by: #418, #419, #420]
+```
+## Phase 詳細
+
+### Phase 1: TargetKind 追加
+
+- `TargetKind::OpenCode`（serde / CLI: `"opencode"`）
+- `as_str` / `command_format` / `agent_format`（ClaudeCode 互換）
+- `parse_target` / `all_targets` / layout helpers / `placement_names`
+- `TargetsConfig::default` への追加方針: **opt-in**（`plm target add opencode`）。Gemini と同様にデフォルト有効リストには入れない（破壊的変更を避ける）
+
+### Phase 2: OpenCodeTarget（Skills）
+
+- `src/target/env/opencode.rs` + `opencode_test.rs`
+- Personal ベース: `$XDG_CONFIG_HOME/opencode`（未設定時 `~/.config/opencode`）
+- Project ベース: `.opencode`
+- Skills: **`original_name` 必須**（Cursor と同型）。空なら配置スキップ
+- `list_placed` / overwrite ガード / ownership 記録
+- cleanup 列挙に `.opencode` と config ルートを追加
+
+### Phase 3: Agents / Commands
+
+- Agents / Commands を flatten 名の `.md` で配置
+- 内容変換なし（拡張子リネームのみ）
+- OpenCode 固有 frontmatter（`mode` / `permission`）は v1 で自動付与しない
+
+### Phase 4: Instructions
+
+- Personal: `~/.config/opencode/AGENTS.md`
+- Project: `AGENTS.md`（Codex / Cursor と共有しうる）
+- Cursor と異なり Personal も `ScopeSupport::Both`
+
+### Phase 5: Docs 整合
+
+- 実装完了後に本計画・`targets.md`・`roadmap.md`・`getting-started.md`・`commands/target.md`・`file-formats.md`・`config.md` の状態表記を ✅ に更新
+- README の対応ターゲット一覧があれば同期
+
+## 設計上の注意
+
+1. **Skills 1 階層発見**: OpenCode は `skills/*/SKILL.md` のみ。深いネストは不可 → Cursor #377 パターンを再利用
+2. **プラグインリソースパス衝突**: OpenCode ネイティブ `plugins/` は JS/TS 用。PLM の plugin-root resources（#393）写像と衝突しうる → 実装時にプレフィックス方針を確定（本仕様の file-formats 注記参照）
+3. **XDG**: `dirs`/`xdg` クレートまたは `std::env::var("XDG_CONFIG_HOME")` で Personal ルートを解決
+4. **sync 名キー**: original_name Skills は #384 と同型の既知制限
+
+## テスト方針
+
+| 観点 | 内容 |
+|------|------|
+| Unit | `placement_location` / `supported_components` / scope / `list_placed` |
+| Unit | `original_name` 欠落時の Skill スキップ |
+| Unit | XDG_CONFIG_HOME 上書き時の Personal パス |
+| Integration（任意） | `plm target add opencode` → install skill → 配置パス確認 |
+
+## 非スコープ
+
+- OpenCode Plugins（`.ts` / `.js`）の生成・配置
+- Claude Code 互換パス（`.claude/`）への二重配置
+- `OPENCODE_CONFIG_DIR` 追加探索
+- Commands のネストパス（`team/review.md`）保持
+
+## 公式ドキュメント
+
+- https://opencode.ai/docs/skills/
+- https://opencode.ai/docs/agents/
+- https://opencode.ai/docs/commands/
+- https://opencode.ai/docs/rules/
+- https://opencode.ai/docs/plugins/
+- https://opencode.ai/docs/config/
+
+## 関連
+
+- [#416](https://github.com/DIO0550/plugin-manager/issues/416)（OpenCode ターゲット追加 Epic）
+- #356（Cursor ターゲット追加 Epic — 同型の作業）
+- #96（Claude Code ターゲット追加 Epic）
+- #363（その他ツールのターゲット対応調査）
+- #377（Cursor Skills original_name 配置）
+- #384（sync と original_name Skills）

--- a/docs/commands/target.md
+++ b/docs/commands/target.md
@@ -22,6 +22,7 @@ $ plm target list
    • copilot     (skills, agents, commands, instructions, hooks)
    • cursor      (skills, agents, commands, instructions, hooks)
    • gemini      (skills, instructions)
+   • opencode    (skills, agents, commands, instructions)
 ```
 
 ## plm target add
@@ -56,6 +57,10 @@ $ plm target add gemini
 $ plm target add cursor
 ✅ Added target: cursor
    Supports: skills, agents, commands, instructions, hooks
+
+$ plm target add opencode
+✅ Added target: opencode
+   Supports: skills, agents, commands, instructions
 ```
 
 ### 利用可能なターゲット
@@ -67,6 +72,7 @@ $ plm target add cursor
 | `copilot` | Skills, Agents, Commands, Instructions, Hooks |
 | `cursor` | Skills, Agents, Commands, Instructions, Hooks |
 | `gemini` | Skills, Instructions |
+| `opencode` | Skills, Agents, Commands, Instructions（実装予定） |
 
 ## plm target remove
 

--- a/docs/concepts/targets.md
+++ b/docs/concepts/targets.md
@@ -11,16 +11,17 @@ PLMがサポートするAI開発環境（ターゲット）について説明し
 | **antigravity** | Google Antigravity（IDE / CLI・Hooks 共通） | ✅ 対応済み |
 | **gemini** | Gemini CLI（ターミナルベースAIエージェント） | ✅ 対応済み |
 | **cursor** | Cursor（IDE / CLI） | ✅ 対応済み |
+| **opencode** | OpenCode（ターミナル AI エージェント） | 📋 仕様策定中 |
 
 ## サポートするコンポーネント
 
-| コンポーネント | Codex | Copilot | Antigravity | Gemini CLI | Cursor |
-|----------------|-------|---------|-------------|------------|--------|
-| Skills | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Agents | ✅ | ✅ | ❌* | ❌ | ✅ |
-| Commands | ❌ | ✅ | ❌* | ❌ | ✅ |
-| Instructions | ✅ | ✅ | ❌* | ✅** | ✅*** |
-| Hooks | ✅ | ✅ | ✅**** | ❌****** | ✅***** |
+| コンポーネント | Codex | Copilot | Antigravity | Gemini CLI | Cursor | OpenCode |
+|----------------|-------|---------|-------------|------------|--------|----------|
+| Skills | ✅ | ✅ | ✅ | ✅ | ✅ | 📋******* |
+| Agents | ✅ | ✅ | ❌* | ❌ | ✅ | 📋******* |
+| Commands | ❌ | ✅ | ❌* | ❌ | ✅ | 📋******* |
+| Instructions | ✅ | ✅ | ❌* | ✅** | ✅*** | 📋******** |
+| Hooks | ✅ | ✅ | ✅**** | ❌****** | ✅***** | ❌********* |
 
 > *Antigravity は公式に Agents（`agent.md`）/ Workflows（Commands 相当）/ Rules・`GEMINI.md`・`AGENTS.md`（Instructions 相当）をサポートする。PLM 実装は未着手（調査: [#400](https://github.com/DIO0550/plugin-manager/issues/400)）。
 > **Gemini CLIは`GEMINI.md`による階層的な指示システムを持ちます。
@@ -28,6 +29,9 @@ PLMがサポートするAI開発環境（ターゲット）について説明し
 > ****Antigravity（IDE / CLI 共通）Hooks は公式 5 イベント対応の変換・配置を実装済み。単一 `hooks.json`・複数 Hook 同時配置は拒否（フルマージ未実装）。stdin/stdout ラッパーは未生成（インライン command）。
 > *****CursorのHooksは単一の `hooks.json` に配置する。既存の非管理ファイルの上書きと、同一インストール内の複数 Hook コンポーネントは拒否する（フルマージは未実装）。
 > ******Gemini CLI の Hooks は非対応。一般向けは Antigravity CLI へ移行済みで、Hooks は Antigravity（IDE / CLI 共通）仕様として扱う。Enterprise 向け `gemini` ターゲットはレガシーとして維持する。
+> *******OpenCode は Skills / Agents / Commands をファイルベースでサポート（仕様: 本ページ「OpenCode」セクション。Epic [#416](https://github.com/DIO0550/plugin-manager/issues/416)）。
+> ********OpenCode の Instructions は Personal（`~/.config/opencode/AGENTS.md`）と Project（`AGENTS.md`）の両方。
+> *********OpenCode の拡張は JSON Hooks ではなく TypeScript/JavaScript Plugin。PLM の Hook コンポーネントとはモデルが異なるため初回スコープ外。
 
 ## OpenAI Codex
 
@@ -419,6 +423,106 @@ Agents / Commands / Hooks は他ターゲットと同様に `flatten_name(plugin
 
 - Cursor CLI（`cursor-agent`）でどのhooksイベントが発火するか
 
+## OpenCode
+
+> **実装状況**: 仕様策定中（未実装）。Epic: [#416](https://github.com/DIO0550/plugin-manager/issues/416)。計画: [`docs/architecture/opencode-target-plan.md`](../architecture/opencode-target-plan.md)。
+
+### 概要
+
+OpenCode はターミナルベースの AI コーディングエージェント。Agent Skills open standard（`SKILL.md`）、Markdown エージェント、カスタムスラッシュコマンド、`AGENTS.md` をファイルベースでサポートする。Claude Code 互換パス（`.claude/` / `~/.claude/`）も読み込むが、PLM の配置先は OpenCode ネイティブパス（`.opencode/` / `~/.config/opencode/`）を正とする。
+
+公式ドキュメント:
+- [Agent Skills | OpenCode](https://opencode.ai/docs/skills/)
+- [Agents | OpenCode](https://opencode.ai/docs/agents/)
+- [Commands | OpenCode](https://opencode.ai/docs/commands/)
+- [Rules / AGENTS.md | OpenCode](https://opencode.ai/docs/rules/)
+- [Config | OpenCode](https://opencode.ai/docs/config/)
+- [Plugins | OpenCode](https://opencode.ai/docs/plugins/)
+
+### 読み込みパスと優先順位
+
+| 種別 | スコープ | パス | 自動読み込み | 備考 |
+|------|---------|------|--------------|------|
+| Skills | Global | `~/.config/opencode/skills/<name>/SKILL.md` | ✅ | XDG: `$XDG_CONFIG_HOME/opencode/skills/`（未設定時 `~/.config`） |
+| Skills | Global（互換） | `~/.claude/skills/`、`~/.agents/skills/` | ✅ | PLM 配置先には使わない |
+| Skills | Project | `.opencode/skills/<name>/SKILL.md` | ✅ | cwd から git worktree まで上方走査 |
+| Skills | Project（互換） | `.claude/skills/`、`.agents/skills/` | ✅ | PLM 配置先には使わない |
+| Agents | Global | `~/.config/opencode/agents/<name>.md` | ✅ | ファイル名がエージェント名 |
+| Agents | Project | `.opencode/agents/<name>.md` | ✅ | 同上 |
+| Commands | Global | `~/.config/opencode/commands/<name>.md` | ✅ | ネスト可（`team/review.md` → `/team/review`） |
+| Commands | Project | `.opencode/commands/<name>.md` | ✅ | 同上 |
+| Instructions | Global | `~/.config/opencode/AGENTS.md` | ✅ | Personal 対応（Cursor との差分） |
+| Instructions | Project | `AGENTS.md`（cwd〜プロジェクトルート） | ✅ | `CLAUDE.md` は AGENTS.md 無し時のフォールバック |
+| Plugins（Hooks 相当） | Global / Project | `~/.config/opencode/plugins/`、`.opencode/plugins/` | ✅ | **JS/TS モジュール**。PLM Hook 対象外 |
+
+### 重要な特徴
+
+- **SKILL.md 形式**: frontmatter は `name`（必須）と `description`（必須）。`license` / `compatibility` / `metadata` は任意。未知フィールドは無視
+- **`name` 制約**: 1–64 文字、`^[a-z0-9]+(-[a-z0-9]+)*$`、**親ディレクトリ名と一致必須**（Cursor Skills と同型）
+- **Skills 発見は 1 階層**: 公式は `skills/*/SKILL.md`。`<marketplace>/<plugin>/<skill>/` の深いネストは発見されないため、PLM は **`original_name` フラット配置**（Cursor #377 と同型）
+- **Agents**: YAML frontmatter（`description`, `mode`, `model`, `permission` 等）付き Markdown。`mode` は `primary` / `subagent` / `all`
+- **Commands**: 本文がプロンプトテンプレート。`$ARGUMENTS` / `$1` と `` !`shell` `` / `@file` をサポート
+- **Instructions**: Personal + Project の両方。Project `AGENTS.md` は Codex / Cursor と同一パスを共有しうる
+- **Claude Code 互換読み込み**: OpenCode 自体は `.claude/` も読むが、PLM はネイティブパスへ配置して責務を明確化する
+
+### Hooks / Plugins（初回スコープ外）
+
+OpenCode の拡張点は Claude Code / Cursor 系の JSON Hooks ではなく、**TypeScript/JavaScript Plugin**（`tool.execute.before` 等のフック関数を export）。
+
+| 項目 | Claude Code / Cursor Hooks | OpenCode Plugins |
+|------|---------------------------|------------------|
+| 形式 | JSON（`hooks.json`） | `.ts` / `.js` モジュール |
+| 配置 | 単一 JSON or ディレクトリ | `plugins/` ディレクトリ |
+| 実行 | シェルコマンド | Bun 上の JS 関数 |
+
+PLM の `ComponentKind::Hook` 変換パイプラインとはモデルが根本的に異なるため、**初回の OpenCode 対応では Hooks をサポートしない**（`supported_components` に含めない）。将来の Plugin 配置・生成は別 Epic とする。
+
+### コンポーネント配置場所（PLM 計画）
+
+Skills は frontmatter `name` と親フォルダ名の一致要件に合わせ、**元のスキル名（`original_name`）**で配置する（Cursor #377 と同型）。同名スキルの衝突時はエラー。
+
+Agents / Commands は他ターゲットと同様に `flatten_name(plugin, original)` により `{plugin}_{original}` へ平坦化し、プレーン `.md` として配置する。
+
+| 種別 | ファイル形式 | Personal | Project |
+|------|-------------|----------|---------|
+| Skills | `SKILL.md` | `~/.config/opencode/skills/<original_name>/` | `.opencode/skills/<original_name>/` |
+| Agents | `<flattened_name>.md` | `~/.config/opencode/agents/<flattened_name>.md` | `.opencode/agents/<flattened_name>.md` |
+| Commands | `<flattened_name>.md` | `~/.config/opencode/commands/<flattened_name>.md` | `.opencode/commands/<flattened_name>.md` |
+| Instructions | `AGENTS.md` | `~/.config/opencode/AGENTS.md` | `AGENTS.md` |
+| Hooks | — | ❌ 対象外 | ❌ 対象外 |
+
+### フォーマット変換方針
+
+| コンポーネント | 変換 | 備考 |
+|----------------|------|------|
+| Skills | 不要 | open standard のまま。未知 frontmatter は OpenCode が無視 |
+| Agents | 拡張子のみ（`.agent.md` → `.md`） | 内容は Claude Code 互換をコピー。OpenCode 固有 `mode` / `permission` は v1 で自動付与しない |
+| Commands | 拡張子のみ（`.prompt.md` → `.md`） | `$ARGUMENTS` / `$1` は OpenCode ネイティブ互換。Claude 固有 frontmatter は残っても実害は小さい想定 |
+| Instructions | 不要 | `AGENTS.md` 共通 |
+| Hooks | — | 対象外 |
+
+### 制約事項
+
+- **Skills は元名配置**: プラグイン接頭辞が無いため、同名スキルを持つ別プラグインとの衝突時はエラー（Cursor と同型）
+- **Skills は 1 階層のみ発見**: 深いネスト配置は OpenCode に読まれない
+- **Personal Instruction あり**: Cursor と異なり `~/.config/opencode/AGENTS.md` をサポートする
+- **Project `AGENTS.md` は Codex / Cursor と共有**: 複数ターゲット有効時は同一パスを参照する
+- **Hooks 非対応**: JS/TS Plugin モデルのため別設計が必要
+- **XDG**: Personal ルートは `$XDG_CONFIG_HOME/opencode`（デフォルト `~/.config/opencode`）。実装時は環境変数を尊重する
+- **sync と OpenCode Skills**: Cursor と同様、Skill 名キーが元名のため他ターゲット（フラット化名）との sync 名不一致に注意（既知パターン: [#384](https://github.com/DIO0550/plugin-manager/issues/384)）
+
+### 検証結果（仕様調査）
+
+- Skills / Agents / Commands / AGENTS.md のパスは公式 docs（opencode.ai）で確認済み（2026-08）
+- Global Skills は `~/.config/opencode/skills/` であり、`~/.opencode/skills/` ではない（第三者記事の誤りに注意）
+- Plugins は Hook 相当だが JSON 変換対象外と決定
+
+### 未検証
+
+- Commands のネスト配置（`commands/team/review.md`）を PLM フラット配置で使う必要性
+- OpenCode が Agents / Commands ディレクトリを再帰走査するか（フラット配置で十分かは実装前に再確認）
+- `OPENCODE_CONFIG_DIR` 指定時の追加探索パスを PLM が扱うべきか（v1 では標準パスのみ）
+
 ## PLMでの対応方針
 
 | ターゲット | Personal インストール | 追加アクション |
@@ -428,10 +532,12 @@ Agents / Commands / Hooks は他ターゲットと同様に `flatten_name(plugin
 | Antigravity | Skills: `~/.gemini/antigravity/`。Hooks: `~/.gemini/config/hooks.json`（実装済み・[#309](https://github.com/DIO0550/plugin-manager/issues/309)）。Agents / Workflows / Instructions は未実装（[#400](https://github.com/DIO0550/plugin-manager/issues/400)） | Skills / Hooks は自動読み込み。Hooks は単一 `hooks.json`（上書きガードあり） |
 | Gemini CLI | `~/.gemini/skills/` に配置 | 不要（自動読み込み、要Settings有効化） |
 | Cursor | `~/.cursor/` に配置（Skills / Agents / Commands / Hooks） | 不要（自動読み込み）。Hooksは単一 `hooks.json` へ変換配置（上書きガードあり） |
+| OpenCode | `~/.config/opencode/` に配置（Skills / Agents / Commands / Instructions） | 不要（自動読み込み）。Hooks/Plugins は初回対象外 |
 
 ## 将来の拡張候補
 
 - Claude Code（計画中）
+- OpenCode Plugins（JS/TS）対応（Hooks 相当の別モデル）
 - Windsurf
 - Aider
 - その他SKILL.md対応ツール

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -40,6 +40,10 @@ $ plm target add gemini
 $ plm target add cursor
 ✅ Added target: cursor
    Supports: skills, agents, commands, instructions, hooks
+
+$ plm target add opencode
+✅ Added target: opencode
+   Supports: skills, agents, commands, instructions
 ```
 
 ターゲットの確認:
@@ -52,6 +56,7 @@ $ plm target list
    • copilot     (skills, agents, commands, instructions, hooks)
    • cursor      (skills, agents, commands, instructions, hooks)
    • gemini      (skills, instructions)
+   • opencode    (skills, agents, commands, instructions)
 ```
 
 ### 2. マーケットプレイスの登録（オプション）

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ GitHubからAI開発環境向けのプラグインをダウンロードし、複
 
 | 機能 | 説明 |
 |------|------|
-| マルチターゲット対応 | OpenAI Codex、VSCode Copilot、Google Antigravity、Gemini CLI、Cursorに対応 |
+| マルチターゲット対応 | OpenAI Codex、VSCode Copilot、Google Antigravity、Gemini CLI、Cursor、OpenCode（仕様策定中）に対応 |
 | 統一管理 | 複数環境のプラグインを一元管理 |
 | 自動展開 | コンポーネント種別に応じて適切な場所へ配置 |
 | マーケットプレイス | GitHubリポジトリをマーケットプレイスとして登録 |
@@ -69,6 +69,14 @@ GitHubからAI開発環境向けのプラグインをダウンロードし、複
 - [Subagents](https://cursor.com/docs/agent/subagents)
 - [Rules / AGENTS.md](https://cursor.com/docs/context/rules)
 - [Hooks](https://cursor.com/docs/agent/hooks)
+
+### OpenCode
+
+- [Agent Skills](https://opencode.ai/docs/skills/)
+- [Agents](https://opencode.ai/docs/agents/)
+- [Commands](https://opencode.ai/docs/commands/)
+- [Rules / AGENTS.md](https://opencode.ai/docs/rules/)
+- [Plugins](https://opencode.ai/docs/plugins/)
 
 ### Claude Code
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -64,6 +64,16 @@ skills_project = ".gemini/skills"
 instructions_personal = "~/.gemini/GEMINI.md"
 instructions_project = "GEMINI.md"
 
+[targets.opencode]
+skills_personal = "~/.config/opencode/skills"
+skills_project = ".opencode/skills"
+agents_personal = "~/.config/opencode/agents"
+agents_project = ".opencode/agents"
+commands_personal = "~/.config/opencode/commands"
+commands_project = ".opencode/commands"
+instructions_personal = "~/.config/opencode/AGENTS.md"
+instructions_project = "AGENTS.md"
+
 [marketplaces]
 
 [marketplaces.anthropic]
@@ -183,6 +193,35 @@ skills_project = ".gemini/skills"
 instructions_personal = "~/.gemini/GEMINI.md"
 instructions_project = "GEMINI.md"
 ```
+
+### [targets.opencode]
+
+OpenCode ターゲットのパス設定（将来仕様。実装は `docs/concepts/targets.md` の OpenCode セクションに従う）。
+
+| キー | 型 | デフォルト |
+|------|-----|------------|
+| `skills_personal` | string | `"~/.config/opencode/skills"` |
+| `skills_project` | string | `".opencode/skills"` |
+| `agents_personal` | string | `"~/.config/opencode/agents"` |
+| `agents_project` | string | `".opencode/agents"` |
+| `commands_personal` | string | `"~/.config/opencode/commands"` |
+| `commands_project` | string | `".opencode/commands"` |
+| `instructions_personal` | string | `"~/.config/opencode/AGENTS.md"` |
+| `instructions_project` | string | `"AGENTS.md"` |
+
+```toml
+[targets.opencode]
+skills_personal = "~/.config/opencode/skills"
+skills_project = ".opencode/skills"
+agents_personal = "~/.config/opencode/agents"
+agents_project = ".opencode/agents"
+commands_personal = "~/.config/opencode/commands"
+commands_project = ".opencode/commands"
+instructions_personal = "~/.config/opencode/AGENTS.md"
+instructions_project = "AGENTS.md"
+```
+
+> 注: Personal ルートは `$XDG_CONFIG_HOME/opencode`（未設定時 `~/.config/opencode`）。Hooks は OpenCode Plugins（JS/TS）のため本セクションには含めない。
 
 ### [marketplaces]
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -123,6 +123,17 @@ Epic: [#356](https://github.com/DIO0550/plugin-manager/issues/356)（仕様: `do
 - [x] Hooks（hooks.json）変換・配置対応（[#361](https://github.com/DIO0550/plugin-manager/issues/361)）
 - [x] ドキュメント・整合性更新（[#362](https://github.com/DIO0550/plugin-manager/issues/362)）
 
+### Phase 17: OpenCode ターゲット対応 📋
+
+Epic: [#416](https://github.com/DIO0550/plugin-manager/issues/416)（仕様: `docs/concepts/targets.md` の「OpenCode」セクション / 計画: `docs/architecture/opencode-target-plan.md`）
+
+- [ ] `TargetKind` に OpenCode バリアントを追加（[#417](https://github.com/DIO0550/plugin-manager/issues/417)）
+- [ ] `OpenCodeTarget` 実装（Skills 配置・`original_name`）（[#418](https://github.com/DIO0550/plugin-manager/issues/418)）
+- [ ] Agents / Commands 配置対応（[#419](https://github.com/DIO0550/plugin-manager/issues/419)）
+- [ ] Instructions（Personal + Project）配置対応（[#420](https://github.com/DIO0550/plugin-manager/issues/420)）
+- [ ] ドキュメント・整合性更新（[#421](https://github.com/DIO0550/plugin-manager/issues/421)）
+- [ ] Hooks / Plugins は対象外（JS/TS Plugin モデルのため別 Epic）
+
 ## 将来の拡張
 
 ### リファクタ（ドメイン整合）
@@ -138,6 +149,7 @@ Epic: [#356](https://github.com/DIO0550/plugin-manager/issues/356)（仕様: `do
 
 | ターゲット | 説明 | 状態 |
 |------------|------|------|
+| OpenCode | `.opencode/` / `~/.config/opencode/` | 📋 仕様策定中（[#416](https://github.com/DIO0550/plugin-manager/issues/416)） |
 | Claude Code | .claude/ ディレクトリ | 計画中（[#96](https://github.com/DIO0550/plugin-manager/issues/96)）。**#338 完了後に着手推奨** |
 | Windsurf | Windsurf IDE | 調査対象 |
 | Aider | Aider CLI | 調査対象 |
@@ -198,6 +210,14 @@ impl GitRepo {
 - [Subagents | Cursor Docs](https://cursor.com/docs/agent/subagents)
 - [Rules / AGENTS.md | Cursor Docs](https://cursor.com/docs/context/rules)
 - [Hooks | Cursor Docs](https://cursor.com/docs/agent/hooks)
+
+### OpenCode
+
+- [Agent Skills | OpenCode](https://opencode.ai/docs/skills/)
+- [Agents | OpenCode](https://opencode.ai/docs/agents/)
+- [Commands | OpenCode](https://opencode.ai/docs/commands/)
+- [Rules / AGENTS.md | OpenCode](https://opencode.ai/docs/rules/)
+- [Plugins | OpenCode](https://opencode.ai/docs/plugins/)
 
 ### Google Antigravity
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

OpenCode を PLM の新ターゲットとして追加するための仕様書更新と、実装用 GitHub Issues の起票です（Rust 実装は含みません）。

- `docs/concepts/targets.md` に OpenCode セクションを追加（配置パス・スコープ・制約）
- `docs/architecture/opencode-target-plan.md` に実装計画（Cursor Epic #356 と同型）を追加
- roadmap / getting-started / commands / file-formats / config / README を同期
- GitHub Issues: Epic [#416](https://github.com/DIO0550/plugin-manager/issues/416) と子 Issue [#417](https://github.com/DIO0550/plugin-manager/issues/417)–[#421](https://github.com/DIO0550/plugin-manager/issues/421)（Sub-issue リンク済み）

## 設計上の要点

| 項目 | 方針 |
|------|------|
| Skills | `original_name` フラット配置（`skills/*/SKILL.md` の 1 階層発見に合わせる） |
| Agents / Commands | flatten 名の `.md`（内容無変換） |
| Instructions | Personal + Project（Cursor との差分） |
| Hooks | 対象外（JS/TS Plugin モデルのため別 Epic） |
| デフォルト有効 | opt-in（`plm target add opencode`） |

## Test plan

- [x] 仕様書の配置表が公式 OpenCode docs（skills / agents / commands / rules）と一致することを確認
- [x] Epic #416 に子 Issue が Sub-issue としてリンクされていることを確認
- [ ] レビューで Hooks 対象外・プラグインリソース `plugins/` 衝突注記に異論がないか確認

## Notes

- 誤作成の [#415](https://github.com/DIO0550/plugin-manager/issues/415)（権限確認用）はトークン権限上クローズ不可です。手動クローズをお願いします。
- Epic #416 本文の Issue 一覧は作成直後の TBD のままです（Issue 更新権限なし）。正確な番号対応は `docs/architecture/opencode-target-plan.md` を正としてください。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2c516ed3-baba-46b3-b906-7dbc7b16d3b4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2c516ed3-baba-46b3-b906-7dbc7b16d3b4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

