### PR TITLE
📝 [Doc]: 上流 CLI 仕様の追随状況を記録し、TODO を docs 側で管理する

### DIFF
--- a/docs/concepts/targets.md
+++ b/docs/concepts/targets.md
@@ -13,6 +13,9 @@ PLMがサポートするAI開発環境（ターゲット）について説明し
 | **cursor** | Cursor（IDE / CLI） | ✅ 対応済み |
 | **opencode** | OpenCode（ターミナル AI エージェント） | ✅ 対応済み |
 
+> **上流仕様の追随状況**: 各ターゲットの公式仕様は継続的に更新される。最終調査日と未対応 TODO は
+> [`docs/reference/upstream-spec-updates.md`](../reference/upstream-spec-updates.md) を参照（最終調査: 2026-08-20）。
+
 ## サポートするコンポーネント
 
 | コンポーネント | Codex | Copilot | Antigravity | Gemini CLI | Cursor | OpenCode |
@@ -66,7 +69,10 @@ PLMがサポートするAI開発環境（ターゲット）について説明し
 
 ### Hooks（10 イベント対応）
 
-公式ドキュメント: [Codex Hooks](https://developers.openai.com/codex/hooks)
+公式ドキュメント: [Codex Hooks](https://developers.openai.com/codex/hooks)（現行 URL: [learn.chatgpt.com/docs/hooks](https://learn.chatgpt.com/docs/hooks)。URL 移行対応は [#463](https://github.com/DIO0550/plugin-manager/issues/463)）
+
+> **TODO（2026-08-20 調査）**: 上流に `SessionEnd` イベントと `async` フィールドが追加されたが PLM 未対応（[#455](https://github.com/DIO0550/plugin-manager/issues/455)）。
+> また hooks は上流で既定有効になり `codex_hooks` は deprecated alias となったため、`[features] codex_hooks = true` の自動追記を見直す（[#456](https://github.com/DIO0550/plugin-manager/issues/456)）。
 
 Codex CLI は PascalCase 命名の hooks イベントを 10 種サポートし、PLM の `CodexEventMap` はそれらをすべて変換対象として保持する（イベント名は変換時にそのまま維持）。
 
@@ -100,7 +106,7 @@ Codex CLI は PascalCase 命名の hooks イベントを 10 種サポートし�
 
 ### 重要な制約
 
-- **Copilotはグローバルファイル（`~/.copilot/`等）を直接読み込まない**
+- **Copilotはグローバルファイル（`~/.copilot/`等）を直接読み込まない**（Instructions / Prompts の話。Skills は上流で `~/.copilot/skills/` が追加済み → [#457](https://github.com/DIO0550/plugin-manager/issues/457)）
 - Personal スコープは VSCode 設定経由で外部ファイルを参照する形式
 - Issue: [Global files outside workspace の要望](https://github.com/microsoft/vscode-copilot-release/issues/3129)
 
@@ -122,7 +128,7 @@ Codex CLI は PascalCase 命名の hooks イベントを 10 種サポートし�
 
 | 種別 | ファイル形式 | Personal | Project |
 |------|-------------|----------|---------|
-| Skills | `SKILL.md` | - | `.github/skills/<marketplace>/<plugin>/<skill>/` |
+| Skills | `SKILL.md` | -（TODO: [#457](https://github.com/DIO0550/plugin-manager/issues/457)） | `.github/skills/<marketplace>/<plugin>/<skill>/` |
 | Agents | `*.agent.md` | `~/.copilot/agents/<marketplace>/<plugin>/` | `.github/agents/<marketplace>/<plugin>/` |
 | Prompts | `*.prompt.md` | - | `.github/prompts/<marketplace>/<plugin>/` |
 | Instructions | `AGENTS.md` | - | `AGENTS.md` |
@@ -147,6 +153,10 @@ VSCode Copilot Agent Modeでは、エージェントセッションのライフ�
 | `PreCompact` | コンテキスト圧縮前 | 重要コンテキストの退避 |
 | `SubagentStart` | サブエージェント開始時 | 追跡 |
 | `SubagentStop` | サブエージェント終了時 | クリーンアップ |
+
+> **TODO（2026-08-20 調査）**: `PostToolUseFailure`（Copilot CLI の `errorOccurred`）/ `PreCompact` / `SubagentStart` が
+> PLM のイベントマップに無く、変換時に除外される（[#458](https://github.com/DIO0550/plugin-manager/issues/458)）。
+> Personal スコープの Skills パス `~/.copilot/skills/` も上流で追加済み（[#457](https://github.com/DIO0550/plugin-manager/issues/457)）。
 
 #### 設定形式
 
@@ -249,7 +259,8 @@ Google Antigravityはエージェント指向の開発プラットフォーム�
 | Skills | `SKILL.md` | `~/.gemini/antigravity/skills/<marketplace>/<plugin>/<skill>/` | `.agent/skills/<marketplace>/<plugin>/<skill>/` |
 | Hooks | `hooks.json` | `~/.gemini/config/hooks.json` | `.agents/hooks.json` |
 
-> Skills の公式推奨パスは Personal `~/.gemini/config/skills/`、Project `.agents/skills/`。PLM 現状パスは IDE 互換だが CLI 非対応のため、パス移行は別 feature（[#402](https://github.com/DIO0550/plugin-manager/issues/402) 連携）で扱う。
+> Skills の公式推奨パスは Personal `~/.gemini/config/skills/`、Project `.agents/skills/`。PLM 現状パスは IDE 互換だが CLI 非対応のため、パス移行は別 feature（[#460](https://github.com/DIO0550/plugin-manager/issues/460)、[#402](https://github.com/DIO0550/plugin-manager/issues/402) 連携）で扱う。
+> **TODO（2026-08-20 調査）**: 上流は `.agents/skills` を既定とし `.agent/skills` は後方互換扱いになった（[#460](https://github.com/DIO0550/plugin-manager/issues/460)）。
 >
 > Hooks は Claude Code 形式から命名フックマップへ変換して単一 `hooks.json` に配置する（[#309](https://github.com/DIO0550/plugin-manager/issues/309)）。非管理ファイルの上書きと複数 Hook 同時配置は拒否。スキーマ詳細は [hooks-schema-mapping.md](../reference/hooks-schema-mapping.md)。
 
@@ -338,7 +349,8 @@ Gemini CLIは `GEMINI.md` ファイルによる階層的な指示システムを
 
 ### 制約事項
 
-- **実験的機能**: `/settings` で Agent Skills を `true` に設定して有効化が必要
+- ~~**実験的機能**: `/settings` で Agent Skills を `true` に設定して有効化が必要~~
+  → **TODO（2026-08-20 調査）**: 上流で GA 済み。`.agents/skills` エイリアスや管理コマンドの追加も含めて記載を更新する（[#461](https://github.com/DIO0550/plugin-manager/issues/461)）
 - **Agents非対応**: `.agent.md` 形式はサポートしない
 - **Prompts非対応**: `.prompt.md` 形式はサポートしない
 - **Hooks 非対応**: Gemini CLI 単体の hooks 公式仕様は追わず、Antigravity（IDE / CLI）共通仕様へ一本化する。一般向け製品移行の詳細は [Transitioning Gemini CLI to Antigravity CLI](https://github.com/google-gemini/gemini-cli/discussions/27274) を参照
@@ -376,6 +388,7 @@ CursorはAnysphere社のAIコードエディタ。エディタに加えてター
 ### 重要な特徴
 
 - **SKILL.md形式**: frontmatterは `name`（必須、小文字・数字・ハイフンのみ、フォルダ名と一致）と `description`（必須）に加え、`paths`（globで適用範囲を制限）、`disable-model-invocation`（trueで明示的スラッシュコマンド専用化）、`metadata` をサポート
+  - **TODO（2026-08-20 調査）**: 上流に `icon` / `color`（Custom Mode 表示用）が追加済み（[#459](https://github.com/DIO0550/plugin-manager/issues/459)）
 - **skillsルートの再帰走査**: ネストしたディレクトリ内の `SKILL.md` も発見されるため、PLMの `<marketplace>/<plugin>/<skill>/` 階層はそのまま読み込まれる見込み
 - **Agents（サブエージェント）**: YAMLフロントマター（`name`, `description`, `model`, `readonly`, `is_background`）付きMarkdown。エディタ・CLI・Cloud Agentsで利用可能
 - **CommandsはSkillsへ移行中**: `/migrate-to-skills` により既存のCommandsは `disable-model-invocation: true` 付きSkillsへ変換される方向。`.cursor/commands/` 自体は引き続き動作する
@@ -386,6 +399,10 @@ CursorはAnysphere社のAIコードエディタ。エディタに加えてター
 設定は単一の `hooks.json`（`{"version": 1, "hooks": {"<event>": [{"command": "..."}]}}`）。イベント名は**camelCase**で、Copilot CLI形式（camelCase + `"version": 1`）に近い。
 
 主なイベント: `sessionStart`, `sessionEnd`, `preToolUse`, `postToolUse`, `postToolUseFailure`, `subagentStart`, `subagentStop`, `beforeShellExecution`, `afterShellExecution`, `beforeMCPExecution`, `afterMCPExecution`, `beforeReadFile`, `afterFileEdit`, `beforeSubmitPrompt`, `preCompact`, `stop`, `afterAgentResponse` など。
+
+> **TODO（2026-08-20 調査）**: 上流に `afterAgentThought`・Tab hooks（`beforeTabFileRead` / `afterTabFileEdit`）・`workspaceOpen` が追加され、
+> hook 単位のフィールドにも `type`（`command` / `prompt`）・`loop_limit`・`failClosed`・`matcher` が加わった。
+> 設定スコープの優先順位も Enterprise → Team → Project → User へ拡張されている（[#459](https://github.com/DIO0550/plugin-manager/issues/459)）。
 
 Claude Code側に対応イベントがないもの（`beforeShellExecution` 等のCursor固有イベント）は変換対象外。PLM は Claude Code → Cursor 変換（camelCase + `version: 1`）を行い、単一の `hooks.json` として配置する。既存の非管理 `hooks.json` の上書きと、同一インストール内の複数 Hook コンポーネントは拒否する（フルマージは将来対応）。
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,6 +35,7 @@ GitHubからAI開発環境向けのプラグインをダウンロードし、複
 - [Concepts](./concepts/targets.md) - コンセプト・仕組み
 - [Architecture](./architecture/overview.md) - 内部アーキテクチャ
 - [Reference](./reference/config.md) - 技術リファレンス
+- [上流仕様の追随状況](./reference/upstream-spec-updates.md) - 各CLI公式仕様の更新チェックとTODO
 - [Roadmap](./roadmap.md) - 実装状況・ロードマップ
 
 ## 対応規格

--- a/docs/reference/upstream-spec-updates.md
+++ b/docs/reference/upstream-spec-updates.md
@@ -1,0 +1,101 @@
+# 上流仕様の追随状況
+
+各ターゲット環境（CLI / IDE）の公式 Hooks / Skills / Agents 仕様の更新を定期的に調査し、
+PLM 側で対応が必要な項目を TODO として管理するドキュメント。
+
+- **最終調査日**: 2026-08-20
+- **前回同期**: 2026-07〜08（`docs/concepts/targets.md` 最終更新）
+- **調査方法**: 各ターゲットの公式ドキュメントを参照し、`docs/concepts/targets.md` の記載および
+  `src/hooks/` / `src/target/env/` の実装と突き合わせる
+
+## 調査結果サマリ
+
+| ターゲット | Skills | Agents | Hooks | 起票 Issue |
+|-----------|--------|--------|-------|-----------|
+| OpenAI Codex | 変更なし | 変更なし | ⚠️ `SessionEnd` 追加・`async` サポート・有効化フラグ仕様変更 | [#455](https://github.com/DIO0550/plugin-manager/issues/455) / [#456](https://github.com/DIO0550/plugin-manager/issues/456) |
+| VSCode Copilot | ⚠️ Personal スコープ（`~/.copilot/skills/`）追加 | 変更なし | ⚠️ 未マップイベントあり（`errorOccurred` / `preCompact` / `subagentStart`） | [#457](https://github.com/DIO0550/plugin-manager/issues/457) / [#458](https://github.com/DIO0550/plugin-manager/issues/458) |
+| Google Antigravity | ⚠️ 公式既定パスが `.agents/skills` / `~/.gemini/config/skills` へ | 変更なし（PLM 未実装は [#400](https://github.com/DIO0550/plugin-manager/issues/400)） | 変更なし（5 イベント） | [#460](https://github.com/DIO0550/plugin-manager/issues/460) |
+| Gemini CLI | ⚠️ GA 化・`.agents/skills` エイリアス・管理コマンド拡張 | 非対応（変更なし） | 非対応（変更なし） | [#461](https://github.com/DIO0550/plugin-manager/issues/461) |
+| Cursor | ⚠️ frontmatter に `icon` / `color` 追加 | 変更なし（ネスト・model パラメータは情報のみ） | ⚠️ 新イベント・新フィールド追加 | [#459](https://github.com/DIO0550/plugin-manager/issues/459) |
+| OpenCode | 変更なし | 変更なし | 対象外（JS/TS Plugin モデル） | — |
+| Claude Code（変換元） | ⚠️ frontmatter 大幅拡張・commands が skills へ統合 | — | ⚠️ イベント 30 種超へ拡張・`mcp_tool` type 追加 | [#462](https://github.com/DIO0550/plugin-manager/issues/462) |
+
+## TODO
+
+### 優先度: 高（変換結果が実機と食い違う）
+
+- [ ] **Codex hooks の `SessionEnd` / `async` 対応** — [#455](https://github.com/DIO0550/plugin-manager/issues/455)
+  - `CodexEventMap` に `SessionEnd` が無く、Claude Code の `SessionEnd` hook が変換時に除外される
+  - `CodexKeyMap` が `async` を「未サポート」として削除しているが、上流はサポート済み
+- [ ] **Codex hooks 有効化フラグの見直し** — [#456](https://github.com/DIO0550/plugin-manager/issues/456)
+  - 上流では hooks が既定で有効。正式キーは `hooks` で `codex_hooks` は deprecated alias
+  - PLM は Hook 配置のたびにユーザーの `config.toml` へ deprecated キーを追記している
+- [ ] **Copilot hooks の未マップイベント追随** — [#458](https://github.com/DIO0550/plugin-manager/issues/458)
+  - `PostToolUseFailure` / `PreCompact` / `SubagentStart` が Copilot だけ未マップ（Cursor では対応済み）
+- [ ] **Antigravity Skills の配置パス移行** — [#460](https://github.com/DIO0550/plugin-manager/issues/460)
+  - 現行パス（`~/.gemini/antigravity/skills`・`.agent/skills`）は AGY CLI から認識されない
+  - Hooks はすでに新パスへ配置済みで、Skills だけ世代が揃っていない
+
+### 優先度: 中（機能追加・仕様確認）
+
+- [ ] **Copilot Skills の Personal スコープ対応** — [#457](https://github.com/DIO0550/plugin-manager/issues/457)
+  - `~/.copilot/skills/` が公式パスになったが、PLM は `ScopeSupport::ProjectOnly` のまま
+  - Agents / Hooks は Personal 対応済みで、Skills だけ非対称
+- [ ] **Claude Code hooks 仕様拡張への追随** — [#462](https://github.com/DIO0550/plugin-manager/issues/462)
+  - 変換元のイベントが 30 種超へ拡張。PLM の `HookEvent` は 10 種のまま
+  - `mcp_tool` type が未知のため全ターゲットで除外される
+  - Skill / Subagent frontmatter 内の `hooks` は PLM のスキャン対象外
+
+### 優先度: 低（ドキュメント整備）
+
+- [ ] **Cursor の仕様更新をドキュメントへ反映** — [#459](https://github.com/DIO0550/plugin-manager/issues/459)
+  - Skills frontmatter の `icon` / `color`、hooks の新イベント・新フィールド・設定スコープ優先順位
+- [ ] **Gemini CLI Skills の GA 化等を反映** — [#461](https://github.com/DIO0550/plugin-manager/issues/461)
+  - 「実験的機能・要 Settings 有効化」の記載が現状と不一致
+- [ ] **公式ドキュメント URL の移行追随** — [#463](https://github.com/DIO0550/plugin-manager/issues/463)
+  - Codex: `developers.openai.com/codex/*` → `learn.chatgpt.com/docs/*`（308 リダイレクト）
+
+## 変更なしと確認した項目
+
+再調査時の差分判断に使うため、今回「変更なし」を確認した項目も記録する。
+
+| 項目 | 確認内容 |
+|------|---------|
+| Antigravity Hooks | `PreToolUse` / `PostToolUse` / `PreInvocation` / `PostInvocation` / `Stop` の 5 イベント。`enabled` / `type` / `command` / `timeout` フィールド |
+| OpenCode Agents / Commands | ディレクトリ名は複数形（`agents/` / `commands/`）。Global は `~/.config/opencode/` |
+| OpenCode Skills | 探索は `skills/*/SKILL.md` の 1 階層。`name` は親ディレクトリ名と一致必須 |
+| OpenCode Plugins | JS/TS モジュールのまま。JSON Hooks 化の動きなし（PLM 対象外の判断は維持） |
+| Cursor Skills の再帰走査 | skills ルートを再帰走査する仕様は維持 |
+| Cursor Subagents frontmatter | `name` / `description` / `model` / `readonly` / `is_background` に変更なし |
+| Codex hooks の探索パス | `~/.codex/hooks.json` / `<repo>/.codex/hooks.json`（PLM の配置先と一致） |
+| Copilot CLI hooks の形式 | `version: 1` + lowerCamelCase + `bash` / `powershell` / `timeoutSec`。VS Code 側が PascalCase へ自動変換 |
+
+## 再調査の手順
+
+次回調査時は以下を順に確認し、本ドキュメントの「最終調査日」と結果を更新する。
+
+| ターゲット | 参照 URL |
+|-----------|---------|
+| OpenAI Codex | https://learn.chatgpt.com/docs/hooks / https://learn.chatgpt.com/docs/build-skills |
+| VSCode Copilot | https://code.visualstudio.com/docs/copilot/customization/hooks / https://code.visualstudio.com/docs/agent-customization/agent-skills |
+| GitHub Copilot CLI | https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/use-hooks |
+| Google Antigravity | https://antigravity.google/docs/skills / https://antigravity.google/docs/hooks / https://antigravity.google/docs/subagents |
+| Gemini CLI | https://geminicli.com/docs/cli/skills/ |
+| Cursor | https://cursor.com/docs/context/skills / https://cursor.com/docs/agent/subagents / https://cursor.com/docs/agent/hooks |
+| OpenCode | https://opencode.ai/docs/skills/ / https://opencode.ai/docs/agents/ / https://opencode.ai/docs/commands/ / https://opencode.ai/docs/plugins/ |
+| Claude Code（変換元） | https://code.claude.com/docs/en/hooks / https://code.claude.com/docs/en/skills / https://code.claude.com/docs/en/plugins |
+
+確認する観点:
+
+1. **イベント名の増減** — `src/hooks/event/*.rs` のマップと突き合わせる
+2. **hook フィールドの増減** — `src/hooks/converter/*.rs` の KeyMap が削除しているフィールドが今も未サポートか
+3. **配置パスの変更** — `src/placement_names.rs` / `src/target/env/*.rs` と突き合わせる
+4. **frontmatter フィールドの増減** — `docs/architecture/file-formats.md` の変換マッピングと突き合わせる
+5. **スコープ（Personal / Project）の増減** — 各ターゲットの `CAPABILITIES` と突き合わせる
+
+## 関連
+
+- [concepts/targets](../concepts/targets.md) - ターゲット環境の仕様
+- [reference/hooks-schema-mapping](./hooks-schema-mapping.md) - Hooks スキーマ変換マッピング
+- [architecture/file-formats](../architecture/file-formats.md) - ファイルフォーマット仕様
+- [roadmap](../roadmap.md) - 実装状況・ロードマップ

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -129,6 +129,25 @@ Epic: [#416](https://github.com/DIO0550/plugin-manager/issues/416)（仕様: `do
 
 Skills / Agents / Commands / Instructions を対応。Hooks / Plugins（JS/TS）は対象外。
 
+## 上流仕様の追随（TODO）
+
+各ターゲットの公式 Hooks / Skills / Agents 仕様は継続的に更新されるため、定期的に調査して差分を追随する。
+調査結果と TODO の詳細は [`docs/reference/upstream-spec-updates.md`](./reference/upstream-spec-updates.md) を参照。
+
+**最終調査日: 2026-08-20**
+
+| 対象 | 内容 | Issue | 状態 |
+|------|------|-------|------|
+| Codex Hooks | `SessionEnd` イベント追加・`async` フィールド対応 | [#455](https://github.com/DIO0550/plugin-manager/issues/455) | 未着手 |
+| Codex Hooks | 有効化フラグ見直し（`codex_hooks` は deprecated alias・既定で有効） | [#456](https://github.com/DIO0550/plugin-manager/issues/456) | 未着手 |
+| Copilot Skills | Personal スコープ（`~/.copilot/skills/`）対応 | [#457](https://github.com/DIO0550/plugin-manager/issues/457) | 未着手 |
+| Copilot Hooks | 未マップイベント追随（`errorOccurred` / `preCompact` / `subagentStart`） | [#458](https://github.com/DIO0550/plugin-manager/issues/458) | 未着手 |
+| Cursor | Skills frontmatter `icon` / `color`・Hooks 新イベント/新フィールド | [#459](https://github.com/DIO0550/plugin-manager/issues/459) | 未着手 |
+| Antigravity Skills | 公式既定パス（`~/.gemini/config/skills` / `.agents/skills`）へ移行 | [#460](https://github.com/DIO0550/plugin-manager/issues/460) | 未着手 |
+| Gemini CLI | Skills GA 化・`.agents/skills` エイリアス・管理コマンド更新 | [#461](https://github.com/DIO0550/plugin-manager/issues/461) | 未着手 |
+| Claude Code（変換元） | 新イベント群・`mcp_tool` type・新フィールドへの追随 | [#462](https://github.com/DIO0550/plugin-manager/issues/462) | 未着手 |
+| ドキュメント | 公式ドキュメント URL 移行（Codex → learn.chatgpt.com） | [#463](https://github.com/DIO0550/plugin-manager/issues/463) | 未着手 |
+
 ## 将来の拡張
 
 ### リファクタ（ドメイン整合）


### PR DESCRIPTION
## 概要

各ターゲット（Codex / Copilot / Antigravity / Gemini CLI / Cursor / OpenCode）と変換元 Claude Code の
公式 Hooks / Skills / Agents 仕様を調査（2026-08-20）し、PLM 実装との差分を洗い出した。
差分は Issue [#455](https://github.com/DIO0550/plugin-manager/issues/455)〜[#463](https://github.com/DIO0550/plugin-manager/issues/463) として起票済みで、本 PR は**ドキュメント側の TODO 管理**を追加する。

コード変更なし（docs のみ）。

## 変更内容

### 新規: `docs/reference/upstream-spec-updates.md`

- 調査結果サマリ（ターゲット × Skills / Agents / Hooks × 起票 Issue）
- 優先度別 TODO チェックリスト（各 Issue へリンク）
- 「変更なし」と確認した項目の記録（次回の差分判断用）
- 再調査の手順（参照 URL 一覧と確認観点 5 項目）

### 更新

| ファイル | 内容 |
|---------|------|
| `docs/roadmap.md` | 「上流仕様の追随（TODO）」節を追加。Issue と状態の一覧表 |
| `docs/index.md` | ドキュメント構成に追随状況ページを追加 |
| `docs/concepts/targets.md` | 記載が古くなった箇所に TODO 注記を追加（Codex Hooks / Copilot Skills・Hooks / Antigravity Skills パス / Gemini CLI GA 化 / Cursor frontmatter・Hooks） |

## 調査で見つかった主な差分

| ターゲット | 差分 | Issue |
|-----------|------|-------|
| Codex | `SessionEnd` イベント追加・`async` フィールド対応。PLM は前者を除外、後者を警告付き削除 | [#455](https://github.com/DIO0550/plugin-manager/issues/455) |
| Codex | hooks が既定有効化。`codex_hooks` は deprecated alias（PLM は毎回 config.toml へ追記） | [#456](https://github.com/DIO0550/plugin-manager/issues/456) |
| Copilot | Personal Skills パス `~/.copilot/skills/` が追加（PLM は ProjectOnly） | [#457](https://github.com/DIO0550/plugin-manager/issues/457) |
| Copilot | `errorOccurred` / `preCompact` / `subagentStart` が未マップ | [#458](https://github.com/DIO0550/plugin-manager/issues/458) |
| Cursor | Skills frontmatter に `icon` / `color`、Hooks に新イベント・新フィールド | [#459](https://github.com/DIO0550/plugin-manager/issues/459) |
| Antigravity | Skills 既定パスが `.agents/skills` / `~/.gemini/config/skills` へ（現行パスは AGY CLI 非認識） | [#460](https://github.com/DIO0550/plugin-manager/issues/460) |
| Gemini CLI | Skills が GA 化（PLM ドキュメントは実験的機能のまま） | [#461](https://github.com/DIO0550/plugin-manager/issues/461) |
| Claude Code | hooks イベントが 30 種超へ拡張、`mcp_tool` type 追加 | [#462](https://github.com/DIO0550/plugin-manager/issues/462) |
| ドキュメント | Codex 公式 URL が `learn.chatgpt.com` へ移行（308） | [#463](https://github.com/DIO0550/plugin-manager/issues/463) |

なお OpenCode（Skills / Agents / Commands / Plugins）と Antigravity Hooks（5 イベント）は
今回の調査で差分なしを確認した。

## 確認事項

- コード変更が無いため `cargo fmt` / `cargo check` / `cargo test` は未実行（Rust ソース無変更）
- 各 Issue に実装方針・対象ファイル・チェックリストを記載済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0124pdaxGZcFCWhfGnWBCbzp

---
_Generated by [Claude Code](https://claude.ai/code/session_0124pdaxGZcFCWhfGnWBCbzp)_