### PR TITLE
📝 [Doc]: #421 OpenCode 対応ドキュメントの状態表記を同期

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,10 +103,10 @@ cargo deny check
 | Google Antigravity | ○ | × | × | × | ○ |
 | Gemini CLI | ○ | × | × | ○ | × |
 | Cursor | ○ | ○ | ○ | ○* | ○ |
-| OpenCode | ○** | ○** | ○** | ○** | ×*** |
+| OpenCode | ○ | ○ | ○ | ○** | ×*** |
 
 > \*Cursor の Instructions は Project スコープ（`AGENTS.md`）のみ。Personal（User Rules）は対象外。  
-> \*\*OpenCode は仕様策定済み・実装未着手（Epic #416）。Skills は `original_name` 配置、Instructions は Personal + Project。  
+> \*\*OpenCode の Instructions は Personal + Project。Skills は `original_name` 配置。opt-in（`plm target add opencode`）。Epic [#416](https://github.com/DIO0550/plugin-manager/issues/416)。  
 > \*\*\*OpenCode の拡張は JS/TS Plugin モデルのため Hook コンポーネント対象外。
 
 **Component** - コンポーネントタイプを抽象化（`ComponentKind` enum）：

--- a/README.ja.md
+++ b/README.ja.md
@@ -9,7 +9,7 @@ AIコーディングアシスタント（OpenAI Codex、VSCode Copilot、Google 
 
 ## 特徴
 
-- **マルチ環境対応**: OpenAI Codex、VSCode Copilot、Google Antigravity、Gemini CLI、Cursor、OpenCode（仕様策定中）にプラグインを単一ツールでデプロイ
+- **マルチ環境対応**: OpenAI Codex、VSCode Copilot、Google Antigravity、Gemini CLI、Cursor、OpenCode にプラグインを単一ツールでデプロイ
 - **Claude Code Pluginインポート**: 既存のClaude Code Pluginsをインポートして他の環境で使用
 - **コンポーネントタイプ**: Skills、Agents、Prompts、Instructionsに対応
 - **マーケットプレイス連携**: マーケットプレイスからプラグインを検索・インストール
@@ -215,9 +215,9 @@ plm init my-plugin --type skill
 | Google Antigravity | 対応 | -\* | -\* | -\* |
 | Gemini CLI | 対応 | - | - | 対応 |
 | Cursor | 対応 | 対応 | 対応 | 対応 |
-| OpenCode | 仕様策定中 | 仕様策定中 | 仕様策定中 | 仕様策定中 |
+| OpenCode | 対応 | 対応 | 対応 | 対応 |
 
-\* Antigravity 公式は Agents（`agent.md`）/ Workflows（スラッシュコマンド）/ Rules・`AGENTS.md`・`GEMINI.md` をサポート。PLM 実装は未着手（[#400](https://github.com/DIO0550/plugin-manager/issues/400)）。OpenCode の詳細は [`docs/concepts/targets.md`](docs/concepts/targets.md) を参照。
+\* Antigravity 公式は Agents（`agent.md`）/ Workflows（スラッシュコマンド）/ Rules・`AGENTS.md`・`GEMINI.md` をサポート。PLM 実装は未着手（[#400](https://github.com/DIO0550/plugin-manager/issues/400)）。OpenCode は opt-in（`plm target add opencode`）。Hooks/Plugins（JS/TS）は対象外。詳細は [`docs/concepts/targets.md`](docs/concepts/targets.md) / Epic [#416](https://github.com/DIO0550/plugin-manager/issues/416)。
 
 ## 設定
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A unified CLI tool for managing plugins across AI coding assistants (OpenAI Code
 
 ## Features
 
-- **Multi-Environment Support**: Deploy plugins to OpenAI Codex, VSCode Copilot, Google Antigravity, Gemini CLI, Cursor, and OpenCode (spec in progress) from a single tool
+- **Multi-Environment Support**: Deploy plugins to OpenAI Codex, VSCode Copilot, Google Antigravity, Gemini CLI, Cursor, and OpenCode from a single tool
 - **Claude Code Plugin Import**: Import existing Claude Code Plugins and use them in other environments
 - **Component Types**: Handle Skills, Agents, Prompts, and Instructions
 - **Marketplace Integration**: Browse and install plugins from marketplaces
@@ -238,9 +238,9 @@ plm init my-plugin --type skill
 | Google Antigravity | Yes | -* | -* | -* |
 | Gemini CLI | Yes | - | - | Yes |
 | Cursor | Yes | Yes | Yes | Yes |
-| OpenCode | Spec in progress | Spec in progress | Spec in progress | Spec in progress |
+| OpenCode | Yes | Yes | Yes | Yes |
 
-\* Antigravity officially supports Agents (`agent.md`), Workflows (slash commands), and Rules / `AGENTS.md` / `GEMINI.md`. PLM support is not implemented yet ([#400](https://github.com/DIO0550/plugin-manager/issues/400)). OpenCode details: [`docs/concepts/targets.md`](docs/concepts/targets.md) / Epic [#416](https://github.com/DIO0550/plugin-manager/issues/416).
+\* Antigravity officially supports Agents (`agent.md`), Workflows (slash commands), and Rules / `AGENTS.md` / `GEMINI.md`. PLM support is not implemented yet ([#400](https://github.com/DIO0550/plugin-manager/issues/400)). OpenCode is opt-in (`plm target add opencode`); Hooks/Plugins (JS/TS) are out of scope. Details: [`docs/concepts/targets.md`](docs/concepts/targets.md) / Epic [#416](https://github.com/DIO0550/plugin-manager/issues/416).
 
 ## Configuration
 

--- a/docs/architecture/file-formats.md
+++ b/docs/architecture/file-formats.md
@@ -13,7 +13,7 @@ PLMはClaude Code Pluginからコンポーネントをインポートし、Codex
 | Agents | 環境ごとに差異あり | **必要**（Cursor / OpenCode は内容無変換・拡張子のみ） |
 | Commands/Prompts | 環境ごとに異なる | **必要**（Cursor / OpenCode は内容無変換・拡張子のみ） |
 | Instructions | 共通形式（AGENTS.md） | 不要 |
-| Hooks | 環境ごとに差異あり | **必要**（Cursor含む。OpenCode は初回対象外） |
+| Hooks | 環境ごとに差異あり | **必要**（Cursor含む。OpenCode は対象外） |
 
 ---
 
@@ -346,7 +346,7 @@ Personal（User Rules）はアプリ設定画面管理のため PLM 対象外。
 
 ## OpenCode
 
-OpenCode は Skills / Agents / Commands / AGENTS.md をファイルベースでサポートする。PLM はネイティブパス（`.opencode/` / `~/.config/opencode/`）へ配置する。Hooks 相当は JS/TS Plugin のため初回対象外。
+OpenCode は Skills / Agents / Commands / AGENTS.md をファイルベースでサポートする。PLM はネイティブパス（`.opencode/` / `~/.config/opencode/`）へ配置する（実装済み）。Hooks 相当は JS/TS Plugin のため対象外。
 
 詳細な配置方針は [concepts/targets.md の OpenCode セクション](../concepts/targets.md#opencode) を参照。
 

--- a/docs/architecture/opencode-target-plan.md
+++ b/docs/architecture/opencode-target-plan.md
@@ -1,6 +1,6 @@
 # OpenCode ターゲット追加 — 実装計画
 
-> 状態: 仕様策定済み / 実装未着手  
+> 状態: Skills / Agents / Commands / Instructions 実装済み / ドキュメント整合済み（[#421](https://github.com/DIO0550/plugin-manager/issues/421)）  
 > Epic: [#416](https://github.com/DIO0550/plugin-manager/issues/416)  
 > 参照仕様: [`docs/concepts/targets.md`](../concepts/targets.md) の「OpenCode」セクション  
 > 参考 Epic: Cursor [#356](https://github.com/DIO0550/plugin-manager/issues/356)
@@ -21,13 +21,13 @@ PLM に OpenCode を新しいターゲット環境として追加する。`plm i
 
 ## Issue 一覧
 
-| # | タイトル | Phase | blocked_by |
-|:--|:---------|:------|:-----------|
-| [#417](https://github.com/DIO0550/plugin-manager/issues/417) | TargetKind に OpenCode バリアントを追加する | Phase 1 | - |
-| [#418](https://github.com/DIO0550/plugin-manager/issues/418) | OpenCodeTarget を実装する（Skills 配置） | Phase 2 | #417 |
-| [#419](https://github.com/DIO0550/plugin-manager/issues/419) | OpenCode の Agents / Commands 配置に対応する | Phase 3 | #418 |
-| [#420](https://github.com/DIO0550/plugin-manager/issues/420) | OpenCode の Instructions 配置に対応する | Phase 4 | #418 |
-| [#421](https://github.com/DIO0550/plugin-manager/issues/421) | OpenCode 対応のドキュメント・整合性更新 | 最終 | #418, #419, #420 |
+| # | タイトル | Phase | blocked_by | 状態 |
+|:--|:---------|:------|:-----------|:-----|
+| [#417](https://github.com/DIO0550/plugin-manager/issues/417) | TargetKind に OpenCode バリアントを追加する | Phase 1 | - | ✅ |
+| [#418](https://github.com/DIO0550/plugin-manager/issues/418) | OpenCodeTarget を実装する（Skills 配置） | Phase 2 | #417 | ✅ |
+| [#419](https://github.com/DIO0550/plugin-manager/issues/419) | OpenCode の Agents / Commands 配置に対応する | Phase 3 | #418 | ✅ |
+| [#420](https://github.com/DIO0550/plugin-manager/issues/420) | OpenCode の Instructions 配置に対応する | Phase 4 | #418 | ✅ |
+| [#421](https://github.com/DIO0550/plugin-manager/issues/421) | OpenCode 対応のドキュメント・整合性更新 | 最終 | #418, #419, #420 | ✅ |
 
 ## 依存関係図
 
@@ -73,10 +73,9 @@ Epic #416: OpenCode ターゲット追加
 - Project: `AGENTS.md`（Codex / Cursor と共有しうる）
 - Cursor と異なり Personal も `ScopeSupport::Both`
 
-### Phase 5: Docs 整合
+### Phase 5: Docs 整合 ✅
 
-- 実装完了後に本計画・`targets.md`・`roadmap.md`・`getting-started.md`・`commands/target.md`・`file-formats.md`・`config.md` の状態表記を ✅ に更新
-- README の対応ターゲット一覧があれば同期
+- 本計画・`targets.md`・`roadmap.md`・`getting-started.md`・`commands/target.md`・`file-formats.md`・`config.md`・README / `CLAUDE.md` の状態表記を ✅ に更新（[#421](https://github.com/DIO0550/plugin-manager/issues/421)）
 
 ## 設計上の注意
 

--- a/docs/architecture/opencode-target-plan.md
+++ b/docs/architecture/opencode-target-plan.md
@@ -1,6 +1,6 @@
 # OpenCode ターゲット追加 — 実装計画
 
-> 状態: Skills / Agents / Commands / Instructions 実装済み / ドキュメント整合済み（[#421](https://github.com/DIO0550/plugin-manager/issues/421)）  
+> 状態: Skills / Agents / Commands / Instructions 実装済み  
 > Epic: [#416](https://github.com/DIO0550/plugin-manager/issues/416)  
 > 参照仕様: [`docs/concepts/targets.md`](../concepts/targets.md) の「OpenCode」セクション  
 > 参考 Epic: Cursor [#356](https://github.com/DIO0550/plugin-manager/issues/356)
@@ -19,79 +19,15 @@ PLM に OpenCode を新しいターゲット環境として追加する。`plm i
 | Instructions | ✅ | `~/.config/opencode/AGENTS.md` | `AGENTS.md` |
 | Hooks | ❌ | —（JS/TS Plugin モデルのため別 Epic） | — |
 
-## Issue 一覧
-
-| # | タイトル | Phase | blocked_by | 状態 |
-|:--|:---------|:------|:-----------|:-----|
-| [#417](https://github.com/DIO0550/plugin-manager/issues/417) | TargetKind に OpenCode バリアントを追加する | Phase 1 | - | ✅ |
-| [#418](https://github.com/DIO0550/plugin-manager/issues/418) | OpenCodeTarget を実装する（Skills 配置） | Phase 2 | #417 | ✅ |
-| [#419](https://github.com/DIO0550/plugin-manager/issues/419) | OpenCode の Agents / Commands 配置に対応する | Phase 3 | #418 | ✅ |
-| [#420](https://github.com/DIO0550/plugin-manager/issues/420) | OpenCode の Instructions 配置に対応する | Phase 4 | #418 | ✅ |
-| [#421](https://github.com/DIO0550/plugin-manager/issues/421) | OpenCode 対応のドキュメント・整合性更新 | 最終 | #418, #419, #420 | ✅ |
-
-## 依存関係図
-
-```
-Epic #416: OpenCode ターゲット追加
-|
-+-- #417: TargetKind に OpenCode バリアントを追加する
-|
-+-- #418: OpenCodeTarget を実装する（Skills 配置）  [blocked_by: #417]
-|
-+-- #419: Agents / Commands 配置  [blocked_by: #418]
-+-- #420: Instructions（Personal + Project）配置  [blocked_by: #418]
-|
-+-- #421: ドキュメント・整合性更新  [blocked_by: #418, #419, #420]
-```
-## Phase 詳細
-
-### Phase 1: TargetKind 追加
-
-- `TargetKind::OpenCode`（serde / CLI: `"opencode"`）
-- `as_str` / `command_format` / `agent_format`（ClaudeCode 互換）
-- `parse_target` / `all_targets` / layout helpers / `placement_names`
-- `TargetsConfig::default` への追加方針: **opt-in**（`plm target add opencode`）。Gemini と同様にデフォルト有効リストには入れない（破壊的変更を避ける）
-
-### Phase 2: OpenCodeTarget（Skills）
-
-- `src/target/env/opencode.rs` + `opencode_test.rs`
-- Personal ベース: `$XDG_CONFIG_HOME/opencode`（未設定時 `~/.config/opencode`）
-- Project ベース: `.opencode`
-- Skills: **`original_name` 必須**（Cursor と同型）。空なら配置スキップ
-- `list_placed` / overwrite ガード / ownership 記録
-- cleanup 列挙に `.opencode` と config ルートを追加
-
-### Phase 3: Agents / Commands
-
-- Agents / Commands を flatten 名の `.md` で配置
-- 内容変換なし（拡張子リネームのみ）
-- OpenCode 固有 frontmatter（`mode` / `permission`）は v1 で自動付与しない
-
-### Phase 4: Instructions
-
-- Personal: `~/.config/opencode/AGENTS.md`
-- Project: `AGENTS.md`（Codex / Cursor と共有しうる）
-- Cursor と異なり Personal も `ScopeSupport::Both`
-
-### Phase 5: Docs 整合 ✅
-
-- 本計画・`targets.md`・`roadmap.md`・`getting-started.md`・`commands/target.md`・`file-formats.md`・`config.md`・README / `CLAUDE.md` の状態表記を ✅ に更新（[#421](https://github.com/DIO0550/plugin-manager/issues/421)）
-
 ## 設計上の注意
 
-1. **Skills 1 階層発見**: OpenCode は `skills/*/SKILL.md` のみ。深いネストは不可 → Cursor #377 パターンを再利用
-2. **プラグインリソースパス衝突**: OpenCode ネイティブ `plugins/` は JS/TS 用。PLM の plugin-root resources（#393）写像と衝突しうる → 実装時にプレフィックス方針を確定（本仕様の file-formats 注記参照）
-3. **XDG**: `dirs`/`xdg` クレートまたは `std::env::var("XDG_CONFIG_HOME")` で Personal ルートを解決
-4. **sync 名キー**: original_name Skills は #384 と同型の既知制限
-
-## テスト方針
-
-| 観点 | 内容 |
-|------|------|
-| Unit | `placement_location` / `supported_components` / scope / `list_placed` |
-| Unit | `original_name` 欠落時の Skill スキップ |
-| Unit | XDG_CONFIG_HOME 上書き時の Personal パス |
-| Integration（任意） | `plm target add opencode` → install skill → 配置パス確認 |
+1. **Skills 1 階層発見**: OpenCode は `skills/*/SKILL.md` のみ。深いネストは不可 → Cursor #377 パターンを再利用（`original_name` 必須）
+2. **opt-in**: `TargetsConfig::default` には含めない。`plm target add opencode` で有効化（Gemini と同様）
+3. **Agents / Commands**: flatten 名の `.md`、内容無変換（拡張子リネームのみ）。OpenCode 固有 frontmatter（`mode` / `permission`）は v1 で自動付与しない
+4. **Instructions**: Personal + Project（Cursor と異なり Personal も `ScopeSupport::Both`）。Project は Codex / Cursor と `AGENTS.md` を共有しうる
+5. **プラグインリソースパス衝突**: OpenCode ネイティブ `plugins/` は JS/TS 用。PLM の plugin-root resources（#393）写像と衝突しうる
+6. **XDG**: Personal ルートは `$XDG_CONFIG_HOME/opencode`（未設定時 `~/.config/opencode`）
+7. **sync 名キー**: original_name Skills は #384 と同型の既知制限
 
 ## 非スコープ
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -217,7 +217,9 @@ src/
 │   │   ├── antigravity.rs # Antigravity ターゲット実装
 │   │   ├── codex.rs      # Codex ターゲット実装
 │   │   ├── copilot.rs    # Copilot ターゲット実装
-│   │   └── gemini_cli.rs # Gemini CLI ターゲット実装
+│   │   ├── cursor.rs     # Cursor ターゲット実装
+│   │   ├── gemini_cli.rs # Gemini CLI ターゲット実装
+│   │   └── opencode.rs   # OpenCode ターゲット実装
 │   ├── placed/       # 配置ユーティリティサブグループ
 │   │   ├── placed.rs        # 全ターゲット横断スキャン
 │   │   ├── placed_common.rs # Instruction placement 共通ロジック

--- a/docs/commands/target.md
+++ b/docs/commands/target.md
@@ -72,7 +72,7 @@ $ plm target add opencode
 | `copilot` | Skills, Agents, Commands, Instructions, Hooks |
 | `cursor` | Skills, Agents, Commands, Instructions, Hooks |
 | `gemini` | Skills, Instructions |
-| `opencode` | Skills, Agents, Commands, Instructions（実装予定） |
+| `opencode` | Skills, Agents, Commands, Instructions |
 
 ## plm target remove
 

--- a/docs/concepts/components.md
+++ b/docs/concepts/components.md
@@ -20,7 +20,7 @@ PLMが管理するコンポーネントの種類について説明します。
 
 - YAML frontmatterでメタデータを定義
 - 専門的なタスクを実行するための詳細な指示を含む
-- Codex、Copilot、Gemini CLI、Cursorでサポート（Antigravityも対応）
+- Codex、Copilot、Gemini CLI、Cursor、OpenCodeでサポート（Antigravityも対応）
 - Skill ディレクトリ内の `references/` / `assets/` など任意名の補助ファイル・フォルダは **付属リソース**として本体と一緒にターゲットへコピーされる
 - プラグイン直下の任意名フォルダ（`references/` 等）は **Plugin リソース**として、`<target_base>/plugins/<plugin_name>/` 配下に構造を保ったまま配置される
 
@@ -59,6 +59,7 @@ skills/skill-name/
 | Antigravity | `~/.gemini/antigravity/skills/<marketplace>/<plugin>/<skill>/` | `.agent/skills/<marketplace>/<plugin>/<skill>/` |
 | Gemini CLI | `~/.gemini/skills/<marketplace>/<plugin>/<skill>/` | `.gemini/skills/<marketplace>/<plugin>/<skill>/` |
 | Cursor | `~/.cursor/skills/<flattened_name>/` | `.cursor/skills/<flattened_name>/` |
+| OpenCode | `~/.config/opencode/skills/<original_name>/` | `.opencode/skills/<original_name>/` |
 
 ## Agents
 
@@ -68,7 +69,7 @@ skills/skill-name/
 
 - 特定のタスクに特化したエージェントを定義
 - 使用可能なツールを指定可能
-- Codex、Copilot、Cursorでサポート（Antigravity は公式サポートあり・PLM 未実装: [#400](https://github.com/DIO0550/plugin-manager/issues/400)）
+- Codex、Copilot、Cursor、OpenCodeでサポート（Antigravity は公式サポートあり・PLM 未実装: [#400](https://github.com/DIO0550/plugin-manager/issues/400)）
 
 ### ファイル形式
 
@@ -91,6 +92,7 @@ tools: ['search', 'fetch', 'edit']
 | Codex | `~/.codex/agents/<marketplace>/<plugin>/` | `.codex/agents/<marketplace>/<plugin>/` |
 | Copilot | `~/.copilot/agents/<marketplace>/<plugin>/` | `.github/agents/<marketplace>/<plugin>/` |
 | Cursor | `~/.cursor/agents/<flattened_name>.md` | `.cursor/agents/<flattened_name>.md` |
+| OpenCode | `~/.config/opencode/agents/<flattened_name>.md` | `.opencode/agents/<flattened_name>.md` |
 
 ## Commands
 
@@ -99,7 +101,7 @@ tools: ['search', 'fetch', 'edit']
 ### 特徴
 
 - Claude Code のスラッシュコマンド（`.prompt.md`形式）を他ターゲットにも展開
-- Copilot（Prompt Files）と Cursor（プレーン Markdown）でサポート
+- Copilot（Prompt Files）と Cursor / OpenCode（プレーン Markdown）でサポート
 - 手動で呼び出して使用
 
 ### ファイル形式
@@ -122,6 +124,7 @@ description: コマンドの説明
 | Codex | - | - |
 | Copilot | - | `.github/prompts/<marketplace>/<plugin>/` |
 | Cursor | `~/.cursor/commands/<flattened_name>.md` | `.cursor/commands/<flattened_name>.md` |
+| OpenCode | `~/.config/opencode/commands/<flattened_name>.md` | `.opencode/commands/<flattened_name>.md` |
 
 ## Instructions
 
@@ -131,7 +134,7 @@ description: コマンドの説明
 
 - AGENTS.md形式のオープン標準（Linux Foundation管轄）
 - プロジェクト全体に適用される指示
-- Codex、Copilot、Gemini CLI、Cursorでサポート（Gemini CLIは`GEMINI.md`で対応）。Antigravity も公式に `GEMINI.md` / `AGENTS.md` / Rules をサポートするが PLM 未実装（[#400](https://github.com/DIO0550/plugin-manager/issues/400)）
+- Codex、Copilot、Gemini CLI、Cursor、OpenCodeでサポート（Gemini CLIは`GEMINI.md`で対応）。Antigravity も公式に `GEMINI.md` / `AGENTS.md` / Rules をサポートするが PLM 未実装（[#400](https://github.com/DIO0550/plugin-manager/issues/400)）
 
 ### ファイル形式
 
@@ -149,6 +152,7 @@ description: コマンドの説明
 | Copilot | - | `.github/copilot-instructions.md`, `AGENTS.md` |
 | Gemini CLI | `~/.gemini/GEMINI.md` | `GEMINI.md` |
 | Cursor | - | `AGENTS.md` |
+| OpenCode | `~/.config/opencode/AGENTS.md` | `AGENTS.md` |
 
 ## Hooks
 
@@ -207,19 +211,21 @@ description: コマンドの説明
 
 ## ターゲット別サポート状況
 
-| コンポーネント | Codex | Copilot | Antigravity | Gemini CLI | Cursor |
-|----------------|-------|---------|-------------|------------|--------|
-| Skills | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Agents | ✅ | ✅ | ❌* | ❌ | ✅ |
-| Commands | ❌ | ✅ | ❌* | ❌ | ✅ |
-| Instructions | ✅ | ✅ | ❌* | ✅** | ✅*** |
-| Hooks | ✅ | ✅ | ✅**** | ❌ | ✅***** |
+| コンポーネント | Codex | Copilot | Antigravity | Gemini CLI | Cursor | OpenCode |
+|----------------|-------|---------|-------------|------------|--------|----------|
+| Skills | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Agents | ✅ | ✅ | ❌* | ❌ | ✅ | ✅ |
+| Commands | ❌ | ✅ | ❌* | ❌ | ✅ | ✅ |
+| Instructions | ✅ | ✅ | ❌* | ✅** | ✅*** | ✅****** |
+| Hooks | ✅ | ✅ | ✅**** | ❌ | ✅***** | ❌******* |
 
 > *Antigravity 公式は Agents / Workflows（Commands 相当）/ Rules・`AGENTS.md`（Instructions 相当）をサポート。PLM 実装は未着手（[#400](https://github.com/DIO0550/plugin-manager/issues/400)）。
 > **Gemini CLIは`GEMINI.md`形式で対応（`AGENTS.md`は設定で変更可能）。
 > ***CursorのInstructionsはProjectスコープ（`AGENTS.md`）のみ。
 > ****Antigravity Hooks は変換・配置を実装済み（[#309](https://github.com/DIO0550/plugin-manager/issues/309)）。単一 `hooks.json`、複数 Hook 同時配置は拒否。
 > *****CursorのHooksは単一 `hooks.json`。非管理ファイルの上書きと複数 Hook 同時配置は拒否（フルマージ未実装）。
+> ******OpenCode の Instructions は Personal + Project。
+> *******OpenCode の拡張は JS/TS Plugin のため Hook コンポーネント対象外。
 
 ## 共通規格
 

--- a/docs/concepts/deployment.md
+++ b/docs/concepts/deployment.md
@@ -121,6 +121,33 @@ Cursor (Project):  .cursor/hooks.json
 （Claude Code → Cursor 変換。既存の非管理ファイルは上書き拒否）
 ```
 
+### OpenCode（フラット配置）
+
+OpenCode の Agents / Commands は `flatten_name(plugin, original)` によるフラット配置を使う。
+**Skills のみ** frontmatter `name` ↔ 親フォルダ名一致要件に合わせ、元のスキル名（`original_name`）で配置する（Cursor #377 と同型）。
+Instructions は Cursor と異なり Personal もサポートする。Hooks / Plugins（JS/TS）は対象外。
+
+```
+プラグイン内:
+├── skills/formatter-skill/SKILL.md
+├── agents/formatter-agent.md
+└── prompts/format-prompt.prompt.md
+
+展開先（Skills）:
+OpenCode (Personal): ~/.config/opencode/skills/formatter-skill/SKILL.md
+OpenCode (Project):  .opencode/skills/formatter-skill/SKILL.md
+（Skill のみ元名で配置。`$XDG_CONFIG_HOME/opencode` を尊重）
+
+展開先（Agents / Commands）:
+OpenCode (Personal): ~/.config/opencode/agents/code-formatter_formatter-agent.md
+OpenCode (Project):  .opencode/commands/code-formatter_format-prompt.md
+（`.agent.md` / `.prompt.md` サフィックスはプレーン `.md` にリネーム。内容は無変換）
+
+展開先（Instructions）:
+OpenCode (Personal): ~/.config/opencode/AGENTS.md
+OpenCode (Project):  AGENTS.md（Codex / Cursor と共有しうる）
+```
+
 ### Hooks
 
 ```
@@ -231,6 +258,15 @@ Codex/Copilotがネストしたディレクトリを読み込むかは公式ド�
 | Commands | `~/.cursor/commands/<flattened_name>.md` | `.cursor/commands/<flattened_name>.md` |
 | Instructions | - | `AGENTS.md` |
 | Hooks | `~/.cursor/hooks.json` | `.cursor/hooks.json` |
+
+### OpenCode
+
+| コンポーネント | Personal | Project |
+|----------------|----------|---------|
+| Skills | `~/.config/opencode/skills/<original_name>/` | `.opencode/skills/<original_name>/` |
+| Agents | `~/.config/opencode/agents/<flattened_name>.md` | `.opencode/agents/<flattened_name>.md` |
+| Commands | `~/.config/opencode/commands/<flattened_name>.md` | `.opencode/commands/<flattened_name>.md` |
+| Instructions | `~/.config/opencode/AGENTS.md` | `AGENTS.md` |
 
 ## 関連
 

--- a/docs/concepts/scopes.md
+++ b/docs/concepts/scopes.md
@@ -51,6 +51,15 @@ PLMのインストールスコープについて説明します。
 | Instructions | - | `AGENTS.md` |
 | Hooks | `~/.cursor/hooks.json` | `.cursor/hooks.json` |
 
+### OpenCode
+
+| 種別 | Personal | Project |
+|------|----------|---------|
+| Skills | `~/.config/opencode/skills/` | `.opencode/skills/` |
+| Agents | `~/.config/opencode/agents/` | `.opencode/agents/` |
+| Commands | `~/.config/opencode/commands/` | `.opencode/commands/` |
+| Instructions | `~/.config/opencode/AGENTS.md` | `AGENTS.md` |
+
 ## スコープの選択
 
 ### コマンドラインでの指定
@@ -69,8 +78,8 @@ plm install owner/repo --scope project
 
 ```
 ? Select scope:
-> ( ) personal - ~/.codex/, ~/.copilot/, ~/.cursor/
-  (x) project  - .codex/, .github/, .cursor/
+> ( ) personal - ~/.codex/, ~/.copilot/, ~/.cursor/, ~/.config/opencode/
+  (x) project  - .codex/, .github/, .cursor/, .opencode/
 ```
 
 ## 使い分けガイド

--- a/docs/concepts/targets.md
+++ b/docs/concepts/targets.md
@@ -11,16 +11,16 @@ PLMがサポートするAI開発環境（ターゲット）について説明し
 | **antigravity** | Google Antigravity（IDE / CLI・Hooks 共通） | ✅ 対応済み |
 | **gemini** | Gemini CLI（ターミナルベースAIエージェント） | ✅ 対応済み |
 | **cursor** | Cursor（IDE / CLI） | ✅ 対応済み |
-| **opencode** | OpenCode（ターミナル AI エージェント） | 📋 仕様策定中 |
+| **opencode** | OpenCode（ターミナル AI エージェント） | ✅ 対応済み |
 
 ## サポートするコンポーネント
 
 | コンポーネント | Codex | Copilot | Antigravity | Gemini CLI | Cursor | OpenCode |
 |----------------|-------|---------|-------------|------------|--------|----------|
-| Skills | ✅ | ✅ | ✅ | ✅ | ✅ | 📋******* |
-| Agents | ✅ | ✅ | ❌* | ❌ | ✅ | 📋******* |
-| Commands | ❌ | ✅ | ❌* | ❌ | ✅ | 📋******* |
-| Instructions | ✅ | ✅ | ❌* | ✅** | ✅*** | 📋******** |
+| Skills | ✅ | ✅ | ✅ | ✅ | ✅ | ✅******* |
+| Agents | ✅ | ✅ | ❌* | ❌ | ✅ | ✅******* |
+| Commands | ❌ | ✅ | ❌* | ❌ | ✅ | ✅******* |
+| Instructions | ✅ | ✅ | ❌* | ✅** | ✅*** | ✅******** |
 | Hooks | ✅ | ✅ | ✅**** | ❌****** | ✅***** | ❌********* |
 
 > *Antigravity は公式に Agents（`agent.md`）/ Workflows（Commands 相当）/ Rules・`GEMINI.md`・`AGENTS.md`（Instructions 相当）をサポートする。PLM 実装は未着手（調査: [#400](https://github.com/DIO0550/plugin-manager/issues/400)）。
@@ -29,9 +29,9 @@ PLMがサポートするAI開発環境（ターゲット）について説明し
 > ****Antigravity（IDE / CLI 共通）Hooks は公式 5 イベント対応の変換・配置を実装済み。単一 `hooks.json`・複数 Hook 同時配置は拒否（フルマージ未実装）。stdin/stdout ラッパーは未生成（インライン command）。
 > *****CursorのHooksは単一の `hooks.json` に配置する。既存の非管理ファイルの上書きと、同一インストール内の複数 Hook コンポーネントは拒否する（フルマージは未実装）。
 > ******Gemini CLI の Hooks は非対応。一般向けは Antigravity CLI へ移行済みで、Hooks は Antigravity（IDE / CLI 共通）仕様として扱う。Enterprise 向け `gemini` ターゲットはレガシーとして維持する。
-> *******OpenCode は Skills / Agents / Commands をファイルベースでサポート（仕様: 本ページ「OpenCode」セクション。Epic [#416](https://github.com/DIO0550/plugin-manager/issues/416)）。
+> *******OpenCode の Skills / Agents / Commands はファイルベースで配置する（Skills は `original_name`。Epic [#416](https://github.com/DIO0550/plugin-manager/issues/416)）。
 > ********OpenCode の Instructions は Personal（`~/.config/opencode/AGENTS.md`）と Project（`AGENTS.md`）の両方。
-> *********OpenCode の拡張は JSON Hooks ではなく TypeScript/JavaScript Plugin。PLM の Hook コンポーネントとはモデルが異なるため初回スコープ外。
+> *********OpenCode の拡張は JSON Hooks ではなく TypeScript/JavaScript Plugin。PLM の Hook コンポーネントとはモデルが異なるため対象外。
 
 ## OpenAI Codex
 
@@ -425,7 +425,7 @@ Agents / Commands / Hooks は他ターゲットと同様に `flatten_name(plugin
 
 ## OpenCode
 
-> **実装状況**: 仕様策定中（未実装）。Epic: [#416](https://github.com/DIO0550/plugin-manager/issues/416)。計画: [`docs/architecture/opencode-target-plan.md`](../architecture/opencode-target-plan.md)。
+> **実装状況**: Skills / Agents / Commands / Instructions 配置は実装済み（Epic [#416](https://github.com/DIO0550/plugin-manager/issues/416)）。Hooks / Plugins（JS/TS）は対象外。計画: [`docs/architecture/opencode-target-plan.md`](../architecture/opencode-target-plan.md)。
 
 ### 概要
 
@@ -465,7 +465,7 @@ OpenCode はターミナルベースの AI コーディングエージェント�
 - **Instructions**: Personal + Project の両方。Project `AGENTS.md` は Codex / Cursor と同一パスを共有しうる
 - **Claude Code 互換読み込み**: OpenCode 自体は `.claude/` も読むが、PLM はネイティブパスへ配置して責務を明確化する
 
-### Hooks / Plugins（初回スコープ外）
+### Hooks / Plugins（対象外）
 
 OpenCode の拡張点は Claude Code / Cursor 系の JSON Hooks ではなく、**TypeScript/JavaScript Plugin**（`tool.execute.before` 等のフック関数を export）。
 
@@ -475,9 +475,9 @@ OpenCode の拡張点は Claude Code / Cursor 系の JSON Hooks ではなく、*
 | 配置 | 単一 JSON or ディレクトリ | `plugins/` ディレクトリ |
 | 実行 | シェルコマンド | Bun 上の JS 関数 |
 
-PLM の `ComponentKind::Hook` 変換パイプラインとはモデルが根本的に異なるため、**初回の OpenCode 対応では Hooks をサポートしない**（`supported_components` に含めない）。将来の Plugin 配置・生成は別 Epic とする。
+PLM の `ComponentKind::Hook` 変換パイプラインとはモデルが根本的に異なるため、**OpenCode 対応では Hooks をサポートしない**（`supported_components` に含めない）。将来の Plugin 配置・生成は別 Epic とする。
 
-### コンポーネント配置場所（PLM 計画）
+### コンポーネント配置場所（PLM 実装）
 
 Skills は frontmatter `name` と親フォルダ名の一致要件に合わせ、**元のスキル名（`original_name`）**で配置する（Cursor #377 と同型）。同名スキルの衝突時はエラー。
 
@@ -508,8 +508,9 @@ Agents / Commands は他ターゲットと同様に `flatten_name(plugin, origin
 - **Personal Instruction あり**: Cursor と異なり `~/.config/opencode/AGENTS.md` をサポートする
 - **Project `AGENTS.md` は Codex / Cursor と共有**: 複数ターゲット有効時は同一パスを参照する
 - **Hooks 非対応**: JS/TS Plugin モデルのため別設計が必要
-- **XDG**: Personal ルートは `$XDG_CONFIG_HOME/opencode`（デフォルト `~/.config/opencode`）。実装時は環境変数を尊重する
+- **XDG**: Personal ルートは `$XDG_CONFIG_HOME/opencode`（デフォルト `~/.config/opencode`）。環境変数を尊重する
 - **sync と OpenCode Skills**: Cursor と同様、Skill 名キーが元名のため他ターゲット（フラット化名）との sync 名不一致に注意（既知パターン: [#384](https://github.com/DIO0550/plugin-manager/issues/384)）
+- **opt-in**: デフォルト有効ターゲットには含めない。`plm target add opencode` で有効化する
 
 ### 検証結果（仕様調査）
 
@@ -517,11 +518,11 @@ Agents / Commands は他ターゲットと同様に `flatten_name(plugin, origin
 - Global Skills は `~/.config/opencode/skills/` であり、`~/.opencode/skills/` ではない（第三者記事の誤りに注意）
 - Plugins は Hook 相当だが JSON 変換対象外と決定
 
-### 未検証
+### 未対応・将来検討
 
-- Commands のネスト配置（`commands/team/review.md`）を PLM フラット配置で使う必要性
-- OpenCode が Agents / Commands ディレクトリを再帰走査するか（フラット配置で十分かは実装前に再確認）
-- `OPENCODE_CONFIG_DIR` 指定時の追加探索パスを PLM が扱うべきか（v1 では標準パスのみ）
+- Commands のネスト配置（`commands/team/review.md`）の保持（v1 はフラット配置のみ）
+- `OPENCODE_CONFIG_DIR` 指定時の追加探索パス（v1 では標準パスのみ）
+- OpenCode Plugins（JS/TS）の生成・配置
 
 ## PLMでの対応方針
 
@@ -532,7 +533,7 @@ Agents / Commands は他ターゲットと同様に `flatten_name(plugin, origin
 | Antigravity | Skills: `~/.gemini/antigravity/`。Hooks: `~/.gemini/config/hooks.json`（実装済み・[#309](https://github.com/DIO0550/plugin-manager/issues/309)）。Agents / Workflows / Instructions は未実装（[#400](https://github.com/DIO0550/plugin-manager/issues/400)） | Skills / Hooks は自動読み込み。Hooks は単一 `hooks.json`（上書きガードあり） |
 | Gemini CLI | `~/.gemini/skills/` に配置 | 不要（自動読み込み、要Settings有効化） |
 | Cursor | `~/.cursor/` に配置（Skills / Agents / Commands / Hooks） | 不要（自動読み込み）。Hooksは単一 `hooks.json` へ変換配置（上書きガードあり） |
-| OpenCode | `~/.config/opencode/` に配置（Skills / Agents / Commands / Instructions） | 不要（自動読み込み）。Hooks/Plugins は初回対象外 |
+| OpenCode | `~/.config/opencode/` に配置（Skills / Agents / Commands / Instructions） | 不要（自動読み込み）。Hooks/Plugins は対象外 |
 
 ## 将来の拡張候補
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ GitHubからAI開発環境向けのプラグインをダウンロードし、複
 
 | 機能 | 説明 |
 |------|------|
-| マルチターゲット対応 | OpenAI Codex、VSCode Copilot、Google Antigravity、Gemini CLI、Cursor、OpenCode（仕様策定中）に対応 |
+| マルチターゲット対応 | OpenAI Codex、VSCode Copilot、Google Antigravity、Gemini CLI、Cursor、OpenCode に対応 |
 | 統一管理 | 複数環境のプラグインを一元管理 |
 | 自動展開 | コンポーネント種別に応じて適切な場所へ配置 |
 | マーケットプレイス | GitHubリポジトリをマーケットプレイスとして登録 |

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -196,7 +196,7 @@ instructions_project = "GEMINI.md"
 
 ### [targets.opencode]
 
-OpenCode ターゲットのパス設定（将来仕様。実装は `docs/concepts/targets.md` の OpenCode セクションに従う）。
+OpenCode ターゲットのパス設定（将来仕様。配置パスは実装済みのハードコード定数と一致させる想定。実装は `docs/concepts/targets.md` の OpenCode セクションに従う）。
 
 | キー | 型 | デフォルト |
 |------|-----|------------|

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -127,12 +127,7 @@ Epic: [#356](https://github.com/DIO0550/plugin-manager/issues/356)（仕様: `do
 
 Epic: [#416](https://github.com/DIO0550/plugin-manager/issues/416)（仕様: `docs/concepts/targets.md` の「OpenCode」セクション / 計画: `docs/architecture/opencode-target-plan.md`）
 
-- [x] `TargetKind` に OpenCode バリアントを追加（[#417](https://github.com/DIO0550/plugin-manager/issues/417)）
-- [x] `OpenCodeTarget` 実装（Skills 配置・`original_name`）（[#418](https://github.com/DIO0550/plugin-manager/issues/418)）
-- [x] Agents / Commands 配置対応（[#419](https://github.com/DIO0550/plugin-manager/issues/419)）
-- [x] Instructions（Personal + Project）配置対応（[#420](https://github.com/DIO0550/plugin-manager/issues/420)）
-- [x] ドキュメント・整合性更新（[#421](https://github.com/DIO0550/plugin-manager/issues/421)）
-- [x] Hooks / Plugins は対象外（JS/TS Plugin モデルのため別 Epic）
+Skills / Agents / Commands / Instructions を対応。Hooks / Plugins（JS/TS）は対象外。
 
 ## 将来の拡張
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -123,16 +123,16 @@ Epic: [#356](https://github.com/DIO0550/plugin-manager/issues/356)（仕様: `do
 - [x] Hooks（hooks.json）変換・配置対応（[#361](https://github.com/DIO0550/plugin-manager/issues/361)）
 - [x] ドキュメント・整合性更新（[#362](https://github.com/DIO0550/plugin-manager/issues/362)）
 
-### Phase 17: OpenCode ターゲット対応 📋
+### Phase 17: OpenCode ターゲット対応 ✅
 
 Epic: [#416](https://github.com/DIO0550/plugin-manager/issues/416)（仕様: `docs/concepts/targets.md` の「OpenCode」セクション / 計画: `docs/architecture/opencode-target-plan.md`）
 
-- [ ] `TargetKind` に OpenCode バリアントを追加（[#417](https://github.com/DIO0550/plugin-manager/issues/417)）
-- [ ] `OpenCodeTarget` 実装（Skills 配置・`original_name`）（[#418](https://github.com/DIO0550/plugin-manager/issues/418)）
-- [ ] Agents / Commands 配置対応（[#419](https://github.com/DIO0550/plugin-manager/issues/419)）
-- [ ] Instructions（Personal + Project）配置対応（[#420](https://github.com/DIO0550/plugin-manager/issues/420)）
-- [ ] ドキュメント・整合性更新（[#421](https://github.com/DIO0550/plugin-manager/issues/421)）
-- [ ] Hooks / Plugins は対象外（JS/TS Plugin モデルのため別 Epic）
+- [x] `TargetKind` に OpenCode バリアントを追加（[#417](https://github.com/DIO0550/plugin-manager/issues/417)）
+- [x] `OpenCodeTarget` 実装（Skills 配置・`original_name`）（[#418](https://github.com/DIO0550/plugin-manager/issues/418)）
+- [x] Agents / Commands 配置対応（[#419](https://github.com/DIO0550/plugin-manager/issues/419)）
+- [x] Instructions（Personal + Project）配置対応（[#420](https://github.com/DIO0550/plugin-manager/issues/420)）
+- [x] ドキュメント・整合性更新（[#421](https://github.com/DIO0550/plugin-manager/issues/421)）
+- [x] Hooks / Plugins は対象外（JS/TS Plugin モデルのため別 Epic）
 
 ## 将来の拡張
 
@@ -149,7 +149,6 @@ Epic: [#416](https://github.com/DIO0550/plugin-manager/issues/416)（仕様: `do
 
 | ターゲット | 説明 | 状態 |
 |------------|------|------|
-| OpenCode | `.opencode/` / `~/.config/opencode/` | 📋 仕様策定中（[#416](https://github.com/DIO0550/plugin-manager/issues/416)） |
 | Claude Code | .claude/ ディレクトリ | 計画中（[#96](https://github.com/DIO0550/plugin-manager/issues/96)）。**#338 完了後に着手推奨** |
 | Windsurf | Windsurf IDE | 調査対象 |
 | Aider | Aider CLI | 調査対象 |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

[Issue #421](https://github.com/DIO0550/plugin-manager/issues/421) に従い、OpenCode Phase 1–4 実装完了後のドキュメント状態表記を ✅ 対応済みに同期します。完了済み子 Issue（#417–#421）のチェックリスト記載は削除しました。

## 変更内容

### 🎯 変更の種類

- [x] 📖 ドキュメント更新 (Documentation)

### 📝 詳細な変更内容

#### 追加された機能・修正

- `targets.md` / `roadmap.md` Phase 17 / `opencode-target-plan.md` を実装済みに更新
- README / README.ja / `index.md` / `commands/target.md` / `CLAUDE.md` の「仕様策定中」「実装予定」を除去
- `scopes.md` / `components.md` / `deployment.md` に OpenCode パス・配置方針を追加
- `file-formats.md` / `config.md` / `overview.md` の表記を同期
- 完了済み子 Issue（#417–#421）のチェックリスト・依存関係図・Phase 詳細を削除（Epic #416 への参照は維持）

#### 変更されたファイル

- `docs/concepts/targets.md`, `scopes.md`, `components.md`, `deployment.md`
- `docs/roadmap.md`, `docs/architecture/opencode-target-plan.md`, `file-formats.md`, `overview.md`
- `docs/commands/target.md`, `docs/index.md`, `docs/reference/config.md`
- `README.md`, `README.ja.md`, `CLAUDE.md`

## 関連Issue

- Closes #421
- Related: #416

## テスト

- ドキュメントのみのため `cargo` 未実行
- OpenCode の「仕様策定中 / Spec in progress / 実装予定 / 実装未着手」表記が残っていないことを検索で確認

## レビューポイント

- Hooks/Plugins を対応済みにしていないこと
- Skills=`original_name`、Instructions Personal あり、opt-in（`plm target add opencode`）の記述一貫性

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3b3b8da8-3d37-41d4-ad38-4af37a8492d6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3b3b8da8-3d37-41d4-ad38-4af37a8492d6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

