### PR TITLE
✨ [New Feature]: #420 OpenCode の Instructions（AGENTS.md）配置に対応

### DIFF
--- a/src/target/env/opencode.rs
+++ b/src/target/env/opencode.rs
@@ -128,9 +128,12 @@ impl Target for OpenCodeTarget {
                 Some(skill_dir(&base, dir_name))
             }
             // Project は Codex / Cursor と同一のルート `AGENTS.md` を共有しうる。
-            ComponentKind::Instruction => {
-                Some(instruction_file(scope, project_root, &base, INSTRUCTION_AGENTS))
-            }
+            ComponentKind::Instruction => Some(instruction_file(
+                scope,
+                project_root,
+                &base,
+                INSTRUCTION_AGENTS,
+            )),
             _ => None,
         }
     }

--- a/src/target/env/opencode.rs
+++ b/src/target/env/opencode.rs
@@ -1,26 +1,29 @@
-//! OpenCode ターゲット実装（Skills 配置 — Phase 2 / #418）
+//! OpenCode ターゲット実装（Skills — #418 / Instructions — #420）
 //!
-//! Agents / Commands / Instructions は後続 Issue（#419 / #420）で追加する。
+//! Agents / Commands は後続 Issue（#419）で追加する。
 //! Hooks は JS/TS Plugin モデルのため対象外。
 
 use crate::component::{ComponentKind, PlacementContext, PlacementLocation, Scope};
 use crate::env::EnvVar;
 use crate::error::Result;
 use crate::placement_names::{
-    OPENCODE_PERSONAL_CHILD, OPENCODE_PERSONAL_PARENT, OPENCODE_PROJECT_SUBDIR,
+    INSTRUCTION_AGENTS, OPENCODE_PERSONAL_CHILD, OPENCODE_PERSONAL_PARENT, OPENCODE_PROJECT_SUBDIR,
 };
 use crate::target::filter::filter_skill_dir;
-use crate::target::list_helpers::scan_and_filter;
+use crate::target::list_helpers::{list_instruction_at, scan_and_filter};
 use crate::target::paths::home_dir;
-use crate::target::placement_helpers::skill_dir;
+use crate::target::placement_helpers::{instruction_file, skill_dir};
 use crate::target::scope_support::{allows_scope, ScopeSupport};
 use crate::target::{PostPlaceOutcome, Target, TargetKind};
 use std::path::{Path, PathBuf};
 
-const SUPPORTED: &[ComponentKind] = &[ComponentKind::Skill];
+const SUPPORTED: &[ComponentKind] = &[ComponentKind::Skill, ComponentKind::Instruction];
 
-const CAPABILITIES: &[(ComponentKind, ScopeSupport)] =
-    &[(ComponentKind::Skill, ScopeSupport::Both)];
+const CAPABILITIES: &[(ComponentKind, ScopeSupport)] = &[
+    (ComponentKind::Skill, ScopeSupport::Both),
+    // Cursor と異なり Personal もサポートする。
+    (ComponentKind::Instruction, ScopeSupport::Both),
+];
 
 /// OpenCode ターゲット
 pub struct OpenCodeTarget;
@@ -40,6 +43,18 @@ impl OpenCodeTarget {
             Scope::Personal => Self::personal_root(),
             Scope::Project => project_root.join(OPENCODE_PROJECT_SUBDIR),
         }
+    }
+
+    /// Instruction パス（Project はルートの `AGENTS.md`、Personal は config 直下）。
+    fn instruction_path(scope: Scope, project_root: &Path) -> PathBuf {
+        instruction_file(
+            scope,
+            project_root,
+            &Self::base_dir(scope, project_root),
+            INSTRUCTION_AGENTS,
+        )
+        .as_path()
+        .to_path_buf()
     }
 
     pub fn skill_overwrite_error(target_path: &Path, plugin_root: &Path) -> Option<String> {
@@ -103,13 +118,18 @@ impl Target for OpenCodeTarget {
             return None;
         }
 
-        let base = Self::base_dir(scope, context.project_root());
+        let project_root = context.project_root();
+        let base = Self::base_dir(scope, project_root);
         match kind {
             // OpenCode は frontmatter `name` と親フォルダ名の一致を要求するため、
             // Skill は original_name で配置する（Cursor #377 と同型）。
             ComponentKind::Skill => {
                 let dir_name = context.original_name().filter(|n| !n.is_empty())?;
                 Some(skill_dir(&base, dir_name))
+            }
+            // Project は Codex / Cursor と同一のルート `AGENTS.md` を共有しうる。
+            ComponentKind::Instruction => {
+                Some(instruction_file(scope, project_root, &base, INSTRUCTION_AGENTS))
             }
             _ => None,
         }
@@ -150,6 +170,13 @@ impl Target for OpenCodeTarget {
     ) -> Result<Vec<String>> {
         if !self.can_place_scope(kind, scope) {
             return Ok(vec![]);
+        }
+
+        if kind == ComponentKind::Instruction {
+            return Ok(list_instruction_at(
+                &Self::instruction_path(scope, project_root),
+                INSTRUCTION_AGENTS,
+            ));
         }
 
         let base = Self::base_dir(scope, project_root);

--- a/src/target/env/opencode_test.rs
+++ b/src/target/env/opencode_test.rs
@@ -1,8 +1,8 @@
-//! OpenCodeTarget unit tests（#418）
+//! OpenCodeTarget unit tests（#418 Skills / #420 Instructions）
 
 use super::*;
 use crate::component::{ComponentRef, PlacementScope, ProjectContext};
-use crate::target::PluginOrigin;
+use crate::target::{CodexTarget, CursorTarget, PluginOrigin};
 use std::ffi::OsStr;
 use std::path::Path;
 use std::sync::{Mutex, OnceLock};
@@ -55,14 +55,22 @@ fn test_opencode_name_and_kind() {
 }
 
 #[test]
-fn test_opencode_supported_components_skills_only() {
+fn test_opencode_supported_components_skill_and_instruction() {
     let target = OpenCodeTarget::new();
     let supported = target.supported_components();
-    assert_eq!(supported, &[ComponentKind::Skill]);
+    assert_eq!(
+        supported,
+        &[ComponentKind::Skill, ComponentKind::Instruction]
+    );
     assert!(!target.supports(ComponentKind::Agent));
     assert!(!target.supports(ComponentKind::Command));
-    assert!(!target.supports(ComponentKind::Instruction));
     assert!(!target.supports(ComponentKind::Hook));
+}
+
+#[test]
+fn test_opencode_supports_instruction() {
+    let target = OpenCodeTarget::new();
+    assert!(target.supports(ComponentKind::Instruction));
 }
 
 #[test]
@@ -70,6 +78,13 @@ fn test_opencode_supports_scope_skill_both() {
     let target = OpenCodeTarget::new();
     assert!(target.supports_scope(ComponentKind::Skill, Scope::Personal));
     assert!(target.supports_scope(ComponentKind::Skill, Scope::Project));
+}
+
+#[test]
+fn test_opencode_supports_scope_instruction_both() {
+    let target = OpenCodeTarget::new();
+    assert!(target.supports_scope(ComponentKind::Instruction, Scope::Personal));
+    assert!(target.supports_scope(ComponentKind::Instruction, Scope::Project));
 }
 
 #[test]
@@ -251,4 +266,140 @@ fn personal_root_prefers_xdg_over_home() {
         OpenCodeTarget::personal_root(),
         Path::new("/custom/xdg/opencode")
     );
+}
+
+#[test]
+fn test_opencode_placement_instruction_project() {
+    let target = OpenCodeTarget::new();
+    let project_root = Path::new("/project");
+    let origin = PluginOrigin::from_marketplace("official", "my-plugin");
+
+    let ctx = PlacementContext {
+        component: ComponentRef::new(ComponentKind::Instruction, "test"),
+        origin: &origin,
+        scope: PlacementScope::new(Scope::Project),
+        project: ProjectContext::new(project_root),
+    };
+    let location = target.placement_location(&ctx).unwrap();
+    assert!(location.is_file());
+    assert_eq!(location.as_path(), Path::new("/project/AGENTS.md"));
+}
+
+#[test]
+fn test_opencode_placement_instruction_personal_default_home() {
+    let _lock = env_lock().lock().unwrap();
+    let guard = EnvGuard::clear(&["XDG_CONFIG_HOME", "HOME"]);
+    guard.set("HOME", "/home/u");
+
+    let target = OpenCodeTarget::new();
+    let project_root = Path::new("/project");
+    let origin = PluginOrigin::from_marketplace("official", "my-plugin");
+
+    let ctx = PlacementContext {
+        component: ComponentRef::new(ComponentKind::Instruction, "test"),
+        origin: &origin,
+        scope: PlacementScope::new(Scope::Personal),
+        project: ProjectContext::new(project_root),
+    };
+    let location = target.placement_location(&ctx).unwrap();
+    assert!(location.is_file());
+    assert_eq!(
+        location.as_path(),
+        Path::new("/home/u/.config/opencode/AGENTS.md")
+    );
+}
+
+#[test]
+fn test_opencode_placement_instruction_personal_respects_xdg_config_home() {
+    let _lock = env_lock().lock().unwrap();
+    let guard = EnvGuard::clear(&["XDG_CONFIG_HOME", "HOME"]);
+    guard.set("HOME", "/home/u");
+    guard.set("XDG_CONFIG_HOME", "/xdg/config");
+
+    let target = OpenCodeTarget::new();
+    let project_root = Path::new("/project");
+    let origin = PluginOrigin::from_marketplace("official", "my-plugin");
+
+    let ctx = PlacementContext {
+        component: ComponentRef::new(ComponentKind::Instruction, "test"),
+        origin: &origin,
+        scope: PlacementScope::new(Scope::Personal),
+        project: ProjectContext::new(project_root),
+    };
+    let location = target.placement_location(&ctx).unwrap();
+    assert!(location.is_file());
+    assert_eq!(
+        location.as_path(),
+        Path::new("/xdg/config/opencode/AGENTS.md")
+    );
+}
+
+#[test]
+fn test_opencode_list_placed_instruction_project_exists() {
+    let target = OpenCodeTarget::new();
+    let temp_dir = TempDir::new().unwrap();
+    let project_root = temp_dir.path();
+
+    std::fs::write(project_root.join("AGENTS.md"), "# Agents").unwrap();
+
+    let result = target
+        .list_placed(ComponentKind::Instruction, Scope::Project, project_root)
+        .unwrap();
+    assert_eq!(result, vec!["AGENTS.md".to_string()]);
+}
+
+#[test]
+fn test_opencode_list_placed_instruction_project_missing() {
+    let target = OpenCodeTarget::new();
+    let temp_dir = TempDir::new().unwrap();
+    let project_root = temp_dir.path();
+
+    let result = target
+        .list_placed(ComponentKind::Instruction, Scope::Project, project_root)
+        .unwrap();
+    assert!(result.is_empty());
+}
+
+#[test]
+fn test_opencode_list_placed_instruction_personal_exists() {
+    let _lock = env_lock().lock().unwrap();
+    let home = TempDir::new().unwrap();
+    let guard = EnvGuard::clear(&["XDG_CONFIG_HOME", "HOME"]);
+    guard.set("HOME", home.path());
+
+    let agents_path = home
+        .path()
+        .join(".config")
+        .join("opencode")
+        .join("AGENTS.md");
+    std::fs::create_dir_all(agents_path.parent().unwrap()).unwrap();
+    std::fs::write(&agents_path, "# Personal Agents").unwrap();
+
+    let target = OpenCodeTarget::new();
+    let project_root = Path::new("/project");
+    let result = target
+        .list_placed(ComponentKind::Instruction, Scope::Personal, project_root)
+        .unwrap();
+    assert_eq!(result, vec!["AGENTS.md".to_string()]);
+}
+
+#[test]
+fn test_opencode_project_instruction_path_matches_codex_and_cursor() {
+    let project_root = Path::new("/project");
+    let origin = PluginOrigin::from_marketplace("official", "my-plugin");
+
+    let ctx = PlacementContext {
+        component: ComponentRef::new(ComponentKind::Instruction, "test"),
+        origin: &origin,
+        scope: PlacementScope::new(Scope::Project),
+        project: ProjectContext::new(project_root),
+    };
+
+    let opencode = OpenCodeTarget::new().placement_location(&ctx).unwrap();
+    let codex = CodexTarget::new().placement_location(&ctx).unwrap();
+    let cursor = CursorTarget::new().placement_location(&ctx).unwrap();
+
+    assert_eq!(opencode.as_path(), Path::new("/project/AGENTS.md"));
+    assert_eq!(opencode.as_path(), codex.as_path());
+    assert_eq!(opencode.as_path(), cursor.as_path());
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

OpenCode ターゲットに Instructions（`AGENTS.md`）の Personal / Project 配置を追加する（Epic #416 Phase 4）。

## 変更内容

### 🎯 変更の種類

- [x] ✨ 新機能 (New feature)
- [x] 🚨 テスト追加/修正 (Tests)

### 📝 詳細な変更内容

#### 追加された機能・修正

- `OpenCodeTarget` が `ComponentKind::Instruction` を `ScopeSupport::Both` でサポート
- Personal: `$XDG_CONFIG_HOME/opencode/AGENTS.md`（未設定時 `~/.config/opencode/AGENTS.md`）
- Project: `{project_root}/AGENTS.md`（Codex / Cursor と同一パス）
- `list_placed` で両スコープの Instruction 列挙
- 単体テスト（配置・XDG・list・Codex/Cursor パス同一性）

#### 変更されたファイル

- `src/target/env/opencode.rs`
- `src/target/env/opencode_test.rs`

#### 削除されたファイル・機能

- なし

## 📊 システム図

```mermaid
flowchart TD
    A[PlacementContext Instruction] --> B{can_place_scope Both?}
    B -->|No| C[None / empty]
    B -->|Yes| D[instruction_file]
    D --> E{Scope}
    E -->|Personal| F["$XDG_CONFIG_HOME/opencode/AGENTS.md"]
    E -->|Project| G["{project_root}/AGENTS.md"]
    G --> H[Codex / Cursor と同一パス]
```

## 📋 関連 Issue

- Closes #420
- Relates to #416
- Relates to #418
- Relates to #419
- Relates to #421

## 🧪 テスト

### テスト実行方法

```bash
cargo test target::env::opencode::tests
```

### テスト項目

- [x] 単体テスト (Unit tests)
- [ ] 統合テスト (Integration tests)
- [ ] E2E テスト (End-to-end tests)
- [ ] 手動テスト (Manual testing)

### テスト結果

- TDD: Red（11 失敗）→ Green（22/22 パス）
- `cargo check`: 成功
- `cargo fmt`: 適用済み

## 🔍 レビューポイント

- Cursor と異なり Personal もサポートしていること（`ScopeSupport::Both`）
- Project が `.opencode/AGENTS.md` ではなくルート `AGENTS.md` であること
- Codex / Cursor との Project パス同一性テスト

## ⚠️ 破壊的変更

- [ ] この変更は既存の API に破壊的変更を含みます

## 📚 追加情報

### 参考資料

- 実装計画: `docs/architecture/issue-420-opencode-instructions-plan.md`（PR #427）
- 参考実装: `gemini_cli.rs`（Both）、`codex.rs`（AGENTS.md）

### 注意事項

- Agents / Commands は #419、ドキュメント状態表記は #421
- Instruction 専用 ownership / overwrite ガードは他ターゲット同様 v1 では未追加

## ✅ チェックリスト

- [x] コードレビューの準備ができている
- [x] テストが正常に実行される
- [x] ドキュメントが更新されている（必要に応じて）
- [x] コミットメッセージが適切な形式で書かれている
- [ ] 関連する Issue が PR の「Development」に Linked されている
- [x] PR 本文に `Closes #` / `Fixes #` / `Refs #` などで Issue が記載されている
- [x] セルフレビューを実施した
- [x] 破壊的変更がある場合は明記されている

## 🤝 レビュアーへのお願い

- Project パス共有の仕様とテスト方針の確認をお願いします

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-985e8fe6-5e1f-42ad-bf60-33f0dbef6936?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-985e8fe6-5e1f-42ad-bf60-33f0dbef6936&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

