### PR TITLE
Add Copilot mappings for PostToolUseFailure / PreCompact / SubagentStart and update docs/tests

### DIFF
--- a/docs/concepts/targets.md
+++ b/docs/concepts/targets.md
@@ -154,8 +154,8 @@ VSCode Copilot Agent Modeでは、エージェントセッションのライフ�
 | `SubagentStart` | サブエージェント開始時 | 追跡 |
 | `SubagentStop` | サブエージェント終了時 | クリーンアップ |
 
-> **TODO（2026-08-20 調査）**: `PostToolUseFailure`（Copilot CLI の `errorOccurred`）/ `PreCompact` / `SubagentStart` が
-> PLM のイベントマップに無く、変換時に除外される（[#458](https://github.com/DIO0550/plugin-manager/issues/458)）。
+> **対応済み（[#458](https://github.com/DIO0550/plugin-manager/issues/458)）**: `PostToolUseFailure` / `PreCompact` / `SubagentStart` を
+> Copilot CLI の `postToolUseFailure` / `preCompact` / `subagentStart` へ変換する。
 > Personal スコープの Skills パス `~/.copilot/skills/` も上流で追加済み（[#457](https://github.com/DIO0550/plugin-manager/issues/457)）。
 
 #### 設定形式

--- a/docs/reference/hooks-schema-mapping.md
+++ b/docs/reference/hooks-schema-mapping.md
@@ -131,19 +131,20 @@ Antigravity の詳細は [セクション 10](#10-google-antigravity)（実装 I
 | `SessionEnd` | `sessionEnd` | `reason` フィールドの値域が異なる |
 | `PreToolUse` | `preToolUse` | stdin/stdout 構造が異なる |
 | `PostToolUse` | `postToolUse` | `toolResult` の型が異なる |
+| `PostToolUseFailure` | `postToolUseFailure` | 失敗したツールの入力フィールドを変換 |
 | `UserPromptSubmit` | `userPromptSubmitted` | イベント名の末尾が異なる (`Submit` vs `Submitted`) |
 | `Stop` | `agentStop` | Claude Code は `Stop`、Copilot CLI は `agentStop` |
 | `SubagentStop` | `subagentStop` | ほぼ同等 |
+| `SubagentStart` | `subagentStart` | エージェント識別フィールドが異なる |
+| `PreCompact` | `preCompact` | 圧縮関連フィールドが異なる |
 
 ### Claude Code 固有（Copilot CLI に対応なし）
 
 | Claude Code | 近似手段 |
 |-------------|---------|
-| `PostToolUseFailure` | `postToolUse` で `toolResult.resultType === "failure"` を判定 |
-| `PreCompact` / `PostCompact` | なし |
+| `PostCompact` | なし |
 | `PermissionRequest` | `preToolUse` で部分的に代替 |
 | `Notification` | なし |
-| `SubagentStart` | なし |
 | `TeammateIdle` | なし |
 | `TaskCompleted` | なし |
 | `InstructionsLoaded` | なし |
@@ -155,7 +156,7 @@ Antigravity の詳細は [セクション 10](#10-google-antigravity)（実装 I
 
 | Copilot CLI | 近似手段 |
 |-------------|---------|
-| `errorOccurred` | `PostToolUseFailure` で部分的に代替 |
+| `errorOccurred` | なし（ツール失敗に限定されない実行時エラー） |
 
 ### Codex CLI（Claude Code と 1:1 対応）
 
@@ -246,7 +247,8 @@ PLM は Codex hook を配置すると同時に、scope に応じた `config.toml
 | `Stop` | `agentStop` | `Stop` | `Stop` |
 | `SubagentStop` | `subagentStop` | `SubagentStop` | × |
 | `PermissionRequest` | （`preToolUse` 近似） | `PermissionRequest` | ×（`ask` / `force_ask` で部分代替） |
-| `PreCompact` / `PostCompact` | × | ○ | × |
+| `PreCompact` | `preCompact` | ○ | × |
+| `PostCompact` | × | ○ | × |
 | `Notification` | × | × | × |
 | — | — | — | `PreInvocation` / `PostInvocation`（Antigravity 固有） |
 
@@ -342,7 +344,7 @@ PLM は Codex hook を配置すると同時に、scope に応じた `config.toml
 
 **注意:**
 - Claude Code の `tool_response` はツール固有のオブジェクト、Copilot CLI の `toolResult` は `resultType` + `textResultForLlm` の固定構造
-- Claude Code の `PostToolUseFailure` は別イベントだが、Copilot CLI では `postToolUse` の `resultType: "failure"` で表現
+- Claude Code の `PostToolUseFailure` は Copilot CLI の `postToolUseFailure` へ変換し、`toolName` / `toolArgs` を正規化する
 
 ### SessionStart / sessionStart
 
@@ -440,7 +442,7 @@ PLM は Codex hook を配置すると同時に、scope に応じた `config.toml
 }
 ```
 
-Claude Code には対応イベントなし。`PostToolUseFailure` で部分的に代替可能。
+Claude Code には対応イベントなし。ツール実行失敗には専用の `PostToolUseFailure` / `postToolUseFailure` を使用する。
 
 ---
 

--- a/src/hooks/converter/converter_test.rs
+++ b/src/hooks/converter/converter_test.rs
@@ -182,9 +182,12 @@ fn test_convert_supported_events() {
             "SessionEnd": [{ "hooks": [{ "type": "command", "command": "echo 2" }] }],
             "PreToolUse": [{ "hooks": [{ "type": "command", "command": "echo 3" }] }],
             "PostToolUse": [{ "hooks": [{ "type": "command", "command": "echo 4" }] }],
+            "PostToolUseFailure": [{ "hooks": [{ "type": "command", "command": "echo failure" }] }],
             "UserPromptSubmit": [{ "hooks": [{ "type": "command", "command": "echo 5" }] }],
             "Stop": [{ "hooks": [{ "type": "command", "command": "echo 6" }] }],
-            "SubagentStop": [{ "hooks": [{ "type": "command", "command": "echo 7" }] }]
+            "SubagentStart": [{ "hooks": [{ "type": "command", "command": "echo start" }] }],
+            "SubagentStop": [{ "hooks": [{ "type": "command", "command": "echo 7" }] }],
+            "PreCompact": [{ "hooks": [{ "type": "command", "command": "echo compact" }] }]
         }
     }"#;
     let result = convert(input, TargetKind::Copilot).unwrap();
@@ -193,17 +196,19 @@ fn test_convert_supported_events() {
     assert!(hooks.contains_key("sessionEnd"));
     assert!(hooks.contains_key("preToolUse"));
     assert!(hooks.contains_key("postToolUse"));
+    assert!(hooks.contains_key("postToolUseFailure"));
     assert!(hooks.contains_key("userPromptSubmitted"));
     assert!(hooks.contains_key("agentStop"));
+    assert!(hooks.contains_key("subagentStart"));
     assert!(hooks.contains_key("subagentStop"));
-    assert_eq!(hooks.len(), 7);
+    assert!(hooks.contains_key("preCompact"));
+    assert_eq!(hooks.len(), 10);
 }
 
 #[test]
 fn test_exclude_unsupported_events() {
     let input = r#"{
         "hooks": {
-            "PreCompact": [{ "hooks": [{ "type": "command", "command": "echo 1" }] }],
             "PostCompact": [{ "hooks": [{ "type": "command", "command": "echo 2" }] }],
             "Notification": [{ "hooks": [{ "type": "command", "command": "echo 3" }] }]
         }
@@ -217,7 +222,7 @@ fn test_exclude_unsupported_events() {
             .iter()
             .filter(|w| matches!(w, ConversionWarning::UnsupportedEvent { .. }))
             .count(),
-        3
+        2
     );
 }
 
@@ -963,10 +968,10 @@ fn test_full_conversion_scenario() {
     assert!(hooks.contains_key("preToolUse"));
     assert!(hooks.contains_key("postToolUse"));
     assert!(hooks.contains_key("agentStop"));
+    assert!(hooks.contains_key("preCompact"));
 
-    // Unsupported event excluded
+    // Unsupported event names are absent.
     assert!(!hooks.contains_key("PreCompact"));
-    assert!(!hooks.contains_key("preCompact"));
 
     // PreToolUse has 2 hooks (from 2 matcher groups, matchers moved to wrapper scripts)
     let pre_tool = hooks["preToolUse"].as_array().unwrap();
@@ -1002,12 +1007,9 @@ fn test_full_conversion_scenario() {
     // prompt hook -> stub
     assert!(result.scripts.iter().any(|s| s.content.contains("STUB")));
 
-    // Warnings: disableAllHooks removed + PreCompact unsupported + prompt stub
+    // Warnings: disableAllHooks removed + prompt stub
     assert!(result.warnings.iter().any(
         |w| matches!(w, ConversionWarning::RemovedField { field, .. } if field == "disableAllHooks")
-    ));
-    assert!(result.warnings.iter().any(
-        |w| matches!(w, ConversionWarning::UnsupportedEvent { event } if event == "PreCompact")
     ));
     assert!(result
         .warnings

--- a/src/hooks/converter/copilot.rs
+++ b/src/hooks/converter/copilot.rs
@@ -319,6 +319,10 @@ exit 0
 /// # Arguments
 ///
 /// * `event` - Hook event name (e.g. `preToolUse`, `postToolUse`, `sessionStart`).
+///
+/// # Returns
+///
+/// Copilot の入力を Claude Code 形式へ変換するシェルコードを返す。
 fn build_env_bridge(event: &str) -> String {
     let base_jq = r#"    . as $in | $in
     # Remove Copilot-specific timestamp
@@ -349,6 +353,14 @@ fn build_env_bridge(event: &str) -> String {
         else null end
       )"#;
 
+    let pre_compact_jq = r#"
+    | .transcript_path = $in.transcriptPath
+    | .custom_instructions = $in.customInstructions"#;
+
+    let subagent_start_jq = r#"
+    | .transcript_path = $in.transcriptPath
+    | .agent_type = $in.agentName"#;
+
     let jq_body = match event {
         "preToolUse" => format!(
             "{}{}\n    # Clean up Copilot-specific keys that have been normalized\n    | del(.toolName, .toolArgs, .sessionId)",
@@ -357,6 +369,18 @@ fn build_env_bridge(event: &str) -> String {
         "postToolUse" => format!(
             "{}{}{}\n    # Clean up Copilot-specific keys that have been normalized\n    | del(.toolName, .toolArgs, .toolResult, .sessionId)",
             base_jq, tool_common_jq, tool_response_jq
+        ),
+        "postToolUseFailure" => format!(
+            "{}{}\n    | del(.toolName, .toolArgs, .sessionId)",
+            base_jq, tool_common_jq
+        ),
+        "preCompact" => format!(
+            "{}{}\n    | del(.transcriptPath, .customInstructions, .sessionId)",
+            base_jq, pre_compact_jq
+        ),
+        "subagentStart" => format!(
+            "{}{}\n    | del(.transcriptPath, .agentName, .sessionId)",
+            base_jq, subagent_start_jq
         ),
         _ => format!(
             "{}\n    # Clean up Copilot-specific keys\n    | del(.sessionId)",

--- a/src/hooks/converter/copilot_test.rs
+++ b/src/hooks/converter/copilot_test.rs
@@ -18,13 +18,18 @@ fn test_event_map_supported_events() {
     assert_eq!(map.map_event("SessionStart"), Some("sessionStart"));
     assert_eq!(map.map_event("PreToolUse"), Some("preToolUse"));
     assert_eq!(map.map_event("PostToolUse"), Some("postToolUse"));
+    assert_eq!(
+        map.map_event("PostToolUseFailure"),
+        Some("postToolUseFailure")
+    );
+    assert_eq!(map.map_event("PreCompact"), Some("preCompact"));
+    assert_eq!(map.map_event("SubagentStart"), Some("subagentStart"));
     assert_eq!(map.map_event("Stop"), Some("agentStop"));
 }
 
 #[test]
 fn test_event_map_unsupported_event() {
     let map = CopilotEventMap;
-    assert_eq!(map.map_event("PreCompact"), None);
     assert_eq!(map.map_event("UnknownEvent"), None);
 }
 
@@ -206,6 +211,72 @@ fn test_generate_command_script_with_matcher() {
     assert!(info.content.contains("matcher filter"));
     assert!(info.content.contains("Bash"));
     assert_eq!(info.matcher, Some("Bash".to_string()));
+}
+
+#[test]
+/// `postToolUseFailure` wrapper がツール入力を Claude Code 形式へ正規化することを検証する。
+///
+/// # Parameters
+/// パラメータはない。
+///
+/// # Returns
+/// 戻り値はない。
+fn test_generate_post_tool_use_failure_script_normalizes_input() {
+    let gen = CopilotScriptGenerator;
+    let hook_value = json!({"type": "command", "command": "cat"});
+    let hook_obj = hook_value.as_object().unwrap();
+    let cmd = CommandHook::new(hook_obj, &hook_value).unwrap();
+    let info = gen.generate_command_script(&cmd, "postToolUseFailure", None, 0);
+
+    assert!(info.content.contains("$in.toolName"));
+    assert!(info.content.contains("$in.toolArgs"));
+    assert!(info
+        .content
+        .contains("del(.toolName, .toolArgs, .sessionId)"));
+}
+
+#[test]
+/// `preCompact` wrapper が圧縮情報を Claude Code 形式へ正規化することを検証する。
+///
+/// # Parameters
+/// パラメータはない。
+///
+/// # Returns
+/// 戻り値はない。
+fn test_generate_pre_compact_script_normalizes_input() {
+    let gen = CopilotScriptGenerator;
+    let hook_value = json!({"type": "command", "command": "cat"});
+    let hook_obj = hook_value.as_object().unwrap();
+    let cmd = CommandHook::new(hook_obj, &hook_value).unwrap();
+    let info = gen.generate_command_script(&cmd, "preCompact", None, 0);
+
+    assert!(info
+        .content
+        .contains(".transcript_path = $in.transcriptPath"));
+    assert!(info
+        .content
+        .contains(".custom_instructions = $in.customInstructions"));
+}
+
+#[test]
+/// `subagentStart` wrapper がサブエージェント情報を Claude Code 形式へ正規化することを検証する。
+///
+/// # Parameters
+/// パラメータはない。
+///
+/// # Returns
+/// 戻り値はない。
+fn test_generate_subagent_start_script_normalizes_input() {
+    let gen = CopilotScriptGenerator;
+    let hook_value = json!({"type": "command", "command": "cat"});
+    let hook_obj = hook_value.as_object().unwrap();
+    let cmd = CommandHook::new(hook_obj, &hook_value).unwrap();
+    let info = gen.generate_command_script(&cmd, "subagentStart", None, 0);
+
+    assert!(info
+        .content
+        .contains(".transcript_path = $in.transcriptPath"));
+    assert!(info.content.contains(".agent_type = $in.agentName"));
 }
 
 #[test]

--- a/src/hooks/event/copilot.rs
+++ b/src/hooks/event/copilot.rs
@@ -19,6 +19,10 @@ const COPILOT_EVENT_ENTRIES: &[EventBridge] = &[
         target: "postToolUse",
     },
     EventBridge {
+        event: HookEvent::PostToolUseFailure,
+        target: "postToolUseFailure",
+    },
+    EventBridge {
         event: HookEvent::UserPromptSubmit,
         target: "userPromptSubmitted",
     },
@@ -27,8 +31,16 @@ const COPILOT_EVENT_ENTRIES: &[EventBridge] = &[
         target: "agentStop",
     },
     EventBridge {
+        event: HookEvent::SubagentStart,
+        target: "subagentStart",
+    },
+    EventBridge {
         event: HookEvent::SubagentStop,
         target: "subagentStop",
+    },
+    EventBridge {
+        event: HookEvent::PreCompact,
+        target: "preCompact",
     },
 ];
 

--- a/src/hooks/event/copilot_test.rs
+++ b/src/hooks/event/copilot_test.rs
@@ -4,7 +4,7 @@ use super::copilot::CopilotEventMap;
 use crate::hooks::converter::EventMap;
 
 // ============================================================================
-// Supported events (7)
+// Supported events (10)
 // ============================================================================
 
 #[test]
@@ -15,27 +15,30 @@ fn test_copilot_event_map_all_supported() {
     assert_eq!(map.map_event("PreToolUse"), Some("preToolUse"));
     assert_eq!(map.map_event("PostToolUse"), Some("postToolUse"));
     assert_eq!(
+        map.map_event("PostToolUseFailure"),
+        Some("postToolUseFailure")
+    );
+    assert_eq!(
         map.map_event("UserPromptSubmit"),
         Some("userPromptSubmitted")
     );
     assert_eq!(map.map_event("Stop"), Some("agentStop"));
+    assert_eq!(map.map_event("SubagentStart"), Some("subagentStart"));
     assert_eq!(map.map_event("SubagentStop"), Some("subagentStop"));
+    assert_eq!(map.map_event("PreCompact"), Some("preCompact"));
 }
 
 // ============================================================================
-// Excluded events (14)
+// Excluded events (11)
 // ============================================================================
 
 #[test]
 fn test_copilot_event_map_excluded() {
     let map = CopilotEventMap;
     let excluded = [
-        "PostToolUseFailure",
-        "PreCompact",
         "PostCompact",
         "PermissionRequest",
         "Notification",
-        "SubagentStart",
         "TeammateIdle",
         "TaskCompleted",
         "InstructionsLoaded",


### PR DESCRIPTION
### Motivation

- Align the PLM hooks conversion with upstream Copilot CLI by mapping additional Claude Code events to Copilot equivalents so tool failures, compaction and subagent starts are preserved during conversion. 
- Ensure wrapper scripts normalize Copilot input into Claude Code fields for these events so downstream hooks receive the expected schema. 
- Update documentation to reflect the new bidirectional mappings and remove inaccurate TODO notes about unsupported events.

### Description

- Added event mappings for `PostToolUseFailure` → `postToolUseFailure`, `PreCompact` → `preCompact`, and `SubagentStart` → `subagentStart` in `src/hooks/event/copilot.rs` by extending the `COPILOT_EVENT_ENTRIES`. 
- Extended `build_env_bridge` in `src/hooks/converter/copilot.rs` to produce jq transformations for `postToolUseFailure`, `preCompact`, and `subagentStart` to normalize `toolName`/`toolArgs`, compaction fields, and subagent identification respectively. 
- Updated conversion logic/tests in `src/hooks/converter/*` and `src/hooks/event/*` to assert the new mappings and to check wrapper script contents (added tests such as `test_generate_post_tool_use_failure_script_normalizes_input`, `test_generate_pre_compact_script_normalizes_input`, and `test_generate_subagent_start_script_normalizes_input`). 
- Revised documentation pages `docs/concepts/targets.md` and `docs/reference/hooks-schema-mapping.md` to mark these events as supported and to replace the TODO with a resolved note referencing issue `#458`.

### Testing

- Ran unit tests for the hooks conversion and copilot mapping modules including `test_convert_supported_events`, `test_generate_post_tool_use_failure_script_normalizes_input`, `test_generate_pre_compact_script_normalizes_input`, `test_generate_subagent_start_script_normalizes_input`, and `test_copilot_event_map_all_supported` via the project test suite, and they all passed. 
- Verified updated converter integration tests in `src/hooks/converter/converter_test.rs` that check full conversion scenarios and warning counts, and they passed. 
- No changes to end-to-end CI or packaging were required for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a89a9131b3c832399b638d75b388abe)