### PR TITLE
Claude Code の frontmatter 正規化ヘルパー追加と解析分離

### DIFF
--- a/src/parser/claude_code.rs
+++ b/src/parser/claude_code.rs
@@ -2,6 +2,7 @@
 
 mod agent;
 mod command;
+mod frontmatter;
 
 pub use agent::ClaudeCodeAgent;
 pub use command::ClaudeCodeCommand;

--- a/src/parser/claude_code/agent.rs
+++ b/src/parser/claude_code/agent.rs
@@ -14,7 +14,7 @@ use super::super::frontmatter::{
     deserialize_frontmatter, emit_frontmatter, extract_frontmatter, normalize_optional_name,
     stem_without_suffixes, ExtractedFrontmatter,
 };
-use super::frontmatter::normalize_description_examples;
+use super::frontmatter::AGENT_FRONTMATTER_SCHEMA;
 
 /// Claude Code Agent frontmatter fields.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -63,10 +63,9 @@ impl ClaudeCodeAgent {
     pub fn parse(content: &str) -> Result<Self> {
         let ExtractedFrontmatter { yaml, body } = extract_frontmatter(content);
         let fm = match yaml {
-            Some(yaml) => deserialize_frontmatter(&normalize_description_examples(
-                &yaml,
-                &["name", "description", "tools", "model"],
-            ))?,
+            Some(yaml) => deserialize_frontmatter(
+                &AGENT_FRONTMATTER_SCHEMA.normalize_description_examples(&yaml),
+            )?,
             None => ClaudeCodeAgentFrontmatter::default(),
         };
 

--- a/src/parser/claude_code/agent.rs
+++ b/src/parser/claude_code/agent.rs
@@ -11,9 +11,10 @@ use super::super::codex::CodexAgent;
 use super::super::convert::{self, TargetFormat, TargetType};
 use super::super::copilot::CopilotAgent;
 use super::super::frontmatter::{
-    emit_frontmatter, normalize_optional_name, parse_frontmatter, stem_without_suffixes,
-    ParsedDocument,
+    deserialize_frontmatter, emit_frontmatter, extract_frontmatter, normalize_optional_name,
+    stem_without_suffixes, ExtractedFrontmatter,
 };
+use super::frontmatter::normalize_description_examples;
 
 /// Claude Code Agent frontmatter fields.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -60,10 +61,14 @@ impl ClaudeCodeAgent {
     ///
     /// * `content` - Raw markdown content including optional YAML frontmatter.
     pub fn parse(content: &str) -> Result<Self> {
-        let ParsedDocument { frontmatter, body } =
-            parse_frontmatter::<ClaudeCodeAgentFrontmatter>(content)?;
-
-        let fm = frontmatter.unwrap_or_default();
+        let ExtractedFrontmatter { yaml, body } = extract_frontmatter(content);
+        let fm = match yaml {
+            Some(yaml) => deserialize_frontmatter(&normalize_description_examples(
+                &yaml,
+                &["name", "description", "tools", "model"],
+            ))?,
+            None => ClaudeCodeAgentFrontmatter::default(),
+        };
 
         Ok(ClaudeCodeAgent {
             name: normalize_optional_name(fm.name),

--- a/src/parser/claude_code/agent_test.rs
+++ b/src/parser/claude_code/agent_test.rs
@@ -70,6 +70,54 @@ fn parse_yaml_error() {
 }
 
 #[test]
+fn parse_description_with_examples_and_following_fields() {
+    let content = r#"---
+name: reviewer
+description: Reviews changes carefully.
+Examples:
+
+<example>
+Context: A pull request changes authentication.
+user: Review this change.
+assistant: I will inspect the authentication flow.
+<commentary>Focus on security boundaries.</commentary>
+</example>
+
+<example>
+Context: A pull request adds tests.
+user: Check coverage.
+assistant: I will identify missing cases.
+</example>
+tools: Read, Grep
+model: opus
+---
+
+Review the code."#;
+
+    let agent = ClaudeCodeAgent::parse(content).unwrap();
+    assert_eq!(
+        agent.description.as_deref(),
+        Some(
+            "Reviews changes carefully.\nExamples:\n\n<example>\nContext: A pull request changes authentication.\nuser: Review this change.\nassistant: I will inspect the authentication flow.\n<commentary>Focus on security boundaries.</commentary>\n</example>\n\n<example>\nContext: A pull request adds tests.\nuser: Check coverage.\nassistant: I will identify missing cases.\n</example>"
+        )
+    );
+    assert_eq!(agent.tools.as_deref(), Some("Read, Grep"));
+    assert_eq!(agent.model.as_deref(), Some("opus"));
+
+    for target in [TargetType::Codex, TargetType::Copilot] {
+        let markdown = agent.to_format(target).unwrap().to_markdown();
+        let yaml = markdown.split("---").nth(1).unwrap();
+        serde_yaml::from_str::<serde_yaml::Value>(yaml).unwrap();
+    }
+}
+
+#[test]
+fn parse_description_examples_does_not_absorb_unknown_invalid_yaml() {
+    let content = "---\ndescription: Test.\nExamples:\n<example>\nuser: Run it.\n</example>\nunknown: [invalid yaml\n---\nBody.";
+    assert!(ClaudeCodeAgent::parse(content).is_err());
+}
+
+#[test]
 fn parse_unknown_fields_ignored() {
     let content = "---\nname: test\nunknown_field: value\n---\n\nBody.";
     let agent = ClaudeCodeAgent::parse(content).unwrap();

--- a/src/parser/claude_code/command.rs
+++ b/src/parser/claude_code/command.rs
@@ -14,7 +14,7 @@ use super::super::frontmatter::{
     deserialize_frontmatter, emit_frontmatter, extract_frontmatter, normalize_optional_name,
     stem_without_suffixes, ExtractedFrontmatter,
 };
-use super::frontmatter::normalize_description_examples;
+use super::frontmatter::COMMAND_FRONTMATTER_SCHEMA;
 
 /// Claude Code Command frontmatter fields.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -81,18 +81,9 @@ impl ClaudeCodeCommand {
     pub fn parse(content: &str) -> Result<Self> {
         let ExtractedFrontmatter { yaml, body } = extract_frontmatter(content);
         let fm = match yaml {
-            Some(yaml) => deserialize_frontmatter(&normalize_description_examples(
-                &yaml,
-                &[
-                    "name",
-                    "description",
-                    "allowed-tools",
-                    "argument-hint",
-                    "model",
-                    "disable-model-invocation",
-                    "user-invocable",
-                ],
-            ))?,
+            Some(yaml) => deserialize_frontmatter(
+                &COMMAND_FRONTMATTER_SCHEMA.normalize_description_examples(&yaml),
+            )?,
             None => ClaudeCodeCommandFrontmatter::default(),
         };
 

--- a/src/parser/claude_code/command.rs
+++ b/src/parser/claude_code/command.rs
@@ -11,9 +11,10 @@ use super::super::codex::CodexPrompt;
 use super::super::convert::{self, TargetFormat, TargetType};
 use super::super::copilot::CopilotPrompt;
 use super::super::frontmatter::{
-    emit_frontmatter, normalize_optional_name, parse_frontmatter, stem_without_suffixes,
-    ParsedDocument,
+    deserialize_frontmatter, emit_frontmatter, extract_frontmatter, normalize_optional_name,
+    stem_without_suffixes, ExtractedFrontmatter,
 };
+use super::frontmatter::normalize_description_examples;
 
 /// Claude Code Command frontmatter fields.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -78,10 +79,22 @@ impl ClaudeCodeCommand {
     ///
     /// * `content` - Raw markdown content including optional YAML frontmatter.
     pub fn parse(content: &str) -> Result<Self> {
-        let ParsedDocument { frontmatter, body } =
-            parse_frontmatter::<ClaudeCodeCommandFrontmatter>(content)?;
-
-        let fm = frontmatter.unwrap_or_default();
+        let ExtractedFrontmatter { yaml, body } = extract_frontmatter(content);
+        let fm = match yaml {
+            Some(yaml) => deserialize_frontmatter(&normalize_description_examples(
+                &yaml,
+                &[
+                    "name",
+                    "description",
+                    "allowed-tools",
+                    "argument-hint",
+                    "model",
+                    "disable-model-invocation",
+                    "user-invocable",
+                ],
+            ))?,
+            None => ClaudeCodeCommandFrontmatter::default(),
+        };
 
         Ok(ClaudeCodeCommand {
             name: normalize_optional_name(fm.name),

--- a/src/parser/claude_code/command_test.rs
+++ b/src/parser/claude_code/command_test.rs
@@ -184,6 +184,59 @@ Body."#;
     assert_eq!(cmd.name, Some("test".to_string()));
 }
 
+#[test]
+fn parse_command_description_with_examples_and_following_fields() {
+    let content = r#"---
+name: explain
+description: Explains a command.
+<example>
+Context: The user is learning Git.
+user: Explain rebase.
+assistant: I will provide a safe example.
+<commentary>Prefer a visual explanation.</commentary>
+</example>
+
+<example>
+Context: The user has conflicts.
+user: Help resolve them.
+assistant: I will explain each step.
+</example>
+allowed-tools: Read, Bash
+argument-hint: "[topic]"
+model: haiku
+disable-model-invocation: true
+user-invocable: false
+---
+
+Explain $ARGUMENTS."#;
+
+    let command = ClaudeCodeCommand::parse(content).unwrap();
+    assert_eq!(
+        command.description.as_deref(),
+        Some(
+            "Explains a command.\n<example>\nContext: The user is learning Git.\nuser: Explain rebase.\nassistant: I will provide a safe example.\n<commentary>Prefer a visual explanation.</commentary>\n</example>\n\n<example>\nContext: The user has conflicts.\nuser: Help resolve them.\nassistant: I will explain each step.\n</example>"
+        )
+    );
+    assert_eq!(command.allowed_tools.as_deref(), Some("Read, Bash"));
+    assert_eq!(command.argument_hint.as_deref(), Some("[topic]"));
+    assert_eq!(command.model.as_deref(), Some("haiku"));
+    assert_eq!(command.disable_model_invocation, Some(true));
+    assert_eq!(command.user_invocable, Some(false));
+
+    for target in [TargetType::Codex, TargetType::Copilot] {
+        let markdown = command.to_format(target).unwrap().to_markdown();
+        let yaml = markdown.split("---").nth(1).unwrap();
+        serde_yaml::from_str::<serde_yaml::Value>(yaml).unwrap();
+    }
+}
+
+#[test]
+fn parse_command_description_examples_does_not_absorb_unknown_invalid_yaml() {
+    let content =
+        "---\ndescription: Test.\nExamples:\nuser: Run it.\nunknown: {invalid yaml\n---\nBody.";
+    assert!(ClaudeCodeCommand::parse(content).is_err());
+}
+
 // ============================================================================
 // to_markdown tests
 // ============================================================================

--- a/src/parser/claude_code/frontmatter.rs
+++ b/src/parser/claude_code/frontmatter.rs
@@ -2,26 +2,46 @@
 
 /// Claude Code frontmatter schema used during description normalization.
 pub(super) struct FrontmatterSchema {
-    /// Top-level YAML fields supported by the target component.
-    top_level_fields: &'static [&'static str],
+    /// Whether the YAML accepts `name`.
+    name: bool,
+    /// Whether the YAML accepts `description`.
+    description: bool,
+    /// Whether the YAML accepts `tools`.
+    tools: bool,
+    /// Whether the YAML accepts `allowed-tools`.
+    allowed_tools: bool,
+    /// Whether the YAML accepts `argument-hint`.
+    argument_hint: bool,
+    /// Whether the YAML accepts `model`.
+    model: bool,
+    /// Whether the YAML accepts `disable-model-invocation`.
+    disable_model_invocation: bool,
+    /// Whether the YAML accepts `user-invocable`.
+    user_invocable: bool,
 }
 
 /// Agent frontmatter schema.
 pub(super) const AGENT_FRONTMATTER_SCHEMA: FrontmatterSchema = FrontmatterSchema {
-    top_level_fields: &["name", "description", "tools", "model"],
+    name: true,
+    description: true,
+    tools: true,
+    allowed_tools: false,
+    argument_hint: false,
+    model: true,
+    disable_model_invocation: false,
+    user_invocable: false,
 };
 
 /// Command frontmatter schema.
 pub(super) const COMMAND_FRONTMATTER_SCHEMA: FrontmatterSchema = FrontmatterSchema {
-    top_level_fields: &[
-        "name",
-        "description",
-        "allowed-tools",
-        "argument-hint",
-        "model",
-        "disable-model-invocation",
-        "user-invocable",
-    ],
+    name: true,
+    description: true,
+    tools: false,
+    allowed_tools: true,
+    argument_hint: true,
+    model: true,
+    disable_model_invocation: true,
+    user_invocable: true,
 };
 
 impl FrontmatterSchema {
@@ -119,9 +139,32 @@ impl FrontmatterSchema {
         if matches!(key, "Examples" | "Context" | "user" | "assistant") {
             return false;
         }
-        self.top_level_fields.contains(&key)
+        self.is_supported_field(key)
             || key
                 .chars()
                 .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    }
+
+    /// Determines whether a key is a supported top-level YAML field.
+    ///
+    /// # Arguments
+    ///
+    /// * `key` - Top-level YAML key to inspect.
+    ///
+    /// # Returns
+    ///
+    /// `true` when the corresponding schema property is enabled.
+    fn is_supported_field(&self, key: &str) -> bool {
+        match key {
+            "name" => self.name,
+            "description" => self.description,
+            "tools" => self.tools,
+            "allowed-tools" => self.allowed_tools,
+            "argument-hint" => self.argument_hint,
+            "model" => self.model,
+            "disable-model-invocation" => self.disable_model_invocation,
+            "user-invocable" => self.user_invocable,
+            _ => false,
+        }
     }
 }

--- a/src/parser/claude_code/frontmatter.rs
+++ b/src/parser/claude_code/frontmatter.rs
@@ -1,0 +1,103 @@
+//! Claude Code-specific frontmatter normalization.
+
+/// Normalizes a malformed plain-scalar description containing example blocks.
+///
+/// Only a `description:` whose following line is `Examples:` or `<example>` is
+/// converted to a YAML literal block. Known metadata fields and unknown
+/// top-level keys terminate the description, while Claude example labels remain
+/// part of it.
+///
+/// # Arguments
+///
+/// * `yaml` - Claude Code frontmatter without `---` delimiter lines.
+/// * `fields` - Top-level field names supported by the caller's frontmatter type.
+///
+/// # Returns
+///
+/// Normalized YAML, or the original YAML unchanged when the targeted malformed
+/// description shape is not present.
+pub(super) fn normalize_description_examples(yaml: &str, fields: &[&str]) -> String {
+    let lines: Vec<&str> = yaml.lines().collect();
+    let Some(description_index) = lines.iter().position(|line| {
+        line.strip_prefix("description:")
+            .is_some_and(|value| is_plain_scalar(value.trim()))
+    }) else {
+        return yaml.to_string();
+    };
+
+    let example_index = description_index + 1;
+    if !lines
+        .get(example_index)
+        .is_some_and(|line| matches!(line.trim(), "Examples:" | "<example>"))
+    {
+        return yaml.to_string();
+    }
+
+    let end = lines[example_index..]
+        .iter()
+        .position(|line| is_metadata_boundary(line, fields))
+        .map(|offset| example_index + offset)
+        .unwrap_or(lines.len());
+    let first = lines[description_index]
+        .strip_prefix("description:")
+        .unwrap()
+        .trim_start();
+    let mut normalized: Vec<String> = Vec::with_capacity(lines.len() + 1);
+    normalized.extend(
+        lines[..description_index]
+            .iter()
+            .map(|line| (*line).to_string()),
+    );
+    normalized.push("description: |-".to_string());
+    normalized.push(format!("  {first}"));
+    for line in &lines[example_index..end] {
+        normalized.push(format!("  {line}"));
+    }
+    normalized.extend(lines[end..].iter().map(|line| (*line).to_string()));
+    normalized.join("\n")
+}
+
+/// Determines whether a description value uses a non-empty YAML plain scalar.
+///
+/// # Arguments
+///
+/// * `value` - Text after the `description:` key.
+///
+/// # Returns
+///
+/// `true` when the value is non-empty and does not start with YAML quoting,
+/// collection, or block-scalar syntax.
+fn is_plain_scalar(value: &str) -> bool {
+    !value.is_empty()
+        && !matches!(
+            value.as_bytes()[0],
+            b'\'' | b'"' | b'[' | b'{' | b'|' | b'>'
+        )
+}
+
+/// Determines whether a line starts a top-level metadata field.
+///
+/// # Arguments
+///
+/// * `line` - Frontmatter line to inspect.
+/// * `fields` - Top-level field names supported by the caller.
+///
+/// # Returns
+///
+/// `true` when the line is a known or unknown YAML-like top-level key, except
+/// for labels explicitly allowed inside Claude example descriptions.
+fn is_metadata_boundary(line: &str, fields: &[&str]) -> bool {
+    if line.starts_with(char::is_whitespace) || line.is_empty() {
+        return false;
+    }
+    let Some((key, _)) = line.split_once(':') else {
+        return false;
+    };
+    if matches!(key, "Examples" | "Context" | "user" | "assistant") {
+        return false;
+    }
+    fields.contains(&key)
+        || key
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+}

--- a/src/parser/claude_code/frontmatter.rs
+++ b/src/parser/claude_code/frontmatter.rs
@@ -1,103 +1,127 @@
 //! Claude Code-specific frontmatter normalization.
 
-/// Normalizes a malformed plain-scalar description containing example blocks.
-///
-/// Only a `description:` whose following line is `Examples:` or `<example>` is
-/// converted to a YAML literal block. Known metadata fields and unknown
-/// top-level keys terminate the description, while Claude example labels remain
-/// part of it.
-///
-/// # Arguments
-///
-/// * `yaml` - Claude Code frontmatter without `---` delimiter lines.
-/// * `fields` - Top-level field names supported by the caller's frontmatter type.
-///
-/// # Returns
-///
-/// Normalized YAML, or the original YAML unchanged when the targeted malformed
-/// description shape is not present.
-pub(super) fn normalize_description_examples(yaml: &str, fields: &[&str]) -> String {
-    let lines: Vec<&str> = yaml.lines().collect();
-    let Some(description_index) = lines.iter().position(|line| {
-        line.strip_prefix("description:")
-            .is_some_and(|value| is_plain_scalar(value.trim()))
-    }) else {
-        return yaml.to_string();
-    };
+/// Claude Code frontmatter schema used during description normalization.
+pub(super) struct FrontmatterSchema {
+    /// Top-level YAML fields supported by the target component.
+    top_level_fields: &'static [&'static str],
+}
 
-    let example_index = description_index + 1;
-    if !lines
-        .get(example_index)
-        .is_some_and(|line| matches!(line.trim(), "Examples:" | "<example>"))
-    {
-        return yaml.to_string();
-    }
+/// Agent frontmatter schema.
+pub(super) const AGENT_FRONTMATTER_SCHEMA: FrontmatterSchema = FrontmatterSchema {
+    top_level_fields: &["name", "description", "tools", "model"],
+};
 
-    let end = lines[example_index..]
-        .iter()
-        .position(|line| is_metadata_boundary(line, fields))
-        .map(|offset| example_index + offset)
-        .unwrap_or(lines.len());
-    let first = lines[description_index]
-        .strip_prefix("description:")
-        .unwrap()
-        .trim_start();
-    let mut normalized: Vec<String> = Vec::with_capacity(lines.len() + 1);
-    normalized.extend(
-        lines[..description_index]
+/// Command frontmatter schema.
+pub(super) const COMMAND_FRONTMATTER_SCHEMA: FrontmatterSchema = FrontmatterSchema {
+    top_level_fields: &[
+        "name",
+        "description",
+        "allowed-tools",
+        "argument-hint",
+        "model",
+        "disable-model-invocation",
+        "user-invocable",
+    ],
+};
+
+impl FrontmatterSchema {
+    /// Normalizes a malformed plain-scalar description containing example blocks.
+    ///
+    /// Only a `description:` whose following line is `Examples:` or `<example>` is
+    /// converted to a YAML literal block. Known metadata fields and unknown
+    /// top-level keys terminate the description, while Claude example labels remain
+    /// part of it.
+    ///
+    /// # Arguments
+    ///
+    /// * `yaml` - Claude Code frontmatter without `---` delimiter lines.
+    ///
+    /// # Returns
+    ///
+    /// Normalized YAML, or the original YAML unchanged when the targeted malformed
+    /// description shape is not present.
+    pub(super) fn normalize_description_examples(&self, yaml: &str) -> String {
+        let lines: Vec<&str> = yaml.lines().collect();
+        let Some(description_index) = lines.iter().position(|line| {
+            line.strip_prefix("description:")
+                .is_some_and(|value| Self::is_plain_scalar(value.trim()))
+        }) else {
+            return yaml.to_string();
+        };
+
+        let example_index = description_index + 1;
+        if !lines
+            .get(example_index)
+            .is_some_and(|line| matches!(line.trim(), "Examples:" | "<example>"))
+        {
+            return yaml.to_string();
+        }
+
+        let end = lines[example_index..]
             .iter()
-            .map(|line| (*line).to_string()),
-    );
-    normalized.push("description: |-".to_string());
-    normalized.push(format!("  {first}"));
-    for line in &lines[example_index..end] {
-        normalized.push(format!("  {line}"));
+            .position(|line| self.is_metadata_boundary(line))
+            .map(|offset| example_index + offset)
+            .unwrap_or(lines.len());
+        let first = lines[description_index]
+            .strip_prefix("description:")
+            .unwrap()
+            .trim_start();
+        let mut normalized: Vec<String> = Vec::with_capacity(lines.len() + 1);
+        normalized.extend(
+            lines[..description_index]
+                .iter()
+                .map(|line| (*line).to_string()),
+        );
+        normalized.push("description: |-".to_string());
+        normalized.push(format!("  {first}"));
+        for line in &lines[example_index..end] {
+            normalized.push(format!("  {line}"));
+        }
+        normalized.extend(lines[end..].iter().map(|line| (*line).to_string()));
+        normalized.join("\n")
     }
-    normalized.extend(lines[end..].iter().map(|line| (*line).to_string()));
-    normalized.join("\n")
-}
 
-/// Determines whether a description value uses a non-empty YAML plain scalar.
-///
-/// # Arguments
-///
-/// * `value` - Text after the `description:` key.
-///
-/// # Returns
-///
-/// `true` when the value is non-empty and does not start with YAML quoting,
-/// collection, or block-scalar syntax.
-fn is_plain_scalar(value: &str) -> bool {
-    !value.is_empty()
-        && !matches!(
-            value.as_bytes()[0],
-            b'\'' | b'"' | b'[' | b'{' | b'|' | b'>'
-        )
-}
+    /// Determines whether a description value uses a non-empty YAML plain scalar.
+    ///
+    /// # Arguments
+    ///
+    /// * `value` - Text after the `description:` key.
+    ///
+    /// # Returns
+    ///
+    /// `true` when the value is non-empty and does not start with YAML quoting,
+    /// collection, or block-scalar syntax.
+    fn is_plain_scalar(value: &str) -> bool {
+        !value.is_empty()
+            && !matches!(
+                value.as_bytes()[0],
+                b'\'' | b'"' | b'[' | b'{' | b'|' | b'>'
+            )
+    }
 
-/// Determines whether a line starts a top-level metadata field.
-///
-/// # Arguments
-///
-/// * `line` - Frontmatter line to inspect.
-/// * `fields` - Top-level field names supported by the caller.
-///
-/// # Returns
-///
-/// `true` when the line is a known or unknown YAML-like top-level key, except
-/// for labels explicitly allowed inside Claude example descriptions.
-fn is_metadata_boundary(line: &str, fields: &[&str]) -> bool {
-    if line.starts_with(char::is_whitespace) || line.is_empty() {
-        return false;
+    /// Determines whether a line starts a top-level metadata field.
+    ///
+    /// # Arguments
+    ///
+    /// * `line` - Frontmatter line to inspect.
+    ///
+    /// # Returns
+    ///
+    /// `true` when the line is a known or unknown YAML-like top-level key, except
+    /// for labels explicitly allowed inside Claude example descriptions.
+    fn is_metadata_boundary(&self, line: &str) -> bool {
+        if line.starts_with(char::is_whitespace) || line.is_empty() {
+            return false;
+        }
+        let Some((key, _)) = line.split_once(':') else {
+            return false;
+        };
+        if matches!(key, "Examples" | "Context" | "user" | "assistant") {
+            return false;
+        }
+        self.top_level_fields.contains(&key)
+            || key
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
     }
-    let Some((key, _)) = line.split_once(':') else {
-        return false;
-    };
-    if matches!(key, "Examples" | "Context" | "user" | "assistant") {
-        return false;
-    }
-    fields.contains(&key)
-        || key
-            .chars()
-            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
 }

--- a/src/parser/frontmatter.rs
+++ b/src/parser/frontmatter.rs
@@ -16,6 +16,87 @@ pub struct ParsedDocument<T> {
     pub body: String,
 }
 
+/// Document with YAML frontmatter kept as an undecoded string.
+#[derive(Debug, Clone)]
+pub(crate) struct ExtractedFrontmatter {
+    /// Extracted YAML (None if no frontmatter is present).
+    pub yaml: Option<String>,
+    /// Body text (everything after the frontmatter).
+    pub body: String,
+}
+
+/// Extracts optional YAML frontmatter without deserializing it.
+///
+/// # Arguments
+///
+/// * `content` - Document text whose frontmatter and body should be separated.
+///
+/// # Returns
+///
+/// The undecoded YAML and body, or no YAML when the document has no complete
+/// frontmatter envelope.
+pub(crate) fn extract_frontmatter(content: &str) -> ExtractedFrontmatter {
+    let content = content.strip_prefix('\u{feff}').unwrap_or(content);
+    let lines: Vec<&str> = content.lines().collect();
+
+    let first_line = lines.first().map(|s| s.trim()).unwrap_or("");
+    if !first_line.starts_with("---") {
+        return ExtractedFrontmatter {
+            yaml: None,
+            body: content.to_string(),
+        };
+    }
+
+    let closing_index = lines
+        .iter()
+        .enumerate()
+        .skip(1)
+        .find(|(_, line)| line.trim().starts_with("---"))
+        .map(|(i, _)| i);
+
+    let Some(closing_index) = closing_index else {
+        return ExtractedFrontmatter {
+            yaml: None,
+            body: content.to_string(),
+        };
+    };
+
+    let yaml = lines[1..closing_index].join("\n");
+    let body = if closing_index + 1 < lines.len() {
+        let offset = lines
+            .iter()
+            .take(closing_index + 1)
+            .map(|line| line.len() + 1)
+            .sum::<usize>();
+        content.get(offset..).unwrap_or_default().to_string()
+    } else {
+        String::new()
+    };
+
+    ExtractedFrontmatter {
+        yaml: Some(yaml),
+        body,
+    }
+}
+
+/// Deserializes an extracted YAML frontmatter string into a requested type.
+///
+/// # Arguments
+///
+/// * `yaml` - YAML frontmatter content without delimiter lines.
+///
+/// # Returns
+///
+/// The deserialized value, using `T::default()` when `yaml` is empty, or a YAML
+/// parsing error when the input is invalid for `T`.
+pub(crate) fn deserialize_frontmatter<T: DeserializeOwned + Default>(yaml: &str) -> Result<T> {
+    if yaml.trim().is_empty() {
+        Ok(T::default())
+    } else {
+        serde_yaml::from_str(yaml).map_err(PlmError::Yaml)
+    }
+}
+
 /// Parses YAML frontmatter from a document.
 ///
 /// # Format
@@ -50,63 +131,14 @@ pub struct ParsedDocument<T> {
 pub fn parse_frontmatter<T: DeserializeOwned + Default>(
     content: &str,
 ) -> Result<ParsedDocument<T>> {
-    // Remove UTF-8 BOM if present
-    let content = content.strip_prefix('\u{feff}').unwrap_or(content);
-
-    let lines: Vec<&str> = content.lines().collect();
-
-    let first_line = lines.first().map(|s| s.trim()).unwrap_or("");
-    if !first_line.starts_with("---") {
-        // No frontmatter - entire content is body
+    let ExtractedFrontmatter { yaml, body } = extract_frontmatter(content);
+    let Some(yaml) = yaml else {
         return Ok(ParsedDocument {
             frontmatter: None,
-            body: content.to_string(),
-        });
-    }
-
-    let closing_index = lines
-        .iter()
-        .enumerate()
-        .skip(1) // Skip the opening ---
-        .find(|(_, line)| line.trim().starts_with("---"))
-        .map(|(i, _)| i);
-
-    let Some(closing_index) = closing_index else {
-        // No closing --- found - treat entire content as body
-        return Ok(ParsedDocument {
-            frontmatter: None,
-            body: content.to_string(),
+            body,
         });
     };
-
-    let yaml_content: String = lines[1..closing_index].join("\n");
-
-    let frontmatter: T = if yaml_content.trim().is_empty() {
-        // Empty frontmatter - use default
-        T::default()
-    } else {
-        serde_yaml::from_str(&yaml_content).map_err(PlmError::Yaml)?
-    };
-
-    // Extract body (everything after closing ---)
-    // Preserve exact content including leading newlines
-    let body = if closing_index + 1 < lines.len() {
-        let mut offset = 0;
-        for (i, line) in lines.iter().enumerate() {
-            if i <= closing_index {
-                offset += line.len() + 1; // +1 for newline
-            } else {
-                break;
-            }
-        }
-        if offset <= content.len() {
-            content[offset..].to_string()
-        } else {
-            String::new()
-        }
-    } else {
-        String::new()
-    };
+    let frontmatter = deserialize_frontmatter(&yaml)?;
 
     Ok(ParsedDocument {
         frontmatter: Some(frontmatter),


### PR DESCRIPTION
### Motivation

- Claude Code のフロントマターでプレーンスカラー形式の `description:` に続く `Examples:` / `<example>` ブロックを正しく扱うため、専用の正規化ヘルパーが必要だった。
- 汎用の `parse_frontmatter` に余分なフォールバックを入れず、区切り抽出と YAML デシリアライズを分離して Claude Code 側から正規化済み YAML を安全に渡せる構造にする意図。

### Description

- `src/parser/claude_code/frontmatter.rs` を追加し、`normalize_description_examples` を実装して、プレーンスカラーの `description:` の直後に `Examples:` または `<example>` がある場合のみ YAML リテラルブロックへ変換するロジックを実装し、関数に引数・戻り値を明記した doc コメントを付与した。
- 汎用パーサ `src/parser/frontmatter.rs` に `extract_frontmatter` と `deserialize_frontmatter` を追加して「区切り抽出」と「型への YAML デシリアライズ」を分離し、`parse_frontmatter` は従来の厳密な経路を維持したまま抽出ヘルパーを利用するように変更した。
- Claude Code 側では `src/parser/claude_code/agent.rs` と `src/parser/claude_code/command.rs` の `parse` 実装のみを変更し、抽出→正規化→デシリアライズの流れを導入して他ターゲット（Codex／Copilot）には影響を与えないようにした。
- テストを追加・拡張し、`src/parser/claude_code/agent_test.rs` と `src/parser/claude_code/command_test.rs` に複数 `<example>`、空行、`Context:`・`user:`・`assistant:`・`<commentary>`、および後続フィールドを含む再現ケースを追加して、description が改行込みで保持され、後続フィールドが個別に解析されることを検証した。既存の `parse_yaml_error` テストも維持している。
- 変更はコミット `05a3eb4`（メッセージ: `Claude Codeフロントマターを正規化`）として適用済みで、該当変更ファイルは `src/parser/claude_code/frontmatter.rs`, `src/parser/frontmatter.rs`, `src/parser/claude_code/agent.rs`, `src/parser/claude_code/command.rs` とテストファイル群である。

### Testing

- `cargo fmt --check` は成功した。 
- 単体対象: `cargo test parser::claude_code` と `cargo test parser::frontmatter_test` を実行し、両方とも全テストが成功した（合計 52 + 21 テスト、すべて成功）。
- 全体: `cargo test` を実行したところ、今回の変更範囲（parser 関連）は成功したが、CI 環境依存で `assert_cmd::cargo_bin` に起因する既存の CLI テストなど 30 件の未関連テストが失敗したため全体では失敗になった点に注意（環境依存の実行バイナリ検出が原因）。
- 静的解析: `git diff --check` は問題なし、`cargo clippy --all-targets -- -D warnings` はリポジトリ既存の警告（非推奨 API、clippy 警告等）によりエラーとなったが、これらは今回の変更範囲外の既存コードが原因である。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a804049b19c832396109a2eac99c703)